### PR TITLE
Remove duplicate sniper task comment

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -218,7 +218,6 @@ class MLUnavailableError(RuntimeError):
 # Track WebSocket ping tasks
 WS_PING_TASKS: set[asyncio.Task] = set()
 # Track async sniper trade tasks
-# Track async sniper trade tasks
 SNIPER_TASKS: set[asyncio.Task] = set()
 # Track newly scanned Solana tokens pending evaluation
 NEW_SOLANA_TOKENS: set[str] = set()


### PR DESCRIPTION
## Summary
- tidy task registries by removing duplicate sniper task comment in `crypto_bot/main.py`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'keyring', 'solana', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689baad937608330b08a233d7946d1ce