### PR TITLE
Avoid redundant transaction serialization for Jito submissions

### DIFF
--- a/crypto_bot/execution/solana_executor.py
+++ b/crypto_bot/execution/solana_executor.py
@@ -304,8 +304,8 @@ async def execute_swap(
     async with AsyncClient(rpc_url) as client:
         if jito_key:
             try:
-                signed_tx = base64.b64encode(tx.serialize()).decode()
-                signed_tx = base64.b64encode(signed_bytes).decode()
+                signed_tx_bytes = signed_bytes or tx.serialize()
+                signed_tx = base64.b64encode(signed_tx_bytes).decode()
                 async with aiohttp.ClientSession() as jito_session:
                     async with jito_session.post(
                         JITO_BUNDLE_URL,


### PR DESCRIPTION
## Summary
- reuse existing serialized transaction bytes when building Jito bundle payload

## Testing
- `pytest` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b59034ffc833094958ea8a0f8f936