### PR TITLE
Fix slippage order book and telegram monkeypatch in tests

### DIFF
--- a/tests/test_cex_executor.py
+++ b/tests/test_cex_executor.py
@@ -310,7 +310,6 @@ def test_get_exchange_websocket_missing_creds(monkeypatch):
 class SlippageExchange:
     def fetch_order_book(self, symbol, limit=10):
         return {"bids": [[100, 10]], "asks": [[120, 0.5], [150, 0.5]]}
-        return {"bids": [[100, 10]], "asks": [[100, 0.5], [120, 10]]}
 
     def create_market_order(self, symbol, side, amount):
         raise AssertionError("should not execute")
@@ -500,9 +499,6 @@ def test_execute_trade_async_retries_network_error(monkeypatch):
 
 def test_execute_trade_no_message_when_disabled(monkeypatch):
     calls = {"count": 0}
-    from crypto_bot.utils import telegram
-    monkeypatch.setattr(
-        telegram,
     import crypto_bot.utils.telegram as telegram_mod
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- remove duplicate return from `SlippageExchange.fetch_order_book`
- clean up telegram monkeypatch in `test_execute_trade_no_message_when_disabled`

## Testing
- `pytest tests/test_cex_executor.py::test_execute_trade_skips_on_slippage tests/test_cex_executor.py::test_execute_trade_no_message_when_disabled -q`

------
https://chatgpt.com/codex/tasks/task_e_689a3421027c8330ab75125f44cb04c2