### PR TITLE
fix: remove redundant LOG_DIR definition

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -126,7 +126,6 @@ def _run_wallet_manager() -> None:
     """Launch the interactive wallet manager or exit in headless mode."""
     if not sys.stdin.isatty():
         print("wallet_manager requires an interactive terminal")
-LOG_DIR: Path = Path(".")
 logger = logging.getLogger("bot")
 
 CONFIG_DIR = Path(__file__).resolve().parent


### PR DESCRIPTION
## Summary
- remove local LOG_DIR override in main so shared logger path is used

## Testing
- `PYTHONPATH=/workspace/coinTrader2.0 pytest tests/test_trade_logger.py`
- `PYTHONPATH=/workspace/coinTrader2.0 pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689baad339e88330a3e75ed15d526059