### PR TITLE
Log ML model missing only once

### DIFF
--- a/crypto_bot/strategy/bounce_scalper.py
+++ b/crypto_bot/strategy/bounce_scalper.py
@@ -29,6 +29,7 @@ from crypto_bot.utils import stats
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.cooldown_manager import in_cooldown, mark_cooldown
 from crypto_bot.utils.regime_pnl_tracker import get_recent_win_rate
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 logger = logging.getLogger(__name__)
 
@@ -37,9 +38,7 @@ try:  # pragma: no cover - optional dependency
     ML_AVAILABLE = True
 except Exception:  # pragma: no cover - trainer missing
     ML_AVAILABLE = False
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 if ML_AVAILABLE:
     MODEL = load_model("bounce_scalper")

--- a/crypto_bot/strategy/breakout_bot.py
+++ b/crypto_bot/strategy/breakout_bot.py
@@ -41,6 +41,7 @@ except Exception:  # pragma: no cover - fallback
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils import stats
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +50,7 @@ try:  # pragma: no cover - optional dependency
     ML_AVAILABLE = True
 except Exception:  # pragma: no cover - trainer missing
     ML_AVAILABLE = False
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 if ML_AVAILABLE:
     MODEL = load_model("breakout_bot")

--- a/crypto_bot/strategy/dip_hunter.py
+++ b/crypto_bot/strategy/dip_hunter.py
@@ -9,6 +9,7 @@ from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils import stats
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
 from crypto_bot.cooldown_manager import cooldown, in_cooldown
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 logger = setup_logger(__name__, LOG_DIR / "bot.log")
 
@@ -17,9 +18,7 @@ try:  # Optional LightGBM integration
     ML_AVAILABLE = True
 except Exception:  # pragma: no cover - trainer missing
     ML_AVAILABLE = False
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 if ML_AVAILABLE:
     MODEL = load_model("dip_hunter")

--- a/crypto_bot/strategy/grid_bot.py
+++ b/crypto_bot/strategy/grid_bot.py
@@ -16,6 +16,7 @@ from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.volatility import normalize_score_by_volatility, atr_percent
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
 from crypto_bot.volatility_filter import calc_atr
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 DYNAMIC_THRESHOLD = 1.5
 logger = setup_logger(__name__, LOG_DIR / "bot.log")
@@ -34,9 +35,7 @@ if ML_AVAILABLE:
     MODEL = load_model("grid_bot")
 else:  # pragma: no cover - fallback
     MODEL = None
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 
 @dataclass

--- a/crypto_bot/strategy/lstm_bot.py
+++ b/crypto_bot/strategy/lstm_bot.py
@@ -4,15 +4,14 @@ import logging
 import pandas as pd
 
 logger = logging.getLogger(__name__)
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 try:  # pragma: no cover - optional trainer
     from coinTrader_Trainer.ml_trainer import load_model
     ML_AVAILABLE = True
 except Exception:  # pragma: no cover - trainer unavailable
     ML_AVAILABLE = False
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 if ML_AVAILABLE:
     MODEL = load_model("lstm_bot")

