### PR TITLE
Normalize dependency names in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,9 @@ ccxt>=4.0.0,<5
 gspread
 oauth2client
 python-dotenv
-PyYAML
+pyyaml
 python-telegram-bot
-Flask
+flask
 pytest
 websocket-client
 requests
@@ -44,5 +44,4 @@ gymnasium
 torch
 stable-baselines3
 lunarcrush
-
 keyring


### PR DESCRIPTION
## Summary
- normalize Flask and PyYAML entries to lowercase
- remove extra blank line before keyring entry for consistent formatting

## Testing
- `pytest -q` *(fails: IndentationError, ImportError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a3422edfc83308e0ae5b76c18faf0