### PR TITLE
Add decimal-aware token conversions

### DIFF
--- a/crypto_bot/execution/solana_executor.py
+++ b/crypto_bot/execution/solana_executor.py
@@ -18,6 +18,7 @@ from crypto_bot.utils.notifier import Notifier
 from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
 from crypto_bot import tax_logger
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
+from crypto_bot.utils.token_registry import get_decimals, to_base_units
 from pathlib import Path
 
 
@@ -125,6 +126,9 @@ async def execute_swap(
                 pass
         return result
 
+    decimals = await get_decimals(token_in)
+    amount_base = to_base_units(amount, decimals)
+
     from solana.rpc.api import Client
     from solana.keypair import Keypair
     from solana.transaction import Transaction
@@ -153,7 +157,7 @@ async def execute_swap(
                     params={
                         "inputMint": token_in,
                         "outputMint": token_out,
-                        "amount": int(amount),
+                        "amount": amount_base,
                         "slippageBps": slippage_bps,
                     },
                     timeout=10,

--- a/crypto_bot/utils/token_registry.py
+++ b/crypto_bot/utils/token_registry.py
@@ -5,6 +5,7 @@ import logging
 import os
 import asyncio
 from datetime import datetime, timedelta
+from decimal import Decimal, ROUND_DOWN
 from pathlib import Path
 from typing import Dict, Iterable, List
 
@@ -38,6 +39,9 @@ CACHE_FILE = Path(__file__).resolve().parents[2] / "cache" / "token_mints.json"
 # dictionary at runtime.
 TOKEN_MINTS: Dict[str, str] = {}
 
+# Mapping of mint addresses to their decimal precision
+TOKEN_DECIMALS: Dict[str, int] = {}
+
 _LOADED = False
 
 PUMP_URL = "https://api.pump.fun/tokens?limit=50&offset=0"
@@ -46,6 +50,15 @@ RAYDIUM_URL = "https://api.raydium.io/v2/main/pairs"
 # Poll interval for monitoring external token feeds
 # Reduced poll interval to surface new tokens faster
 POLL_INTERVAL = 10
+
+
+def to_base_units(amount_tokens: float, decimals: int) -> int:
+    """Convert human readable ``amount_tokens`` to integer base units."""
+    factor = Decimal(10) ** decimals
+    quantized = (Decimal(str(amount_tokens)) * factor).quantize(
+        Decimal("1"), rounding=ROUND_DOWN
+    )
+    return int(quantized)
 
 
 async def fetch_from_jupiter() -> Dict[str, str]:
@@ -62,6 +75,9 @@ async def fetch_from_jupiter() -> Dict[str, str]:
         mint = item.get("address") or item.get("mint") or item.get("tokenMint")
         if isinstance(symbol, str) and isinstance(mint, str):
             result[symbol.upper()] = mint
+            dec = item.get("decimals")
+            if isinstance(dec, int):
+                TOKEN_DECIMALS[mint] = dec
     return result
 
 
@@ -404,6 +420,49 @@ async def fetch_from_helius(symbols: Iterable[str]) -> Dict[str, str]:
         if isinstance(symbol, str) and isinstance(mint, str):
             result[symbol.upper()] = mint
     return result
+
+
+async def get_decimals(mint: str) -> int:
+    """Return decimal precision for ``mint``.
+
+    The value is first looked up in ``TOKEN_DECIMALS``.  If not found and a
+    ``HELIUS_KEY`` is configured, the Helius metadata endpoint is queried and
+    the result cached for subsequent calls.
+    """
+
+    cached = TOKEN_DECIMALS.get(mint)
+    if cached is not None:
+        return cached
+
+    api_key = os.getenv("HELIUS_KEY")
+    if not api_key:
+        return 0
+
+    from urllib.parse import urlencode
+
+    params = {"mint": mint, "api-key": api_key}
+    url = f"{HELIUS_TOKEN_API}?{urlencode(params)}"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, timeout=10) as resp:
+                resp.raise_for_status()
+                data = await resp.json(content_type=None)
+    except Exception as exc:  # pragma: no cover - network
+        logger.error("Helius decimals lookup failed for %s: %s", mint, exc)
+        return 0
+
+    items = data if isinstance(data, list) else data.get("tokens") or data.get("data") or []
+    if isinstance(items, dict):
+        items = list(items.values())
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        mint_addr = item.get("mint") or item.get("address") or item.get("tokenMint")
+        dec = item.get("decimals")
+        if isinstance(mint_addr, str) and mint_addr == mint and isinstance(dec, int):
+            TOKEN_DECIMALS[mint] = dec
+            return dec
+    return 0
 
 
 async def monitor_pump_raydium() -> None:

--- a/tests/test_token_registry.py
+++ b/tests/test_token_registry.py
@@ -33,11 +33,12 @@ def _load_module(monkeypatch, tmp_path):
     # use temporary cache and clear preloaded tokens
     monkeypatch.setattr(mod, "CACHE_FILE", tmp_path / "token_mints.json", raising=False)
     mod.TOKEN_MINTS.clear()
+    mod.TOKEN_DECIMALS.clear()
     return mod
 
 
 def test_fetch_from_jupiter(monkeypatch, tmp_path):
-    data = [{"symbol": "SOL", "address": "So111"}]
+    data = [{"symbol": "SOL", "address": "So111", "decimals": 9}]
 
     class DummyResp:
         def __init__(self, d):
@@ -80,6 +81,7 @@ def test_fetch_from_jupiter(monkeypatch, tmp_path):
     result = asyncio.run(mod.fetch_from_jupiter())
     assert result == {"SOL": "So111"}
     assert session.url == mod.JUPITER_TOKEN_URL
+    assert mod.TOKEN_DECIMALS["So111"] == 9
 
 
 def test_fetch_from_helius(monkeypatch, tmp_path):
@@ -751,3 +753,54 @@ def test_monitor_pump_raydium(monkeypatch, tmp_path):
     assert len(calls) == 2
     assert len(runs) == 2
     assert len(writes) == 2
+
+
+def test_to_base_units(monkeypatch, tmp_path):
+    mod = _load_module(monkeypatch, tmp_path)
+    assert mod.to_base_units(1, 9) == 1_000_000_000
+    assert mod.to_base_units(1.5, 6) == 1_500_000
+
+
+def test_get_decimals_cache_and_fallback(monkeypatch, tmp_path):
+    mod = _load_module(monkeypatch, tmp_path)
+    mod.TOKEN_DECIMALS["So111"] = 9
+    assert asyncio.run(mod.get_decimals("So111")) == 9
+
+    class DummyResp:
+        def __init__(self):
+            self.status = 200
+
+        async def json(self, content_type=None):
+            return [{"mint": "m2", "decimals": 6}]
+
+        def raise_for_status(self):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    class DummySession:
+        def __init__(self):
+            self.url = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url, timeout=10):
+            self.url = url
+            return DummyResp()
+
+    session = DummySession()
+    aiohttp_mod = type("M", (), {"ClientSession": lambda: session})
+    monkeypatch.setattr(mod, "aiohttp", aiohttp_mod)
+    monkeypatch.setenv("HELIUS_KEY", "KEY")
+
+    dec = asyncio.run(mod.get_decimals("m2"))
+    assert dec == 6
+    assert mod.TOKEN_DECIMALS["m2"] == 6


### PR DESCRIPTION
## Summary
- convert human token amounts to base units using new utility `to_base_units`
- cache token decimals from Jupiter and resolve missing ones via Helius API
- use decimal-aware amounts in Solana swap execution
- add tests verifying scaling and decimal lookups

## Testing
- `pytest tests/test_token_registry.py -q`
- `pytest tests/test_fund_manager.py tests/test_solana_executor.py::test_execute_swap_dry_run tests/test_solana_executor.py::test_slippage_calc_failure -q` *(fails: AttributeError: <module 'crypto_bot.utils.market_loader'...>)*

------
https://chatgpt.com/codex/tasks/task_e_689a178dd944833080cc0b31d8540770