--- a/crypto_bot/strategy/mean_bot.py
+++ b/crypto_bot/strategy/mean_bot.py
@@ -24,6 +24,7 @@ except Exception:  # pragma: no cover - fallback
 from ta.trend import ADXIndicator
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils import stats
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
@@ -40,9 +41,7 @@ if ML_AVAILABLE:
     MODEL = load_model("mean_bot")
 else:  # pragma: no cover - fallback
     MODEL = None
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 
 async def generate_signal(

--- a/crypto_bot/strategy/micro_scalp_bot.py
+++ b/crypto_bot/strategy/micro_scalp_bot.py
@@ -7,6 +7,7 @@ import ta
 from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.volatility import normalize_score_by_volatility
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +16,7 @@ try:  # pragma: no cover - optional dependency
     ML_AVAILABLE = True
 except Exception:  # pragma: no cover - trainer missing
     ML_AVAILABLE = False
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 if ML_AVAILABLE:
     MODEL = load_model("micro_scalp_bot")

--- a/crypto_bot/strategy/momentum_bot.py
+++ b/crypto_bot/strategy/momentum_bot.py
@@ -5,6 +5,7 @@ import pandas as pd
 import ta
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.volatility import normalize_score_by_volatility
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +19,7 @@ if ML_AVAILABLE:
     MODEL = load_model("momentum_bot")
 else:  # pragma: no cover - fallback
     MODEL = None
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 
 def generate_signal(

--- a/crypto_bot/strategy/range_arb_bot.py
+++ b/crypto_bot/strategy/range_arb_bot.py
@@ -12,6 +12,7 @@ import ta
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils import stats
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +21,7 @@ try:  # pragma: no cover - optional dependency
     ML_AVAILABLE = True
 except Exception:  # pragma: no cover - trainer missing
     ML_AVAILABLE = False
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 if ML_AVAILABLE:
     MODEL = load_model("range_arb_bot")

--- a/crypto_bot/strategy/sniper_bot.py
+++ b/crypto_bot/strategy/sniper_bot.py
@@ -7,6 +7,7 @@ from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.pair_cache import load_liquid_pairs
 from crypto_bot.volatility_filter import calc_atr
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 DEFAULT_PAIRS = ["BTC/USD", "ETH/USD"]
 ALLOWED_PAIRS = load_liquid_pairs() or DEFAULT_PAIRS
@@ -18,9 +19,7 @@ try:  # pragma: no cover - optional dependency
     ML_AVAILABLE = True
 except Exception:  # pragma: no cover - trainer missing
     ML_AVAILABLE = False
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 if ML_AVAILABLE:
     MODEL = load_model("sniper_bot")

--- a/crypto_bot/strategy/stat_arb_bot.py
+++ b/crypto_bot/strategy/stat_arb_bot.py
@@ -8,6 +8,7 @@ import pandas as pd
 from crypto_bot.utils import stats
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.volatility import normalize_score_by_volatility
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 logger = logging.getLogger(__name__)
 
@@ -16,9 +17,7 @@ try:  # pragma: no cover - optional dependency
     ML_AVAILABLE = True
 except Exception:  # pragma: no cover - trainer missing
     ML_AVAILABLE = False
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 if ML_AVAILABLE:
     MODEL = load_model("stat_arb_bot")

--- a/crypto_bot/strategy/trend_bot.py
+++ b/crypto_bot/strategy/trend_bot.py
@@ -28,6 +28,7 @@ from crypto_bot.utils import stats
 
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
+from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
 
 logger = setup_logger(__name__, LOG_DIR / "bot.log")
 
@@ -36,9 +37,7 @@ try:  # pragma: no cover - optional dependency
     ML_AVAILABLE = True
 except Exception:  # pragma: no cover - trainer missing
     ML_AVAILABLE = False
-    logger.info(
-        "Machine learning model not found; running without ML features."
-    )
+    warn_ml_unavailable_once()
 
 if ML_AVAILABLE:
     MODEL = load_model("trend_bot")

--- a/crypto_bot/utils/ml_utils.py
+++ b/crypto_bot/utils/ml_utils.py
@@ -11,6 +11,17 @@ logger = logging.getLogger(__name__)
 
 _REQUIRED_PACKAGES: Iterable[str] = ("sklearn", "joblib", "ta")
 
+_LOGGER_ONCE = {"ml_unavailable": False}
+
+
+def warn_ml_unavailable_once() -> None:
+    """Log a one-time notice when ML components are missing."""
+    if not _LOGGER_ONCE["ml_unavailable"]:
+        logger.info(
+            "Machine learning model not found; running without ML features."
+        )
+        _LOGGER_ONCE["ml_unavailable"] = True
+
 
 def _check_packages(pkgs: Iterable[str]) -> bool:
     """Return ``True`` if all packages in ``pkgs`` can be imported."""
@@ -42,5 +53,5 @@ def is_ml_available() -> bool:
 
 ML_AVAILABLE = is_ml_available()
 
-__all__ = ["is_ml_available", "ML_AVAILABLE"]
+__all__ = ["is_ml_available", "ML_AVAILABLE", "warn_ml_unavailable_once"]
 


### PR DESCRIPTION
## Summary
- add `warn_ml_unavailable_once` helper to log missing ML model a single time
- replace repeated ML warning in strategies with the centralized helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', 'solana', 'numpy.random', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689bab7dffe483308dd38b3b3b466547