### PR TITLE
Refine Kraken WS token retrieval

### DIFF
--- a/crypto_bot/utils/kraken.py
+++ b/crypto_bot/utils/kraken.py
@@ -1,5 +1,4 @@
 import base64
-import base64
 import hashlib
 import hmac
 import os
@@ -18,26 +17,19 @@ use_private_ws = True
 
 def get_ws_token(
     api_key: str,
-    private_key: str,
+    api_secret: str,
     otp: str | None = None,
     environment: str = DEFAULT_KRAKEN_URL,
+    timeout: float = 15.0,
 ) -> str:
     """Return a WebSocket authentication token from Kraken.
 
-    The function performs a signed ``POST`` request using ``requests`` and
-    returns the token found either at ``result.token`` or the top-level
-    ``token`` key. If no token can be extracted a :class:`ValueError` is raised.
-    ``requests`` exceptions are allowed to propagate so callers can decide how
-    to handle network failures.
+    The function performs a signed ``POST`` request to ``environment`` using
+    :mod:`requests` and returns the token found either at ``result.token`` or the
+    top-level ``token`` key. Network failures raise the original
+    :class:`requests.RequestException` while missing tokens and malformed
+    responses raise :class:`RuntimeError`.
     """
-
-def get_ws_token(
-    api_key: str,
-    api_secret: str,
-    otp: str | None = None,
-    timeout: float = 15.0,
-) -> str:
-    """Return a WebSocket authentication token from Kraken."""
 
     if otp is None:
         otp = os.getenv("KRAKEN_OTP")
@@ -59,20 +51,19 @@ def get_ws_token(
         "Content-Type": "application/x-www-form-urlencoded",
     }
 
-    resp = requests.post(environment + PATH, data=encoded_body, headers=headers)
-    resp.raise_for_status()
-    data = resp.json()
     try:
         resp = requests.post(
-            DEFAULT_KRAKEN_URL + PATH,
+            f"{environment}{PATH}",
             data=encoded_body,
             headers=headers,
             timeout=timeout,
         )
         resp.raise_for_status()
         data = resp.json()
-    except (requests.RequestException, ValueError) as exc:
-        raise RuntimeError("Failed to fetch WebSocket token") from exc
+    except requests.RequestException:
+        raise
+    except ValueError as exc:  # json decoding error
+        raise RuntimeError("Failed to parse WebSocket token response") from exc
 
     if data.get("error"):
         raise RuntimeError(f"Kraken API error: {data['error']}")

--- a/tests/test_get_ws_token.py
+++ b/tests/test_get_ws_token.py
@@ -26,15 +26,19 @@ class DummyResponse:
 def test_get_ws_token_success(monkeypatch):
     captured = {}
 
-    def fake_post(url, data=None, headers=None):
+    def fake_post(url, data=None, headers=None, timeout=None):
         captured["url"] = url
         captured["data"] = data
         captured["headers"] = headers
+        captured["timeout"] = timeout
         return DummyResponse({"result": {"token": "abc"}})
 
     monkeypatch.setattr(requests, "post", fake_post)
     monkeypatch.setattr(time, "time", lambda: 1)
     secret = base64.b64encode(b"secret").decode()
+    token = get_ws_token("key", secret)
+    assert token == "abc"
+    assert captured["url"].endswith(PATH)
 
 class DummyResp:
     def __init__(self, data):
@@ -97,23 +101,39 @@ def test_get_ws_token_missing_token(monkeypatch):
     )
     monkeypatch.setattr(time, "time", lambda: 1)
     secret = base64.b64encode(b"secret").decode()
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         get_ws_token("key", secret)
 
 
 def test_get_ws_token_request_failure(monkeypatch):
-    def fake_post(*a, **k):
+    captured = {}
+
+    def fake_post(url, data=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["data"] = data
+        captured["headers"] = headers
+        captured["timeout"] = timeout
         raise requests.RequestException("boom")
 
     monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(time, "time", lambda: 1)
     secret = base64.b64encode(b"secret").decode()
     with pytest.raises(requests.RequestException):
         get_ws_token("key", secret)
+
+    expected_nonce = "1000"
+    expected_body = urllib.parse.urlencode({"nonce": expected_nonce})
+    message = PATH.encode() + hashlib.sha256((expected_nonce + expected_body).encode()).digest()
+    expected_sig = base64.b64encode(
+        hmac.new(base64.b64decode(secret), message, hashlib.sha512).digest()
+    ).decode()
+
+    assert captured["url"].endswith(PATH)
+    assert captured["data"] == expected_body
     assert captured["headers"]["API-Key"] == "key"
     assert captured["headers"]["API-Sign"] == expected_sig
     assert (
         captured["headers"]["Content-Type"]
         == "application/x-www-form-urlencoded"
     )
-    assert captured["data"] == expected_body
     assert captured["timeout"] == 15.0


### PR DESCRIPTION
## Summary
- remove unused get_ws_token definition
- add environment and timeout params to get_ws_token and streamline request handling
- adjust tests for new RuntimeError behaviour

## Testing
- `pytest tests/test_get_ws_token.py -q`
- `pytest -q` *(fails: IndentationError in crypto_bot/main.py, ModuleNotFoundError: fakeredis)*

------
https://chatgpt.com/codex/tasks/task_e_689bb2548d24833086e4c85e6b0e5bb1