### PR TITLE
Add example testing config and smoke test script

### DIFF
--- a/config.example.testing.yaml
+++ b/config.example.testing.yaml
@@ -1,0 +1,11 @@
+mode: paper
+exchange: kraken
+timeframes: ["1h", "4h", "1d"]
+filters:
+  min_ticker_volume: 10000
+features:
+  ml: false
+  helius: false
+  pump_monitor: false
+  telegram: false
+

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,0 +1,57 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import yaml
+import os
+
+# Ensure repository root is on sys.path for direct execution
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Avoid interactive prompts for API credentials
+os.environ.setdefault("PYTEST_CURRENT_TEST", "1")
+
+from crypto_bot.execution.cex_executor import get_exchange
+from crypto_bot.utils.market_loader import load_kraken_symbols, update_ohlcv_cache
+
+
+async def main() -> None:
+    with open("config.example.testing.yaml", "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+
+    exchange, ws_client = get_exchange(config)
+
+    subset: list[str] = []
+    try:
+        symbols = await load_kraken_symbols(exchange, config=config) or []
+        subset = symbols[:5]
+        print(f"Smoke: symbols={len(subset)}")
+    except Exception as exc:  # pragma: no cover - network issues
+        print(f"Smoke: symbols=0 (error: {exc.__class__.__name__})")
+
+    if subset:
+        cache: dict = {}
+        tf = (config.get("timeframes") or ["1h"])[0]
+        try:
+            await update_ohlcv_cache(
+                exchange,
+                cache,
+                subset[:2],
+                timeframe=tf,
+                limit=2,
+                config=config,
+            )
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+    if hasattr(exchange, "close"):
+        if asyncio.iscoroutinefunction(getattr(exchange, "close", None)):
+            await exchange.close()
+        else:
+            await asyncio.to_thread(exchange.close)
+    if ws_client and hasattr(ws_client, "close"):
+        await ws_client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add example testing config for paper-mode runs with public data
- introduce smoke_test script to exercise exchange setup and OHLCV loading without API keys

## Testing
- `python scripts/smoke_test.py`
- `pytest tests/test_logger.py::test_setup_logger_creates_file_and_logs_to_console_by_default -q`


------
https://chatgpt.com/codex/tasks/task_e_689cfef2c0188330af3d505f122c041e