### PR TITLE
Improve Kraken WS token handling tests and fallback

### DIFF
--- a/crypto_bot/utils/kraken.py
+++ b/crypto_bot/utils/kraken.py
@@ -1,17 +1,35 @@
 import base64
+import base64
 import hashlib
 import hmac
-import json
 import time
-import urllib.request
 import urllib.parse
+
+import requests
 
 DEFAULT_KRAKEN_URL = "https://api.kraken.com"
 PATH = "/0/private/GetWebSocketsToken"
 
+# Flag controlling whether the private WebSocket API should be used. Tests
+# toggle this to exercise fallback behaviour in ``cex_executor``.
+use_private_ws = True
 
-def get_ws_token(api_key: str, private_key: str, otp: str | None = None, environment: str = DEFAULT_KRAKEN_URL) -> str:
-    """Return a WebSocket authentication token from Kraken."""
+
+def get_ws_token(
+    api_key: str,
+    private_key: str,
+    otp: str | None = None,
+    environment: str = DEFAULT_KRAKEN_URL,
+) -> str:
+    """Return a WebSocket authentication token from Kraken.
+
+    The function performs a signed ``POST`` request using ``requests`` and
+    returns the token found either at ``result.token`` or the top-level
+    ``token`` key. If no token can be extracted a :class:`ValueError` is raised.
+    ``requests`` exceptions are allowed to propagate so callers can decide how
+    to handle network failures.
+    """
+
     nonce = str(int(time.time() * 1000))
     body = [("nonce", nonce)]
     if otp:
@@ -29,15 +47,9 @@ def get_ws_token(api_key: str, private_key: str, otp: str | None = None, environ
         "Content-Type": "application/x-www-form-urlencoded",
     }
 
-    req = urllib.request.Request(
-        environment + PATH,
-        data=encoded_body.encode(),
-        headers=headers,
-        method="POST",
-    )
-
-    with urllib.request.urlopen(req) as resp:
-        data = json.loads(resp.read().decode())
+    resp = requests.post(environment + PATH, data=encoded_body, headers=headers)
+    resp.raise_for_status()
+    data = resp.json()
 
     token = data.get("result", {}).get("token") or data.get("token")
     if not token:

--- a/tests/test_get_ws_token.py
+++ b/tests/test_get_ws_token.py
@@ -1,40 +1,86 @@
 import base64
 import hashlib
 import hmac
-import json
-import urllib.request
-import urllib.parse
 import time
+import urllib.parse
+
+import pytest
+import requests
 
 from crypto_bot.utils.kraken import get_ws_token, PATH
 
-class DummyResp:
-    def __init__(self, data):
-        self.data = data
-    def read(self):
-        return json.dumps({"result": {"token": self.data}}).encode()
-    def __enter__(self):
-        return self
-    def __exit__(self, exc_type, exc, tb):
-        pass
 
-def test_get_ws_token(monkeypatch):
+class DummyResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} error")
+
+
+def test_get_ws_token_success(monkeypatch):
     captured = {}
-    def fake_urlopen(req):
-        captured['headers'] = dict(req.header_items())
-        captured['body'] = req.data.decode()
-        return DummyResp('abc')
-    monkeypatch.setattr(urllib.request, 'urlopen', fake_urlopen)
-    monkeypatch.setattr(time, 'time', lambda: 1)
-    secret = base64.b64encode(b'secret').decode()
-    token = get_ws_token('key', secret, otp='otp')
-    assert token == 'abc'
-    expected_nonce = '1000'
-    expected_body = urllib.parse.urlencode({'nonce': expected_nonce, 'otp': 'otp'})
+
+    def fake_post(url, data=None, headers=None):
+        captured["url"] = url
+        captured["data"] = data
+        captured["headers"] = headers
+        return DummyResponse({"result": {"token": "abc"}})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(time, "time", lambda: 1)
+    secret = base64.b64encode(b"secret").decode()
+
+    token = get_ws_token("key", secret, otp="otp")
+    assert token == "abc"
+
+    expected_nonce = "1000"
+    expected_body = urllib.parse.urlencode({"nonce": expected_nonce, "otp": "otp"})
     message = PATH.encode() + hashlib.sha256((expected_nonce + expected_body).encode()).digest()
-    expected_sig = base64.b64encode(hmac.new(base64.b64decode(secret), message, hashlib.sha512).digest()).decode()
-    # urllib normalizes header keys to title case
-    assert captured['headers']['Api-key'] == 'key'
-    assert captured['headers']['Api-sign'] == expected_sig
-    assert captured['headers']['Content-type'] == 'application/x-www-form-urlencoded'
-    assert captured['body'] == expected_body
+    expected_sig = base64.b64encode(
+        hmac.new(base64.b64decode(secret), message, hashlib.sha512).digest()
+    ).decode()
+
+    assert captured["url"].endswith(PATH)
+    assert captured["data"] == expected_body
+    assert captured["headers"]["API-Key"] == "key"
+    assert captured["headers"]["API-Sign"] == expected_sig
+    assert captured["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+
+
+def test_get_ws_token_top_level(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *a, **k: DummyResponse({"token": "abc"}),
+    )
+    monkeypatch.setattr(time, "time", lambda: 1)
+    secret = base64.b64encode(b"secret").decode()
+    assert get_ws_token("key", secret) == "abc"
+
+
+def test_get_ws_token_missing_token(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *a, **k: DummyResponse({"result": {}}),
+    )
+    monkeypatch.setattr(time, "time", lambda: 1)
+    secret = base64.b64encode(b"secret").decode()
+    with pytest.raises(ValueError):
+        get_ws_token("key", secret)
+
+
+def test_get_ws_token_request_failure(monkeypatch):
+    def fake_post(*a, **k):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    secret = base64.b64encode(b"secret").decode()
+    with pytest.raises(requests.RequestException):
+        get_ws_token("key", secret)


### PR DESCRIPTION
## Summary
- refactor Kraken token utility to use requests and expose `use_private_ws`
- guard exchange websocket setup with `use_private_ws` and warn on token failures
- extend tests to mock network calls, OTP handling, and fallback when token fetch fails

## Testing
- `pytest tests/test_get_ws_token.py -q`
- `pytest tests/test_cex_executor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bac4a498c83308f47399ec58fe56a