### PR TITLE
feat: support non-interactive credentials

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -2086,7 +2086,7 @@ async def _main_impl() -> TelegramNotifier:
             logger.info("Setting %s from .env", key)
     os.environ.update(secrets)
 
-    user = load_or_create()
+    user = load_or_create(interactive=False)
 
     status_updates = config.get("telegram", {}).get("status_updates", True)
     balance_updates = config.get("telegram", {}).get("balance_updates", False)
@@ -2316,10 +2316,10 @@ async def _main_impl() -> TelegramNotifier:
 
     wallet: Wallet | None = None
     if config.get("execution_mode") == "dry_run":
-        try:
-            start_bal = float(input("Enter paper trading balance in USDT: "))
-        except Exception:
-            start_bal = 1000.0
+        start_bal = float(
+            os.getenv("PAPER_BALANCE")
+            or config.get("paper_balance", 1000.0)
+        )
         wallet = Wallet(
             start_bal,
             config.get("max_open_trades", 1),


### PR DESCRIPTION
## Summary
- avoid interactive prompts by default in wallet manager
- use non-interactive credential loading from main
- allow paper trading balance via env var instead of input

## Testing
- `python -m py_compile crypto_bot/main.py crypto_bot/wallet_manager.py`
- `pytest tests/test_wallet_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa4ea003083308b623d5fb389086d