### PR TITLE
Make Solana mempool monitor asynchronous

### DIFF
--- a/crypto_bot/execution/solana_executor.py
+++ b/crypto_bot/execution/solana_executor.py
@@ -68,7 +68,7 @@ async def execute_swap(
     if mempool_monitor and cfg.get("enabled"):
         threshold = cfg.get("suspicious_fee_threshold", 0.0)
         action = cfg.get("action", "pause")
-        if mempool_monitor.is_suspicious(threshold):
+        if await mempool_monitor.is_suspicious(threshold):
             err_msg = notifier.notify("High priority fees detected")
             if err_msg:
                 logger.error("Failed to send message: %s", err_msg)
@@ -81,7 +81,7 @@ async def execute_swap(
                 }
             if action == "reprice":
                 amount *= cfg.get("reprice_multiplier", 1.0)
-        fee = mempool_monitor.fetch_priority_fee()
+        fee = await mempool_monitor.fetch_priority_fee()
         gas_limit = config.get("gas_threshold_gwei", 0.0)
         if gas_limit and fee > gas_limit:
             logger.warning("Swap aborted due to high priority fee: %s", fee)

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -2483,7 +2483,7 @@ async def _main_impl() -> TelegramNotifier:
         while True:
             try:
                 await asyncio.wait_for(
-                    asyncio.to_thread(mempool_monitor.fetch_priority_fee),
+                    mempool_monitor.fetch_priority_fee(),
                     timeout=interval,
                 )
                 wake_event.set()

--- a/crypto_bot/strategy/cross_chain_arb_bot.py
+++ b/crypto_bot/strategy/cross_chain_arb_bot.py
@@ -53,7 +53,19 @@ def generate_signal(
             fee_thr = float(cfg.get("suspicious_fee_threshold", 0.0))
         except (TypeError, ValueError):
             fee_thr = 0.0
-        if mempool_monitor.is_suspicious(fee_thr):
+        try:
+            suspicious = asyncio.run(mempool_monitor.is_suspicious(fee_thr))
+        except RuntimeError:
+            try:
+                loop = asyncio.get_event_loop()
+                suspicious = loop.run_until_complete(
+                    mempool_monitor.is_suspicious(fee_thr)
+                )
+            except Exception:
+                suspicious = False
+        except Exception:
+            suspicious = False
+        if suspicious:
             return 0.0, "none"
 
     try:

--- a/crypto_bot/strategy/dex_scalper.py
+++ b/crypto_bot/strategy/dex_scalper.py
@@ -85,7 +85,13 @@ def generate_signal(
         fee = None
         if mempool_monitor is not None:
             try:
-                fee = mempool_monitor.fetch_priority_fee()
+                fee = asyncio.run(mempool_monitor.fetch_priority_fee())
+            except RuntimeError:
+                try:
+                    loop = asyncio.get_event_loop()
+                    fee = loop.run_until_complete(mempool_monitor.fetch_priority_fee())
+                except Exception:
+                    fee = None
             except Exception:
                 fee = None
         if fee is None:

--- a/tests/test_cross_chain_arb_bot.py
+++ b/tests/test_cross_chain_arb_bot.py
@@ -13,7 +13,7 @@ class DummyMonitor:
     def __init__(self, suspicious=False):
         self._suspicious = suspicious
 
-    def is_suspicious(self, threshold: float) -> bool:  # pragma: no cover - simple
+    async def is_suspicious(self, threshold: float) -> bool:  # pragma: no cover - simple
         return self._suspicious
 
 

--- a/tests/test_dex_scalper.py
+++ b/tests/test_dex_scalper.py
@@ -93,7 +93,7 @@ class DummyMonitor:
     def __init__(self, fee):
         self._fee = fee
 
-    def fetch_priority_fee(self):
+    async def fetch_priority_fee(self):
         return self._fee
 
 

--- a/tests/test_exit.py
+++ b/tests/test_exit.py
@@ -8,7 +8,7 @@ class DummyMonitor:
         self.suspicious = suspicious
         self.calls = 0
 
-    def is_suspicious(self, threshold: float) -> bool:
+    async def is_suspicious(self, threshold: float) -> bool:
         self.calls += 1
         return self.suspicious
 

--- a/tests/test_micro_scalp_bot.py
+++ b/tests/test_micro_scalp_bot.py
@@ -185,7 +185,7 @@ def test_filters_return_none(make_df, prices, volumes, cfg):
 
 
 class DummyMempool:
-    def is_suspicious(self, threshold):
+    async def is_suspicious(self, threshold):
         return True
 
 
@@ -205,10 +205,10 @@ def test_mempool_blocks_signal(make_df):
 
 
 class LowFeeMempool:
-    def fetch_priority_fee(self):
+    async def fetch_priority_fee(self):
         return 3.0
 
-    def is_suspicious(self, threshold):
+    async def is_suspicious(self, threshold):
         return False
 
 

--- a/tests/test_solana_executor.py
+++ b/tests/test_solana_executor.py
@@ -626,10 +626,10 @@ class DummyMempool:
     def __init__(self, fee):
         self.fee = fee
 
-    def fetch_priority_fee(self):
+    async def fetch_priority_fee(self):
         return self.fee
 
-    def is_suspicious(self, threshold):
+    async def is_suspicious(self, threshold):
         return False
 
 
@@ -824,10 +824,10 @@ def test_execute_swap_low_liquidity(monkeypatch):
 
 def test_swap_paused_on_suspicious(monkeypatch):
     class DummyMonitor:
-        def fetch_priority_fee(self):
+        async def fetch_priority_fee(self):
             return 0.0
 
-        def is_suspicious(self, threshold):
+        async def is_suspicious(self, threshold):
             return True
 
     monkeypatch.setattr(solana_executor.TelegramNotifier, "notify", lambda *a, **k: None)

--- a/tests/test_solana_mempool.py
+++ b/tests/test_solana_mempool.py
@@ -1,19 +1,23 @@
 import asyncio
 import pytest
 
+import asyncio
+import pytest
 from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
 
 
-def test_is_suspicious_from_env(monkeypatch):
+@pytest.mark.asyncio
+async def test_is_suspicious_from_env(monkeypatch):
     monkeypatch.setenv("MOCK_PRIORITY_FEE", "150")
     monitor = SolanaMempoolMonitor()
-    assert monitor.is_suspicious(100) is True
+    assert await monitor.is_suspicious(100) is True
 
 
-def test_is_not_suspicious(monkeypatch):
+@pytest.mark.asyncio
+async def test_is_not_suspicious(monkeypatch):
     monkeypatch.setenv("MOCK_PRIORITY_FEE", "10")
     monitor = SolanaMempoolMonitor()
-    assert monitor.is_suspicious(100) is False
+    assert await monitor.is_suspicious(100) is False
 
 
 class DummyResp:

--- a/tests/test_strategy_router.py
+++ b/tests/test_strategy_router.py
@@ -430,7 +430,7 @@ def test_route_mempool_blocks_signal(monkeypatch):
     df = pd.DataFrame({"open": prices, "high": prices, "low": prices, "close": prices, "volume": volumes})
 
     class DummyMonitor:
-        def is_suspicious(self, threshold):
+        async def is_suspicious(self, threshold):
             return True
 
     cfg = {


### PR DESCRIPTION
## Summary
- refactor SolanaMempoolMonitor to use aiohttp and async methods
- update Solana executor and strategies to await mempool checks
- extend exit helper with optional mempool spike detection

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `pytest tests/test_solana_mempool.py tests/test_dex_scalper.py tests/test_micro_scalp_bot.py tests/test_solana_executor.py tests/test_cross_chain_arb_bot.py tests/test_exit.py` *(fails: AttributeError: <module 'crypto_bot.utils.market_loader' ...)*

------
https://chatgpt.com/codex/tasks/task_e_689a17893e2083308207d08f29accca6