### PR TITLE
Normalize priority fee cap configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ symbol_score_weights:
 * **sentiment_filter** - checks the Fear & Greed index and Twitter sentiment to avoid bearish markets.
 * **sl_pct**/**tp_pct** – defaults for Solana scalper strategies.
 * **mempool_monitor** – pause or reprice when Solana fees spike.
-* **gas_threshold_gwei** – abort scalper trades when priority fees exceed this.
+* **priority_fee_cap_micro_lamports** – abort scalper trades when priority fees exceed this.
 * **min_cooldown** – minimum minutes between trades.
 * **cycle_bias** – optional on-chain metrics to bias trades.
 * **min_expected_value** – minimum expected value for a strategy based on
@@ -1418,7 +1418,7 @@ mempool_monitor:
 
 When enabled, `execute_swap` checks the current priority fee and pauses
 or adjusts the trade according to the selected action.
-If `gas_threshold_gwei` is set, the scalper aborts the swap entirely when
+If `priority_fee_cap_micro_lamports` is set, the scalper aborts the swap entirely when
 the priority fee exceeds this limit.
 
 ## Solana Meme-Wave Sniper

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -108,7 +108,7 @@ exit_strategy:
   trailing_stop_factor: 1.2
   trailing_stop_pct: 0.005
 force_websocket_history: false
-gas_threshold_gwei: 50
+priority_fee_cap_micro_lamports: 50
 gecko_limit: 10
 grid_bot:
   arbitrage_pairs:

--- a/crypto_bot/execution/__init__.py
+++ b/crypto_bot/execution/__init__.py
@@ -1,3 +1,4 @@
+from . import solana_mempool
 from .solana_mempool import SolanaMempoolMonitor
 
-__all__ = ["SolanaMempoolMonitor"]
+__all__ = ["SolanaMempoolMonitor", "solana_mempool"]

--- a/crypto_bot/strategy/dex_scalper.py
+++ b/crypto_bot/strategy/dex_scalper.py
@@ -1,64 +1,14 @@
 import os
+import asyncio
 import pandas as pd
 from typing import Tuple, Optional
-import requests
 import ta
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.pair_cache import load_liquid_pairs
-from crypto_bot.utils.gas_estimator import fetch_priority_fee_gwei
 from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
 
 ALLOWED_PAIRS = load_liquid_pairs() or []
-
-
-def fetch_priority_fee_gwei(endpoint: str | None = None) -> float:
-    """Return the median Ethereum priority fee in gwei.
-
-    The ``MOCK_ETH_PRIORITY_FEE_GWEI`` environment variable overrides
-    network requests for testing purposes. ``endpoint`` defaults to the
-    ``ETH_RPC_URL`` environment variable when not provided. Errors are
-    swallowed and ``0.0`` is returned.
-    """
-
-    mock = os.getenv("MOCK_ETH_PRIORITY_FEE_GWEI")
-    if mock is not None:
-        try:
-            return float(mock)
-        except ValueError:
-            return 0.0
-
-    endpoint = endpoint or os.getenv("ETH_RPC_URL")
-    if not endpoint:
-        return 0.0
-
-    payload = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "eth_feeHistory",
-        "params": [5, "latest", [50]],
-    }
-    try:
-        resp = requests.post(endpoint, json=payload, timeout=5)
-        resp.raise_for_status()
-        data = resp.json()
-        reward = data.get("result", {}).get("reward")
-        if isinstance(reward, list):
-            fees = []
-            for block in reward:
-                if isinstance(block, list) and block:
-                    val = block[0]
-                    try:
-                        fees.append(int(val, 16))
-                    except Exception:
-                        pass
-            if fees:
-                fees.sort()
-                median = fees[len(fees) // 2]
-                return median / 1_000_000_000
-    except Exception:
-        pass
-    return 0.0
 
 
 def generate_signal(
@@ -70,7 +20,8 @@ def generate_signal(
     """Short-term momentum strategy using EMA divergence on DEX pairs.
 
     When ``mempool_monitor`` is supplied the current Solana priority fee is
-    used instead of the Ethereum fee estimator.
+    used. If not provided, the ``MOCK_PRIORITY_FEE`` environment variable can
+    define the fee for testing.
     """
     if df.empty:
         return 0.0, "none"
@@ -79,24 +30,31 @@ def generate_signal(
     fast_window = params.get("ema_fast", 3)
     slow_window = params.get("ema_slow", 10)
     min_score = params.get("min_signal_score", 0.1)
-    gas_threshold_gwei = params.get("gas_threshold_gwei", 10.0)
+    fee_cap = params.get("priority_fee_cap_micro_lamports", 10.0)
 
-    if gas_threshold_gwei > 0:
-        fee = None
+    if fee_cap > 0:
+        fee: float | None = None
         if mempool_monitor is not None:
             try:
                 fee = asyncio.run(mempool_monitor.fetch_priority_fee())
             except RuntimeError:
                 try:
                     loop = asyncio.get_event_loop()
-                    fee = loop.run_until_complete(mempool_monitor.fetch_priority_fee())
+                    fee = loop.run_until_complete(
+                        mempool_monitor.fetch_priority_fee()
+                    )
                 except Exception:
                     fee = None
             except Exception:
                 fee = None
         if fee is None:
-            fee = fetch_priority_fee_gwei()
-        if fee is not None and fee > gas_threshold_gwei:
+            mock_fee = os.getenv("MOCK_PRIORITY_FEE")
+            if mock_fee is not None:
+                try:
+                    fee = float(mock_fee)
+                except ValueError:
+                    fee = None
+        if fee is not None and fee > fee_cap:
             return 0.0, "none"
 
     if len(df) < slow_window:

--- a/tests/test_dex_scalper.py
+++ b/tests/test_dex_scalper.py
@@ -72,8 +72,8 @@ def test_scalper_custom_config():
 def test_priority_fee_aborts(monkeypatch):
     close = pd.Series(range(1, 21))
     df = pd.DataFrame({"close": close})
-    monkeypatch.setenv("MOCK_ETH_PRIORITY_FEE_GWEI", "50")
-    cfg = {"dex_scalper": {"gas_threshold_gwei": 10}}
+    monkeypatch.setenv("MOCK_PRIORITY_FEE", "50")
+    cfg = {"dex_scalper": {"priority_fee_cap_micro_lamports": 10}}
     score, direction = dex_scalper.generate_signal(df, cfg)
     assert score == 0.0
     assert direction == "none"
@@ -82,8 +82,8 @@ def test_priority_fee_aborts(monkeypatch):
 def test_priority_fee_below_threshold(monkeypatch):
     close = pd.Series(range(1, 21))
     df = pd.DataFrame({"close": close})
-    monkeypatch.setenv("MOCK_ETH_PRIORITY_FEE_GWEI", "5")
-    cfg = {"dex_scalper": {"gas_threshold_gwei": 10}}
+    monkeypatch.setenv("MOCK_PRIORITY_FEE", "5")
+    cfg = {"dex_scalper": {"priority_fee_cap_micro_lamports": 10}}
     score, direction = dex_scalper.generate_signal(df, cfg)
     assert direction == "long"
     assert score > 0
@@ -99,7 +99,7 @@ class DummyMonitor:
 
 def test_monitor_fee_blocks_signal():
     df = pd.DataFrame({"close": pd.Series(range(1, 21))})
-    cfg = {"dex_scalper": {"gas_threshold_gwei": 10}}
+    cfg = {"dex_scalper": {"priority_fee_cap_micro_lamports": 10}}
     score, direction = dex_scalper.generate_signal(
         df, cfg, mempool_monitor=DummyMonitor(15)
     )
@@ -109,7 +109,7 @@ def test_monitor_fee_blocks_signal():
 
 def test_monitor_fee_allows_signal():
     df = pd.DataFrame({"close": pd.Series(range(1, 21))})
-    cfg = {"dex_scalper": {"gas_threshold_gwei": 10}}
+    cfg = {"dex_scalper": {"priority_fee_cap_micro_lamports": 10}}
     score, direction = dex_scalper.generate_signal(
         df, cfg, mempool_monitor=DummyMonitor(5)
     )


### PR DESCRIPTION
## Summary
- rename `gas_threshold_gwei` to `priority_fee_cap_micro_lamports`
- only compare priority fee to the configured cap in Solana executor
- handle mocked priority fee in dex scalper and expose Solana mempool module

## Testing
- `pytest tests/test_dex_scalper.py tests/test_solana_executor.py tests/test_solana_mempool.py -q` *(fails: Transaction confirmation failed; missing Solana mempool attributes)*
- `pytest tests/test_dex_scalper.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa0be6e588330833ab8d392c9938c