### PR TITLE
Handle OHLCV worker errors gracefully

### DIFF
--- a/crypto_bot/utils/market_loader.py
+++ b/crypto_bot/utils/market_loader.py
@@ -195,20 +195,29 @@ async def _ohlcv_batch_worker(
             ]
 
             base = reqs[0]
-            cache = await _update_ohlcv_cache_inner(
-                base.exchange,
-                base.cache,
-                union_symbols,
-                timeframe=base.timeframe,
-                limit=base.limit,
-                start_since=base.start_since,
-                use_websocket=base.use_websocket,
-                force_websocket_history=base.force_websocket_history,
-                config=base.config,
-                max_concurrent=base.max_concurrent,
-                notifier=base.notifier,
-                priority_symbols=union_priority,
-            )
+            try:
+                cache = await _update_ohlcv_cache_inner(
+                    base.exchange,
+                    base.cache,
+                    union_symbols,
+                    timeframe=base.timeframe,
+                    limit=base.limit,
+                    start_since=base.start_since,
+                    use_websocket=base.use_websocket,
+                    force_websocket_history=base.force_websocket_history,
+                    config=base.config,
+                    max_concurrent=base.max_concurrent,
+                    notifier=base.notifier,
+                    priority_symbols=union_priority,
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                logger.exception(
+                    "OHLCV worker: failed on timeframe=%s (batch size=%s). Continuing. Error: %s",
+                    base.timeframe,
+                    len(union_symbols),
+                    e,
+                )
+                cache = base.cache
 
             for r in reqs:
                 if r.cache is not cache:

--- a/tests/test_market_loader_worker.py
+++ b/tests/test_market_loader_worker.py
@@ -1,0 +1,30 @@
+import asyncio
+import logging
+
+import pandas as pd
+import pytest
+
+from crypto_bot.utils import market_loader
+
+
+class DummyExchange:
+    pass
+
+
+def test_batch_worker_logs_and_continues(monkeypatch, caplog):
+    async def failing_inner(exchange, cache, symbols, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(market_loader, "_update_ohlcv_cache_inner", failing_inner)
+
+    cache: dict[str, pd.DataFrame] = {}
+    with caplog.at_level(logging.ERROR):
+        res = asyncio.run(
+            market_loader.update_ohlcv_cache(
+                DummyExchange(), cache, ["BTC/USD"], limit=1
+            )
+        )
+    assert res == cache
+    assert any(
+        "OHLCV worker: failed" in r.getMessage() for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- prevent `_ohlcv_batch_worker` from crashing when `_update_ohlcv_cache_inner` raises
- add regression test ensuring the worker logs the error and continues

## Testing
- `pytest tests/test_market_loader_worker.py::test_batch_worker_logs_and_continues -q`


------
https://chatgpt.com/codex/tasks/task_e_689cfe6cd1108330bb3be463ef4bca6e