### PR TITLE
Remove unused Path import from Solana executor

### DIFF
--- a/crypto_bot/execution/solana_executor.py
+++ b/crypto_bot/execution/solana_executor.py
@@ -19,7 +19,6 @@ from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
 from crypto_bot import tax_logger
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
 from crypto_bot.utils.token_registry import get_decimals, to_base_units
-from pathlib import Path
 
 
 logger = setup_logger(__name__, LOG_DIR / "execution.log")


### PR DESCRIPTION
## Summary
- drop unused `Path` import from Solana executor

## Testing
- `ruff check crypto_bot/execution/solana_executor.py` *(fails: SyntaxError in existing code)*
- `python -m pyflakes crypto_bot/execution/solana_executor.py` *(fails: expected indented block)*

------
https://chatgpt.com/codex/tasks/task_e_689a34264b6883309471d828ec713d4d