### PR TITLE
Add Kraken private WS flag and document REST fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ secondary_exchange: kraken
 execution_mode: dry_run  # or live
 mode: auto               # router chooses CEX or on-chain based on token mints
 use_websocket: true
+kraken:
+  use_private_ws: false  # set true only if private WS feeds are required
 telegram:
   token: your_telegram_token
   chat_id: your_chat_id
@@ -354,6 +356,7 @@ The `crypto_bot/config.yaml` file holds the runtime settings for the bot. Below 
   Paper trading defaults to long-only on spot exchanges.
 * **use_websocket** – enable WebSocket data via `KrakenWSClient`.
 * **force_websocket_history** – disable REST fallbacks when streaming (default: true).
+* **kraken.use_private_ws** – enable private WebSocket feeds for trading; REST-only trading continues when `false`.
 * **max_ws_limit** – skip WebSocket OHLCV when `limit` exceeds this value.
 * **exchange_market_types** – market types to trade (spot, margin, futures).
 * **preferred_chain** – chain used for on-chain swaps (e.g. `solana`).
@@ -938,7 +941,9 @@ and bounce_scalper strategies while `timeframe` covers all other analysis.
 
 When `use_websocket` is enabled the bot uses a dedicated Kraken WebSocket
 client for realtime streaming data. Disable websockets if you do not need
-this functionality.
+this functionality. Private order feeds are disabled by default; set
+`kraken.use_private_ws` to `true` to enable them. When `false`, trading
+continues via REST only.
 When OHLCV streaming returns fewer candles than requested the bot calculates
 how many bars are missing and fetches only that remainder via REST. This
 adaptive limit keeps history current without waiting for a full response.

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -108,6 +108,8 @@ exit_strategy:
   trailing_stop_factor: 1.2
   trailing_stop_pct: 0.005
 force_websocket_history: false
+kraken:
+  use_private_ws: false  # set true only if private WS feeds are required
 priority_fee_cap_micro_lamports: 50
 gecko_limit: 10
 grid_bot:


### PR DESCRIPTION
## Summary
- allow configuring Kraken private WebSocket usage with `kraken.use_private_ws`
- document REST-only trading when private WebSockets are disabled

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_689bac4776a083309a4e60b114bfb092