### PR TITLE
Remove duplicate _run_wallet_manager placeholder

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -118,10 +118,6 @@ REQUIRED_ENV_VARS = {
 
 
 LOG_DIR: Path = Path(".")
-def _run_wallet_manager() -> None:
-    """Launch the interactive wallet manager or exit in headless mode."""
-    if not sys.stdin.isatty():
-        print("wallet_manager requires an interactive terminal")
 logger = logging.getLogger("bot")
 
 CONFIG_DIR = Path(__file__).resolve().parent


### PR DESCRIPTION
## Summary
- remove early placeholder `_run_wallet_manager` so only the fully-featured implementation remains

## Testing
- `pytest` *(fails: IndentationError in `crypto_bot/main.py`, missing `fakeredis` dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689bb24b4e088330b4023ac327f6ac61