### PR TITLE
Fix Notifier async sending

### DIFF
--- a/crypto_bot/utils/notifier.py
+++ b/crypto_bot/utils/notifier.py
@@ -36,7 +36,7 @@ class Notifier:
         for attempt in range(1, retries + 1):
             try:
                 return await asyncio.wait_for(
-                    asyncio.to_thread(send_message, self.token, self.chat_id, text),
+                    send_message(self.token, self.chat_id, text),
                     timeout=timeout,
                 )
             except asyncio.TimeoutError:


### PR DESCRIPTION
## Summary
- fix Notifier.notify_async to await send_message directly instead of wrapping in to_thread
- adjust notifier async tests for async send_message

## Testing
- `pytest tests/test_notifier_async.py tests/test_telegram_notifier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa09ed2e883309142aa6d60d5fc2c