### PR TITLE
refactor: use global log dir

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -117,7 +117,6 @@ REQUIRED_ENV_VARS = {
 }
 
 
-LOG_DIR: Path = Path(".")
 def _run_wallet_manager() -> None:
     """Launch the interactive wallet manager or exit in headless mode."""
     if not sys.stdin.isatty():


### PR DESCRIPTION
## Summary
- remove redundant local LOG_DIR definition to rely on shared logger configuration

## Testing
- `python - <<'PY'
from crypto_bot.utils.logger import LOG_DIR, setup_logger
import os
print('LOG_DIR', LOG_DIR)
logger = setup_logger('test_logger', LOG_DIR / 'test.log', to_console=False)
logger.info('Test log entry')
print('Log file exists?', (LOG_DIR / 'test.log').exists())
PY`
- `pytest -q` *(fails: IndentationError: expected an indented block after 'if' statement on line 184)*

------
https://chatgpt.com/codex/tasks/task_e_689bb24875a8833099aa9bb43f349758