### PR TITLE
Remove redundant _fix_symbol alias

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -107,8 +107,7 @@ from crypto_bot.volatility_filter import calc_atr
 from crypto_bot.solana.exit import monitor_price
 from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
 
-# Backwards compatibility for tests
-_fix_symbol = fix_symbol
+# _fix_symbol is defined below for backward compatibility
 
 CONFIG_PATH = Path(__file__).resolve().parent / "config.yaml"
 ENV_PATH = Path(__file__).resolve().parent / ".env"
@@ -2810,7 +2809,6 @@ async def main() -> None:
     global check_wallet_balances, detect_non_trade_tokens
     global classify_regime_async, classify_regime_cached, calc_atr, monitor_price
     global SolanaMempoolMonitor, ScannerConfig, SolanaScannerConfig, PythConfig
-    global _fix_symbol
 
     from schema.scanner import (
         ScannerConfig,
@@ -2882,8 +2880,6 @@ async def main() -> None:
     from crypto_bot.volatility_filter import calc_atr
     from crypto_bot.solana.exit import monitor_price
     from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
-
-    _fix_symbol = fix_symbol
 
     global logger
     logger = setup_logger("bot", LOG_DIR / "bot.log", to_console=False)


### PR DESCRIPTION
## Summary
- remove _fix_symbol alias in `main.py`
- drop runtime rebinding so wrapper remains the public API

## Testing
- `PYTHONPATH=. pytest tests/test_fix_symbol.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689baad6daa88330950d903d3fc5dc6b