### PR TITLE
Fix user setup path check

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -181,16 +181,11 @@ def _run_wallet_manager() -> None:
 
 def _ensure_user_setup() -> None:
     """Ensure a user has configured credentials or launch the wizard."""
-    if USER_CONFIG_FILE.exists():
+    if USER_CONFIG_PATH.exists():
         return
     if all(os.getenv(var) for var in REQUIRED_ENV_VARS):
         return
     _run_wallet_manager()
-    """Ensure API credentials and user configuration are available."""
-    env = _load_env()
-    if _needs_wallet_setup(env):
-        _run_wallet_manager()
-        _load_env()
 
 
 def _fix_symbol(symbol: str) -> str:

--- a/tests/test_main_wallet_setup.py
+++ b/tests/test_main_wallet_setup.py
@@ -16,7 +16,7 @@ def test_wizard_launch(monkeypatch, tmp_path):
 
     monkeypatch.setattr(runpy, "run_module", fake_run_module)
     cfg = tmp_path / "user_config.yaml"
-    monkeypatch.setattr(main, "USER_CONFIG_FILE", cfg)
+    monkeypatch.setattr(main, "USER_CONFIG_PATH", cfg)
     for var in main.REQUIRED_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
 
@@ -34,7 +34,7 @@ def test_no_launch_when_configured(monkeypatch, tmp_path):
     monkeypatch.setattr(runpy, "run_module", fake_run_module)
     cfg = tmp_path / "user_config.yaml"
     cfg.write_text("dummy: 1")
-    monkeypatch.setattr(main, "USER_CONFIG_FILE", cfg)
+    monkeypatch.setattr(main, "USER_CONFIG_PATH", cfg)
     for var in main.REQUIRED_ENV_VARS:
         monkeypatch.setenv(var, "x")
 
@@ -57,5 +57,5 @@ def test_headless_exit(monkeypatch, capsys):
         main._run_wallet_manager()
 
     assert exit_code.get("code") == 2
-    assert "interactive terminal" in capsys.readouterr().out
+    assert "Wallet setup required" in capsys.readouterr().out
 


### PR DESCRIPTION
## Summary
- use `USER_CONFIG_PATH` when verifying if user setup exists
- adjust wallet setup tests to mock new path and messages

## Testing
- `pytest tests/test_main_wallet_setup.py -q`
- `pytest -q` *(fails: No module named 'fakeredis'; No module named 'crypto_bot.wallet')*

------
https://chatgpt.com/codex/tasks/task_e_689baada97b48330872227dbc6b3e2ea