### PR TITLE
refactor: consolidate config paths

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -110,10 +110,6 @@ from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
 # Backwards compatibility for tests
 _fix_symbol = fix_symbol
 
-CONFIG_PATH = Path(__file__).resolve().parent / "config.yaml"
-ENV_PATH = Path(__file__).resolve().parent / ".env"
-USER_CONFIG_FILE = Path(__file__).resolve().parent / "user_config.yaml"
-
 REQUIRED_ENV_VARS = {
     "HELIUS_KEY",
     "SOLANA_PRIVATE_KEY",
@@ -181,7 +177,7 @@ def _run_wallet_manager() -> None:
 
 def _ensure_user_setup() -> None:
     """Ensure a user has configured credentials or launch the wizard."""
-    if USER_CONFIG_FILE.exists():
+    if USER_CONFIG_PATH.exists():
         return
     if all(os.getenv(var) for var in REQUIRED_ENV_VARS):
         return

--- a/tests/test_main_wallet_setup.py
+++ b/tests/test_main_wallet_setup.py
@@ -16,7 +16,7 @@ def test_wizard_launch(monkeypatch, tmp_path):
 
     monkeypatch.setattr(runpy, "run_module", fake_run_module)
     cfg = tmp_path / "user_config.yaml"
-    monkeypatch.setattr(main, "USER_CONFIG_FILE", cfg)
+    monkeypatch.setattr(main, "USER_CONFIG_PATH", cfg)
     for var in main.REQUIRED_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
 
@@ -34,7 +34,7 @@ def test_no_launch_when_configured(monkeypatch, tmp_path):
     monkeypatch.setattr(runpy, "run_module", fake_run_module)
     cfg = tmp_path / "user_config.yaml"
     cfg.write_text("dummy: 1")
-    monkeypatch.setattr(main, "USER_CONFIG_FILE", cfg)
+    monkeypatch.setattr(main, "USER_CONFIG_PATH", cfg)
     for var in main.REQUIRED_ENV_VARS:
         monkeypatch.setenv(var, "x")
 


### PR DESCRIPTION
## Summary
- remove redundant early config constants in `crypto_bot/main.py`
- standardize on `USER_CONFIG_PATH`
- update tests to reference `USER_CONFIG_PATH`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*


------
https://chatgpt.com/codex/tasks/task_e_689baad3f59083309be4652d67594677