### PR TITLE
Pin Pydantic 1.x for FastAPI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1637,6 +1637,11 @@ source .venv/bin/activate
 pip install -r requirements.txt -r requirements-dev.txt
 ```
 
+This project pins **Pydantic** to version `1.10.22` in `requirements.txt` because
+FastAPI 0.97.0 still depends on the 1.x API. Using the latest 1.x release avoids
+compatibility issues introduced in Pydantic 2.x while keeping bug fixes from the
+final 1.x series.
+
 Run the test suite to verify your environment:
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ httpx<0.28
 uvicorn
 rich
 scikit-optimize
-pydantic<2
+pydantic==1.10.22  # pin to last 1.x release for FastAPI 0.97 compatibility
 numba
 cachetools
 tenacity


### PR DESCRIPTION
## Summary
- Pin Pydantic to the latest 1.x release for FastAPI 0.97.0
- Document Pydantic pin and rationale in README

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution for cointrader-trainer>=0.1.0)*
- `python -c "import pydantic; print(pydantic.__version__)"`
- `pytest tests/test_config_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bfc198c608330bc04b0583ed6b2b8