### PR TITLE
refactor: streamline user setup

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -181,13 +181,11 @@ def _run_wallet_manager() -> None:
 
 def _ensure_user_setup() -> None:
     """Ensure a user has configured credentials or launch the wizard."""
+    env = _load_env()
     if USER_CONFIG_FILE.exists():
         return
     if all(os.getenv(var) for var in REQUIRED_ENV_VARS):
         return
-    _run_wallet_manager()
-    """Ensure API credentials and user configuration are available."""
-    env = _load_env()
     if _needs_wallet_setup(env):
         _run_wallet_manager()
         _load_env()


### PR DESCRIPTION
## Summary
- call `_load_env` before checking user setup
- only run wallet manager when `_needs_wallet_setup` returns true
- remove extraneous string in `_ensure_user_setup`

## Testing
- `pytest -q` *(fails: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689baad63c0c8330a2148a95851a56f8