### PR TITLE
feat: expand notifier token types

### DIFF
--- a/crypto_bot/execution/cex_executor.py
+++ b/crypto_bot/execution/cex_executor.py
@@ -109,11 +109,15 @@ def get_exchanges(config) -> Dict[str, Tuple[ccxt.Exchange, Optional[KrakenWSCli
 
 
 def _resolve_notifier(
-    token: Optional[str],
+    token: str | TelegramNotifier | None,
     chat_id: Optional[str],
     notifier: Optional[TelegramNotifier],
 ) -> TelegramNotifier:
-    """Return a ready-to-use :class:`TelegramNotifier` instance."""
+    """Return a ready-to-use :class:`TelegramNotifier` instance.
+
+    The ``token`` argument may be a bot token string, an existing
+    :class:`TelegramNotifier`, or ``None`` when ``notifier`` is provided.
+    """
 
     if notifier is not None:
         return notifier
@@ -438,7 +442,7 @@ def execute_trade(
     symbol: str,
     side: str,
     amount: float,
-    token: Optional[str] = None,
+    token: str | TelegramNotifier | None = None,
     chat_id: Optional[str] = None,
     notifier: Optional[TelegramNotifier] = None,
     dry_run: bool = True,
@@ -612,7 +616,7 @@ async def execute_trade_async(
     symbol: str,
     side: str,
     amount: float,
-    token: Optional[str] = None,
+    token: str | TelegramNotifier | None = None,
     chat_id: Optional[str] = None,
     notifier: Optional[TelegramNotifier] = None,
     dry_run: bool = True,
@@ -763,7 +767,7 @@ def place_stop_order(
     side: str,
     amount: float,
     stop_price: float,
-    token: Optional[str] = None,
+    token: str | TelegramNotifier | None = None,
     chat_id: Optional[str] = None,
     notifier: Optional[TelegramNotifier] = None,
     dry_run: bool = True,


### PR DESCRIPTION
## Summary
- allow `_resolve_notifier` to accept either a bot token string or a `TelegramNotifier`
- update trade helper functions to accept the broader token type

## Testing
- `pytest` *(fails: 50 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689bf53f79e48330820b1b8e5aab9a74