### PR TITLE
Refresh token decimals via Jupiter fallback

### DIFF
--- a/crypto_bot/utils/__init__.py
+++ b/crypto_bot/utils/__init__.py
@@ -34,7 +34,7 @@ except Exception:  # pragma: no cover - optional dependency
     utils_get_solana_new_tokens = None
 from .pyth import get_pyth_price
 from .pyth_utils import async_get_pyth_price, get_pyth_price as sync_get_pyth_price
-from .token_registry import load_token_mints, TOKEN_MINTS
+from .token_registry import load_token_mints, TOKEN_MINTS, fetch_from_jupiter
 from .constants import NON_SOLANA_BASES
 from .ml_utils import is_ml_available, ML_AVAILABLE
 from .lunarcrush_client import LunarCrushClient

--- a/crypto_bot/utils/token_registry.py
+++ b/crypto_bot/utils/token_registry.py
@@ -51,6 +51,19 @@ RAYDIUM_URL = "https://api.raydium.io/v2/main/pairs"
 # Reduced poll interval to surface new tokens faster
 POLL_INTERVAL = 10
 
+__all__ = [
+    "TOKEN_MINTS",
+    "TOKEN_DECIMALS",
+    "load_token_mints",
+    "fetch_from_jupiter",
+    "get_decimals",
+    "to_base_units",
+    "refresh_mints",
+    "set_token_mints",
+    "get_mint_from_gecko",
+    "fetch_from_helius",
+]
+
 
 def to_base_units(amount_tokens: float, decimals: int) -> int:
     """Convert human readable ``amount_tokens`` to integer base units."""


### PR DESCRIPTION
## Summary
- expose `fetch_from_jupiter` and export via utils package
- refresh Solana token decimals from Jupiter before swaps; abort when unknown
- guard price quote path against missing decimals

## Testing
- `pytest tests/test_token_registry.py::test_get_decimals_cache_and_fallback -q`
- `pytest tests/test_solana_executor.py::test_execute_swap_dry_run -q`
- `pytest tests/test_solana_trading.py::test_fetch_price_respects_decimals -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa4d7e8288330a7aef032b27e1524