### PR TITLE
Add timeframe locks to prevent concurrent OHLCV updates

### DIFF
--- a/crypto_bot/utils/market_loader.py
+++ b/crypto_bot/utils/market_loader.py
@@ -87,6 +87,8 @@ MAX_WS_LIMIT = 500
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
 STATUS_UPDATES = True
 SEMA: asyncio.Semaphore | None = None
+# Per-timeframe locks to prevent concurrent updates of the same timeframe
+_TF_LOCKS: Dict[str, asyncio.Lock] = {}
 
 # Redis settings
 REDIS_TTL = 3600  # cache expiry in seconds
@@ -1597,255 +1599,257 @@ async def update_multi_tf_ohlcv_cache(
                 seen.add(sym)
 
     for tf in tfs:
-        logger.info("Starting update for timeframe %s", tf)
-        tf_cache = cache.get(tf, {})
-
-        now_ms = int(time.time() * 1000)
-        dynamic_limits: dict[str, int] = {}
-        snapshot_cap = int(config.get("ohlcv_snapshot_limit", limit))
-        max_cap = min(snapshot_cap, 720)
-
-        concurrency = int(config.get("listing_date_concurrency", 5) or 0)
-        semaphore = asyncio.Semaphore(concurrency) if concurrency > 0 else None
-
-        async def _fetch_listing(sym: str) -> tuple[str, int | None]:
-            if semaphore is not None:
-                async with semaphore:
+        lock = _TF_LOCKS.setdefault(tf, asyncio.Lock())
+        async with lock:
+            logger.info("Starting update for timeframe %s", tf)
+            tf_cache = cache.get(tf, {})
+    
+            now_ms = int(time.time() * 1000)
+            dynamic_limits: dict[str, int] = {}
+            snapshot_cap = int(config.get("ohlcv_snapshot_limit", limit))
+            max_cap = min(snapshot_cap, 720)
+    
+            concurrency = int(config.get("listing_date_concurrency", 5) or 0)
+            semaphore = asyncio.Semaphore(concurrency) if concurrency > 0 else None
+    
+            async def _fetch_listing(sym: str) -> tuple[str, int | None]:
+                if semaphore is not None:
+                    async with semaphore:
+                        ts = await get_kraken_listing_date(sym)
+                else:
                     ts = await get_kraken_listing_date(sym)
-            else:
-                ts = await get_kraken_listing_date(sym)
-            return sym, ts
-
-        start_list = time.perf_counter()
-        tasks = [asyncio.create_task(_fetch_listing(sym)) for sym in symbols]
-        for sym, listing_ts in await asyncio.gather(*tasks):
-            if listing_ts and 0 < listing_ts <= now_ms:
-                age_ms = now_ms - listing_ts
-                tf_sec = timeframe_seconds(exchange, tf)
-                hist_candles = age_ms // (tf_sec * 1000)
-                if hist_candles <= 0:
-                    continue
-                if hist_candles > snapshot_cap * 1000:
-                    logger.info(
-                        "Skipping OHLCV history for %s on %s (age %d candles)",
-                        sym,
-                        tf,
-                        hist_candles,
-                    )
-                    continue
-                dynamic_limits[sym] = int(min(hist_candles, max_cap))
-        logger.debug(
-            "listing date fetch for %d symbols took %.2fs",
-            len(symbols),
-            time.perf_counter() - start_list,
-        )
-
-        cex_symbols: list[str] = []
-        dex_symbols: list[str] = []
-        for s in symbols:
-            sym = s
-            base, _, quote = s.partition("/")
-            is_solana = quote.upper() == "USDC" and base.upper() not in NON_SOLANA_BASES
-            if is_solana:
-                dex_symbols.append(sym)
-            else:
-                if "coinbase" in getattr(exchange, "id", "") and "/USDC" in sym:
-                    mapped = sym.replace("/USDC", "/USD")
-                    if mapped not in getattr(exchange, "symbols", []):
-                        continue  # skip unsupported pair
-                    sym = mapped
-                cex_symbols.append(sym)
-
-        if priority_syms:
-            prio_set = set(priority_syms)
-            cex_symbols = [s for s in priority_syms if s in cex_symbols] + [s for s in cex_symbols if s not in prio_set]
-            dex_symbols = [s for s in priority_syms if s in dex_symbols] + [s for s in dex_symbols if s not in prio_set]
-
-        tf_sec = timeframe_seconds(exchange, tf)
-        tf_limit = limit
-        if start_since is not None:
-            needed = int((time.time() * 1000 - start_since) // (tf_sec * 1000)) + 1
-            tf_limit = max(limit, needed)
-
-        if cex_symbols and start_since is None:
-            groups: Dict[int, list[str]] = {}
-            for sym in cex_symbols:
-                sym_limit = dynamic_limits.get(sym, tf_limit)
-                groups.setdefault(int(sym_limit), []).append(sym)
-            for lim, syms in groups.items():
-                curr_limit = tf_limit
-                if lim < tf_limit:
-                    for s in syms:
+                return sym, ts
+    
+            start_list = time.perf_counter()
+            tasks = [asyncio.create_task(_fetch_listing(sym)) for sym in symbols]
+            for sym, listing_ts in await asyncio.gather(*tasks):
+                if listing_ts and 0 < listing_ts <= now_ms:
+                    age_ms = now_ms - listing_ts
+                    tf_sec = timeframe_seconds(exchange, tf)
+                    hist_candles = age_ms // (tf_sec * 1000)
+                    if hist_candles <= 0:
+                        continue
+                    if hist_candles > snapshot_cap * 1000:
                         logger.info(
-                            "Adjusting limit for %s on %s to %d", s, tf, lim
+                            "Skipping OHLCV history for %s on %s (age %d candles)",
+                            sym,
+                            tf,
+                            hist_candles,
                         )
-                    curr_limit = lim
-                tf_cache = await update_ohlcv_cache(
-                    exchange,
-                    tf_cache,
-                    syms,
-                    timeframe=tf,
-                    limit=curr_limit,
-                    config={
-                        "min_history_fraction": 0,
-                        "ohlcv_batch_size": config.get("ohlcv_batch_size"),
-                    },
-                    batch_size=batch_size,
-                    start_since=start_since,
-                    use_websocket=use_websocket,
-                    force_websocket_history=force_websocket_history,
-                    max_concurrent=max_concurrent,
-                    notifier=notifier,
-                    priority_symbols=priority_syms,
-                )
-        elif cex_symbols:
-            from crypto_bot.main import update_df_cache
-
-            for sym in cex_symbols:
-                batches: list = []
-                current_since = start_since
-                sym_total = min(tf_limit, dynamic_limits.get(sym, tf_limit))
-                if sym_total < tf_limit:
-                    logger.info(
-                        "Adjusting limit for %s on %s to %d", sym, tf, sym_total
+                        continue
+                    dynamic_limits[sym] = int(min(hist_candles, max_cap))
+            logger.debug(
+                "listing date fetch for %d symbols took %.2fs",
+                len(symbols),
+                time.perf_counter() - start_list,
+            )
+    
+            cex_symbols: list[str] = []
+            dex_symbols: list[str] = []
+            for s in symbols:
+                sym = s
+                base, _, quote = s.partition("/")
+                is_solana = quote.upper() == "USDC" and base.upper() not in NON_SOLANA_BASES
+                if is_solana:
+                    dex_symbols.append(sym)
+                else:
+                    if "coinbase" in getattr(exchange, "id", "") and "/USDC" in sym:
+                        mapped = sym.replace("/USDC", "/USD")
+                        if mapped not in getattr(exchange, "symbols", []):
+                            continue  # skip unsupported pair
+                        sym = mapped
+                    cex_symbols.append(sym)
+    
+            if priority_syms:
+                prio_set = set(priority_syms)
+                cex_symbols = [s for s in priority_syms if s in cex_symbols] + [s for s in cex_symbols if s not in prio_set]
+                dex_symbols = [s for s in priority_syms if s in dex_symbols] + [s for s in dex_symbols if s not in prio_set]
+    
+            tf_sec = timeframe_seconds(exchange, tf)
+            tf_limit = limit
+            if start_since is not None:
+                needed = int((time.time() * 1000 - start_since) // (tf_sec * 1000)) + 1
+                tf_limit = max(limit, needed)
+    
+            if cex_symbols and start_since is None:
+                groups: Dict[int, list[str]] = {}
+                for sym in cex_symbols:
+                    sym_limit = dynamic_limits.get(sym, tf_limit)
+                    groups.setdefault(int(sym_limit), []).append(sym)
+                for lim, syms in groups.items():
+                    curr_limit = tf_limit
+                    if lim < tf_limit:
+                        for s in syms:
+                            logger.info(
+                                "Adjusting limit for %s on %s to %d", s, tf, lim
+                            )
+                        curr_limit = lim
+                    tf_cache = await update_ohlcv_cache(
+                        exchange,
+                        tf_cache,
+                        syms,
+                        timeframe=tf,
+                        limit=curr_limit,
+                        config={
+                            "min_history_fraction": 0,
+                            "ohlcv_batch_size": config.get("ohlcv_batch_size"),
+                        },
+                        batch_size=batch_size,
+                        start_since=start_since,
+                        use_websocket=use_websocket,
+                        force_websocket_history=force_websocket_history,
+                        max_concurrent=max_concurrent,
+                        notifier=notifier,
+                        priority_symbols=priority_syms,
                     )
-                remaining = sym_total
-                while remaining > 0:
-                    req = min(remaining, 1000)
-                    data = await load_ohlcv(
+            elif cex_symbols:
+                from crypto_bot.main import update_df_cache
+    
+                for sym in cex_symbols:
+                    batches: list = []
+                    current_since = start_since
+                    sym_total = min(tf_limit, dynamic_limits.get(sym, tf_limit))
+                    if sym_total < tf_limit:
+                        logger.info(
+                            "Adjusting limit for %s on %s to %d", sym, tf, sym_total
+                        )
+                    remaining = sym_total
+                    while remaining > 0:
+                        req = min(remaining, 1000)
+                        data = await load_ohlcv(
+                            exchange,
+                            sym,
+                            timeframe=tf,
+                            limit=req,
+                            mode="rest",
+                            since=current_since,
+                            force_websocket_history=force_websocket_history,
+                        )
+                        if not data or isinstance(data, Exception):
+                            break
+                        batches.extend(data)
+                        remaining -= len(data)
+                        if len(data) < req:
+                            break
+                        current_since = data[-1][0] + 1
+    
+                    if not batches:
+                        continue
+    
+                    df_new = pd.DataFrame(
+                        batches,
+                        columns=["timestamp", "open", "high", "low", "close", "volume"],
+                    )
+                    tf_sec = timeframe_seconds(None, tf)
+                    unit = "ms" if df_new["timestamp"].iloc[0] > 1e10 else "s"
+                    df_new["timestamp"] = pd.to_datetime(df_new["timestamp"], unit=unit)
+                    df_new = (
+                        df_new.set_index("timestamp")
+                        .resample(f"{tf_sec}s")
+                        .agg({
+                            "open": "first",
+                            "high": "max",
+                            "low": "min",
+                            "close": "last",
+                            "volume": "sum",
+                        })
+                        .ffill()
+                        .reset_index()
+                    )
+                    df_new["timestamp"] = df_new["timestamp"].astype(int) // 10 ** 9
+    
+                    if sym in tf_cache and not tf_cache[sym].empty:
+                        last_ts = tf_cache[sym]["timestamp"].iloc[-1]
+                        df_new = df_new[df_new["timestamp"] > last_ts]
+                        if df_new.empty:
+                            continue
+                        df_new = pd.concat([tf_cache[sym], df_new], ignore_index=True)
+    
+                    update_df_cache(cache, tf, sym, df_new)
+                    tf_cache = cache.get(tf, {})
+                    tf_cache[sym]["return"] = tf_cache[sym]["close"].pct_change()
+                    clear_regime_cache(sym, tf)
+    
+            for sym in dex_symbols:
+                data = None
+                vol = 0.0
+                res = None
+                gecko_failed = False
+                base, _, quote = sym.partition("/")
+                is_solana = quote.upper() == "USDC" and base.upper() not in NON_SOLANA_BASES
+                sym_l = min(dynamic_limits.get(sym, tf_limit), tf_limit)
+                if sym_l < tf_limit:
+                    logger.info("Adjusting limit for %s on %s to %d", sym, tf, sym_l)
+                if is_solana:
+                    try:
+                        res = await fetch_geckoterminal_ohlcv(
+                            sym,
+                            timeframe=tf,
+                            limit=sym_l,
+                            min_24h_volume=min_volume_usd,
+                        )
+                    except Exception as e:  # pragma: no cover - network
+                        logger.warning(
+                            f"Gecko failed for {sym}: {e} - using exchange data"
+                        )
+                        gecko_failed = True
+                else:
+                    gecko_failed = True
+    
+                if res and not gecko_failed:
+                    if isinstance(res, tuple):
+                        data, vol, *_ = res
+                    else:
+                        data = res
+                        vol = min_volume_usd
+                    add_priority(data, sym)
+    
+                if gecko_failed or not data or vol < min_volume_usd:
+                    data = await fetch_dex_ohlcv(
                         exchange,
                         sym,
                         timeframe=tf,
-                        limit=req,
-                        mode="rest",
-                        since=current_since,
-                        force_websocket_history=force_websocket_history,
+                        limit=sym_l,
+                        min_volume_usd=min_volume_usd,
+                        gecko_res=res,
+                        use_gecko=is_solana,
                     )
-                    if not data or isinstance(data, Exception):
-                        break
-                    batches.extend(data)
-                    remaining -= len(data)
-                    if len(data) < req:
-                        break
-                    current_since = data[-1][0] + 1
-
-                if not batches:
+                    if isinstance(data, Exception) or not data:
+                        continue
+    
+                if not data:
                     continue
-
+    
+                if not isinstance(data, list):
+                    logger.error(
+                        "Invalid OHLCV data type for %s on %s (type: %s), skipping",
+                        sym,
+                        tf,
+                        type(data),
+                    )
+                    continue
+    
                 df_new = pd.DataFrame(
-                    batches,
+                    data,
                     columns=["timestamp", "open", "high", "low", "close", "volume"],
                 )
-                tf_sec = timeframe_seconds(None, tf)
-                unit = "ms" if df_new["timestamp"].iloc[0] > 1e10 else "s"
-                df_new["timestamp"] = pd.to_datetime(df_new["timestamp"], unit=unit)
-                df_new = (
-                    df_new.set_index("timestamp")
-                    .resample(f"{tf_sec}s")
-                    .agg({
-                        "open": "first",
-                        "high": "max",
-                        "low": "min",
-                        "close": "last",
-                        "volume": "sum",
-                    })
-                    .ffill()
-                    .reset_index()
-                )
-                df_new["timestamp"] = df_new["timestamp"].astype(int) // 10 ** 9
-
+                changed = False
                 if sym in tf_cache and not tf_cache[sym].empty:
                     last_ts = tf_cache[sym]["timestamp"].iloc[-1]
                     df_new = df_new[df_new["timestamp"] > last_ts]
                     if df_new.empty:
                         continue
-                    df_new = pd.concat([tf_cache[sym], df_new], ignore_index=True)
-
-                update_df_cache(cache, tf, sym, df_new)
-                tf_cache = cache.get(tf, {})
-                tf_cache[sym]["return"] = tf_cache[sym]["close"].pct_change()
-                clear_regime_cache(sym, tf)
-
-        for sym in dex_symbols:
-            data = None
-            vol = 0.0
-            res = None
-            gecko_failed = False
-            base, _, quote = sym.partition("/")
-            is_solana = quote.upper() == "USDC" and base.upper() not in NON_SOLANA_BASES
-            sym_l = min(dynamic_limits.get(sym, tf_limit), tf_limit)
-            if sym_l < tf_limit:
-                logger.info("Adjusting limit for %s on %s to %d", sym, tf, sym_l)
-            if is_solana:
-                try:
-                    res = await fetch_geckoterminal_ohlcv(
-                        sym,
-                        timeframe=tf,
-                        limit=sym_l,
-                        min_24h_volume=min_volume_usd,
-                    )
-                except Exception as e:  # pragma: no cover - network
-                    logger.warning(
-                        f"Gecko failed for {sym}: {e} - using exchange data"
-                    )
-                    gecko_failed = True
-            else:
-                gecko_failed = True
-
-            if res and not gecko_failed:
-                if isinstance(res, tuple):
-                    data, vol, *_ = res
+                    tf_cache[sym] = pd.concat([tf_cache[sym], df_new], ignore_index=True)
+                    changed = True
                 else:
-                    data = res
-                    vol = min_volume_usd
-                add_priority(data, sym)
-
-            if gecko_failed or not data or vol < min_volume_usd:
-                data = await fetch_dex_ohlcv(
-                    exchange,
-                    sym,
-                    timeframe=tf,
-                    limit=sym_l,
-                    min_volume_usd=min_volume_usd,
-                    gecko_res=res,
-                    use_gecko=is_solana,
-                )
-                if isinstance(data, Exception) or not data:
-                    continue
-
-            if not data:
-                continue
-
-            if not isinstance(data, list):
-                logger.error(
-                    "Invalid OHLCV data type for %s on %s (type: %s), skipping",
-                    sym,
-                    tf,
-                    type(data),
-                )
-                continue
-
-            df_new = pd.DataFrame(
-                data,
-                columns=["timestamp", "open", "high", "low", "close", "volume"],
-            )
-            changed = False
-            if sym in tf_cache and not tf_cache[sym].empty:
-                last_ts = tf_cache[sym]["timestamp"].iloc[-1]
-                df_new = df_new[df_new["timestamp"] > last_ts]
-                if df_new.empty:
-                    continue
-                tf_cache[sym] = pd.concat([tf_cache[sym], df_new], ignore_index=True)
-                changed = True
-            else:
-                tf_cache[sym] = df_new
-                changed = True
-            if changed:
-                tf_cache[sym]["return"] = tf_cache[sym]["close"].pct_change()
-                clear_regime_cache(sym, tf)
-
-        cache[tf] = tf_cache
-        logger.info("Finished update for timeframe %s", tf)
+                    tf_cache[sym] = df_new
+                    changed = True
+                if changed:
+                    tf_cache[sym]["return"] = tf_cache[sym]["close"].pct_change()
+                    clear_regime_cache(sym, tf)
+    
+            cache[tf] = tf_cache
+            logger.info("Finished update for timeframe %s", tf)
 
     return cache
 


### PR DESCRIPTION
## Summary
- ensure OHLCV updates for a timeframe run under a dedicated asyncio.Lock
- log start/finish of updates while avoiding concurrent execution for the same timeframe

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_689cd042aeec833092e8f9dc16bd9426