### PR TITLE
feat: make helius metadata optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ needed.
    ```
 5. Run the meme-wave sniper separately with Raydium v3 integration.
    Profits are automatically converted to BTC. Set `SOLANA_PRIVATE_KEY` and the
-   required `HELIUS_KEY` or provide a custom `SOLANA_RPC_URL` before launching:
+   required `HELIUS_API_KEY` or provide a custom `SOLANA_RPC_URL` before launching:
    ```bash
    python -m crypto_bot.solana.runner
    ```
@@ -249,11 +249,11 @@ FUNDING_RATE_URL=https://futures.kraken.com/derivatives/api/v3/historical-fundin
 SECRETS_PROVIDER=aws                     # optional
 SECRETS_PATH=/path/to/secret
 SOLANA_PRIVATE_KEY="[1,2,3,...]"       # required for Solana trades
-# defaults to https://mainnet.helius-rpc.com/v1/?api-key=${HELIUS_KEY}
+# defaults to https://mainnet.helius-rpc.com/v1/?api-key=${HELIUS_API_KEY}
 SOLANA_RPC_URL=https://devnet.solana.com  # optional custom endpoint
 SOLANA_RPC_URL=https://api.mainnet-beta.solana.com  # optional
 # SOLANA_RPC_URL=https://api.devnet.solana.com      # devnet example
-HELIUS_KEY=your_helius_api_key          # required for Jupiter/Helius registry
+HELIUS_API_KEY=your_helius_api_key      # required for Jupiter/Helius registry
 MORALIS_KEY=your_moralis_api_key       # optional, for Solana scanner
 BITQUERY_KEY=your_bitquery_api_key     # optional, for Solana scanner
 SUPABASE_URL=https://xyzcompany.supabase.co
@@ -292,10 +292,10 @@ SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
 # SOLANA_RPC_URL=https://api.devnet.solana.com
 ```
 
-When using [Helius](https://www.helius.xyz/) endpoints, append `?api-key=${HELIUS_KEY}` to the URL:
+When using [Helius](https://www.helius.xyz/) endpoints, append `?api-key=${HELIUS_API_KEY}` to the URL:
 
 ```env
-SOLANA_RPC_URL=https://mainnet.helius-rpc.com/v1/?api-key=${HELIUS_KEY}
+SOLANA_RPC_URL=https://mainnet.helius-rpc.com/v1/?api-key=${HELIUS_API_KEY}
 ```
 
 You can generate a key and enable advanced features like **ShredStream** and **LaserStream** from the [Helius dashboard](https://dashboard.helius.xyz/). These streams can be configured directly in the bot's web dashboard.
@@ -1445,16 +1445,16 @@ tweet volume is high.
 
 Add a `meme_wave_sniper` section to `crypto_bot/config.yaml`:
 
-Set `HELIUS_KEY` in `crypto_bot/.env` or as an environment variable. The pool
+Set `HELIUS_API_KEY` in `crypto_bot/.env` or as an environment variable. The pool
 URL should reference this key so Helius can authorize the requests:
 
 ```yaml
 meme_wave_sniper:
   enabled: true
   pool:
-    url: https://mainnet.helius-rpc.com/v1/?api-key=${HELIUS_KEY}
+    url: https://mainnet.helius-rpc.com/v1/?api-key=${HELIUS_API_KEY}
     interval: 5
-    websocket_url: wss://atlas-mainnet.helius-rpc.com/?api-key=${HELIUS_KEY}
+    websocket_url: wss://atlas-mainnet.helius-rpc.com/?api-key=${HELIUS_API_KEY}
     raydium_program_id: EhhTK0i58FmSPrbr30Y8wVDDDeWGPAHDq6vNru6wUATk
   scoring:
     weight_liquidity: 1.0
@@ -1469,7 +1469,7 @@ meme_wave_sniper:
     dry_run: true
 
 ```
-Set the `HELIUS_KEY` environment variable with your Helius API key.
+Set the `HELIUS_API_KEY` environment variable with your Helius API key.
 
 ### Flow
 

--- a/crypto_bot/wallet_manager.py
+++ b/crypto_bot/wallet_manager.py
@@ -197,7 +197,7 @@ def load_or_create(interactive: bool = False) -> dict:
         "coinbase_passphrase": ["COINBASE_API_PASSPHRASE", "API_PASSPHRASE"],
         "kraken_api_key": ["API_KEY"],
         "kraken_api_secret": ["API_SECRET"],
-        "helius_api_key": ["HELIUS_KEY"],
+        "helius_api_key": ["HELIUS_API_KEY", "HELIUS_KEY"],
     }
 
     for key, env_keys in aliases.items():
@@ -223,7 +223,9 @@ def load_or_create(interactive: bool = False) -> dict:
     os.environ["COINBASE_API_PASSPHRASE"] = creds.get("coinbase_passphrase", "")
     os.environ["KRAKEN_API_KEY"] = creds.get("kraken_api_key", "")
     os.environ["KRAKEN_API_SECRET"] = creds.get("kraken_api_secret", "")
-    os.environ["HELIUS_KEY"] = creds.get("helius_api_key", "")
+    helius_val = creds.get("helius_api_key", "")
+    os.environ["HELIUS_API_KEY"] = helius_val
+    os.environ["HELIUS_KEY"] = helius_val
     os.environ["SUPABASE_URL"] = creds.get("supabase_url", "")
     os.environ["SUPABASE_KEY"] = creds.get("supabase_key", "")
     os.environ["LUNARCRUSH_API_KEY"] = creds.get("lunarcrush_api_key", "")

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -60,13 +60,15 @@ def test_load_returns_both_exchange_creds(tmp_path, monkeypatch):
     assert creds["kraken_api_key"] == "kr_key"
 
 
-def test_load_exports_helius_key(tmp_path, monkeypatch):
+def test_load_exports_helius_api_key(tmp_path, monkeypatch):
     cfg = tmp_path / "user_config.yaml"
     data = {"helius_api_key": "hk"}
     cfg.write_text(yaml.safe_dump(data))
     monkeypatch.setattr(wallet_manager, "CONFIG_FILE", cfg)
+    monkeypatch.delenv("HELIUS_API_KEY", raising=False)
     monkeypatch.delenv("HELIUS_KEY", raising=False)
     wallet_manager.load_or_create()
+    assert os.environ["HELIUS_API_KEY"] == "hk"
     assert os.environ["HELIUS_KEY"] == "hk"
 
 


### PR DESCRIPTION
## Summary
- make Helius token metadata optional via new `HELIUS_API_KEY`
- warn on bad Helius responses and validate metadata URL
- expose `HELIUS_API_KEY` alongside legacy `HELIUS_KEY` in wallet manager

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet')*
- `pytest tests/test_token_registry.py tests/test_wallet_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_689cd0624dc483309cda787c55198b67