### PR TITLE
feat: monitor mint overrides with helius metadata

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -84,6 +84,7 @@ from crypto_bot.utils.token_registry import (
     TOKEN_MINTS,
     monitor_pump_raydium,
     refresh_mints,
+    periodic_mint_sanity_check,
 )
 from crypto_bot.utils import pnl_logger, regime_pnl_tracker
 from crypto_bot.utils.ml_utils import ML_AVAILABLE
@@ -2333,6 +2334,7 @@ async def _main_impl() -> TelegramNotifier:
         )
 
     register_task(asyncio.create_task(monitor_pump_raydium()))
+    register_task(asyncio.create_task(periodic_mint_sanity_check()))
 
     monitor_task = register_task(
         asyncio.create_task(

--- a/crypto_bot/utils/token_registry.py
+++ b/crypto_bot/utils/token_registry.py
@@ -6,7 +6,7 @@ import os
 import asyncio
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Any, Dict, Iterable, List
 
 import aiohttp
 import ccxt.async_support as ccxt
@@ -240,24 +240,23 @@ def _write_cache() -> None:
 
 
 # Additional mints discovered via manual searches
-TOKEN_MINTS.update(
-    {
-        "AI16Z": "HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC",
-        "BERA": "A7y2wgyytufsxjg2ub616zqnte3x62f7fcp8fujdmoon",
-        "EUROP": "pD6L7wWeei1LJqb7tmnpfEnvkcBvqMgkfqvg23Bpump",
-        "FARTCOIN": "Bzc9NZfMqkXR6fz1DBph7BDf9BroyEf6pnzESP7v5iiw",
-        "RLUSD": "BkbjmJVa84eiGyp27FTofuQVFLqmKFev4ZPZ3U33pump",
-        "USDG": "2gc4f72GkEtggrkUDJRSbLcBpEUPPPFsnDGJJeNKpump",  # Assuming Unlimited Solana Dump
-        "VIRTUAL": "2FupRnaRfnyPHg798WsCBMGAauEkrhMs4YN7nBmujPtM",
-        "XMR": "Fi9GeixxfhMEGfnAe75nJVrwPqfVefyS6fgmyiTxkS6q",  # Wrapped, verify
-        "MELANIA": "FUAfBo2jgks6gB4Z4LfZkqSZgzNucisEHqnNebaRxM1P",
-        "PENGU": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
-        "USDR": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",  # USDT as proxy
-        "USTC": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",  # USDC proxy (adjust if needed)
-        "TRUMP": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
-        # Add more as needed; skip USDQ/USTC/XTZ as non-Solana
-    }
-)
+MANUAL_OVERRIDES: Dict[str, str] = {
+    "AI16Z": "HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC",
+    "BERA": "A7y2wgyytufsxjg2ub616zqnte3x62f7fcp8fujdmoon",
+    "EUROP": "pD6L7wWeei1LJqb7tmnpfEnvkcBvqMgkfqvg23Bpump",
+    "FARTCOIN": "Bzc9NZfMqkXR6fz1DBph7BDf9BroyEf6pnzESP7v5iiw",
+    "RLUSD": "BkbjmJVa84eiGyp27FTofuQVFLqmKFev4ZPZ3U33pump",
+    "USDG": "2gc4f72GkEtggrkUDJRSbLcBpEUPPPFsnDGJJeNKpump",  # Assuming Unlimited Solana Dump
+    "VIRTUAL": "2FupRnaRfnyPHg798WsCBMGAauEkrhMs4YN7nBmujPtM",
+    "XMR": "Fi9GeixxfhMEGfnAe75nJVrwPqfVefyS6fgmyiTxkS6q",  # Wrapped, verify
+    "MELANIA": "FUAfBo2jgks6gB4Z4LfZkqSZgzNucisEHqnNebaRxM1P",
+    "PENGU": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
+    "USDR": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",  # USDT as proxy
+    "USTC": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",  # USDC proxy (adjust if needed)
+    "TRUMP": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
+    # Add more as needed; skip USDQ/USTC/XTZ as non-Solana
+}
+TOKEN_MINTS.update(MANUAL_OVERRIDES)
 _write_cache()  # Save immediately
 
 
@@ -266,18 +265,11 @@ async def refresh_mints() -> None:
     loaded = await load_token_mints(force_refresh=True)
     if not loaded:
         raise RuntimeError("Failed to load token mints")
+    TOKEN_MINTS.update(MANUAL_OVERRIDES)
     TOKEN_MINTS.update(
         {
-            "AI16Z": "HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC",
-            "FARTCOIN": "Bzc9NZfMqkXR6fz1DBph7BDf9BroyEf6pnzESP7v5iiw",
-            "MELANIA": "FUAfBo2jgks6gB4Z4LfZkqSZgzNucisEHqnNebaRxM1P",
-            "PENGU": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
-            "RLUSD": "BkbjmJVa84eiGyp27FTofuQVFLqmKFev4ZPZ3U33pump",
-            "VIRTUAL": "2FupRnaRfnyPHg798WsCBMGAauEkrhMs4YN7nBmujPtM",
+            # Latest known mappings or proxies
             "USDG": "2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH",
-            "USDR": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-            "USTC": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-            "TRUMP": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
             "SOL": "So11111111111111111111111111111111111111112",
         }
     )
@@ -350,13 +342,19 @@ async def get_mint_from_gecko(base: str) -> str | None:
     return helius.get(base_upper)
 
 
-async def fetch_from_helius(symbols: Iterable[str]) -> Dict[str, str]:
-    """Return mapping of ``symbols`` to mint addresses using Helius.
+async def fetch_from_helius(symbols: Iterable[str], *, full: bool = False) -> Dict[str, Any]:
+    """Return token metadata for ``symbols`` using Helius.
+
+    By default only the mapping of symbol to mint address is returned. When
+    ``full`` is ``True`` a dictionary of metadata is provided for each symbol
+    containing at minimum ``mint``, ``decimals`` and ``supply``.
 
     Parameters
     ----------
     symbols:
         Iterable of token symbols to resolve.
+    full:
+        Return full metadata instead of just mint addresses.
     """
 
     api_key = os.getenv("HELIUS_KEY", "")
@@ -387,7 +385,7 @@ async def fetch_from_helius(symbols: Iterable[str]) -> Dict[str, str]:
         logger.error("Helius lookup error: %s", exc)
         return {}
 
-    result: Dict[str, str] = {}
+    result: Dict[str, Any] = {}
     if isinstance(data, list):
         items = data
     else:
@@ -402,8 +400,54 @@ async def fetch_from_helius(symbols: Iterable[str]) -> Dict[str, str]:
         symbol = item.get("symbol") or item.get("ticker")
         mint = item.get("mint") or item.get("address") or item.get("tokenMint")
         if isinstance(symbol, str) and isinstance(mint, str):
-            result[symbol.upper()] = mint
+            key = symbol.upper()
+            if full:
+                result[key] = {
+                    "mint": mint,
+                    "decimals": item.get("decimals"),
+                    "supply": item.get("supply"),
+                }
+            else:
+                result[key] = mint
     return result
+
+
+async def periodic_mint_sanity_check(interval_hours: float = 24.0) -> None:
+    """Periodically verify manual mint overrides via Helius metadata."""
+
+    symbols = list(MANUAL_OVERRIDES.keys())
+    while True:
+        try:
+            if symbols:
+                metadata = await fetch_from_helius(symbols, full=True)
+                for sym, expected_mint in MANUAL_OVERRIDES.items():
+                    meta = metadata.get(sym)
+                    if not isinstance(meta, dict):
+                        logger.warning("No metadata for %s", sym)
+                        continue
+                    helius_mint = meta.get("mint")
+                    decimals = meta.get("decimals")
+                    supply = meta.get("supply")
+                    if isinstance(helius_mint, str) and helius_mint != expected_mint:
+                        logger.warning(
+                            "Mint mismatch for %s: cache=%s helius=%s",
+                            sym,
+                            expected_mint,
+                            helius_mint,
+                        )
+                        TOKEN_MINTS[sym] = helius_mint
+                        MANUAL_OVERRIDES[sym] = helius_mint
+                        _write_cache()
+                    if not isinstance(decimals, int) or decimals <= 0:
+                        logger.warning("Unexpected decimals for %s: %s", sym, decimals)
+                    if not isinstance(supply, (int, float)) or supply <= 0:
+                        logger.warning("Unexpected supply for %s: %s", sym, supply)
+        except asyncio.CancelledError:
+            logger.info("periodic_mint_sanity_check cancelled")
+            raise
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error("periodic_mint_sanity_check error: %s", exc)
+        await asyncio.sleep(interval_hours * 3600)
 
 
 async def monitor_pump_raydium() -> None:

--- a/tests/test_token_registry.py
+++ b/tests/test_token_registry.py
@@ -133,6 +133,53 @@ def test_fetch_from_helius(monkeypatch, tmp_path):
     )
 
 
+def test_fetch_from_helius_full(monkeypatch, tmp_path):
+    data = [{"symbol": "AAA", "mint": "mmm", "decimals": 5, "supply": 10}]
+
+    class DummyResp:
+        def __init__(self, d):
+            self._d = d
+            self.status = 200
+
+        async def json(self, content_type=None):
+            return self._d
+
+        def raise_for_status(self):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    class DummySession:
+        def __init__(self, d):
+            self.d = d
+            self.url = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url, timeout=10):
+            self.url = url
+            return DummyResp(self.d)
+
+    session = DummySession(data)
+
+    mod = _load_module(monkeypatch, tmp_path)
+    aiohttp_mod = type(
+        "M", (), {"ClientSession": lambda: session, "ClientError": Exception}
+    )
+    monkeypatch.setattr(mod, "aiohttp", aiohttp_mod)
+
+    mapping = asyncio.run(mod.fetch_from_helius(["AAA"], full=True))
+    assert mapping == {"AAA": {"mint": "mmm", "decimals": 5, "supply": 10}}
+
+
 def test_fetch_from_helius_4xx(monkeypatch, tmp_path, caplog):
     class DummyResp:
         def __init__(self, status=401):
@@ -178,6 +225,36 @@ def test_fetch_from_helius_4xx(monkeypatch, tmp_path, caplog):
     mapping = asyncio.run(mod.fetch_from_helius(["AAA"]))
     assert mapping == {}
     assert "Helius lookup failed" in caplog.text
+
+
+def test_periodic_mint_sanity_check(monkeypatch, tmp_path):
+    mod = _load_module(monkeypatch, tmp_path)
+    mod.MANUAL_OVERRIDES.clear()
+    mod.MANUAL_OVERRIDES.update({"AAA": "old"})
+    mod.TOKEN_MINTS.update(mod.MANUAL_OVERRIDES)
+
+    async def fake_fetch(_symbols, *, full=False):
+        return {"AAA": {"mint": "new", "decimals": 9, "supply": 100}}
+
+    monkeypatch.setattr(mod, "fetch_from_helius", fake_fetch)
+
+    called = []
+
+    def fake_write():
+        called.append(True)
+
+    monkeypatch.setattr(mod, "_write_cache", fake_write)
+
+    async def fast_sleep(_):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(mod.asyncio, "sleep", fast_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(mod.periodic_mint_sanity_check(interval_hours=0))
+
+    assert mod.TOKEN_MINTS["AAA"] == "new"
+    assert called
 
 
 def test_load_token_mints(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- extend Helius lookup helper to optionally return full metadata
- add manual override table and periodic mint sanity check task
- launch mint sanity check task during bot startup

## Testing
- `pytest tests/test_token_registry.py::test_fetch_from_helius_full -q`
- `pytest tests/test_token_registry.py::test_periodic_mint_sanity_check -q`
- `pytest -q` *(fails: ImportError: cannot import name 'fetch_geckoterminal_ohlcv' from 'crypto_bot.utils.market_loader', ModuleNotFoundError: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_689a1799d40083308e15fb31ed6abda8