### PR TITLE
Remove redundant Kraken API token prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,6 @@ API_PASSPHRASE=your_coinbase_passphrase_if_needed
 # generate with:
 # python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 FERNET_KEY=your_generated_fernet_key
-KRAKEN_API_TOKEN=your_api_token        # optional for Kraken
 TELEGRAM_TOKEN=your_telegram_token
 TELEGRAM_CHAT_ID=your_chat_id          # chat to receive Telegram notifications
 WALLET_ADDRESS=your_wallet_address     # default on-chain wallet for trades
@@ -869,12 +868,11 @@ environment so the bot can retrieve social metrics. The free tier allows about
    use_websocket: true      # enable when trading on Kraken via WebSocket
    ```
 
-  For Kraken, a WebSocket token is requested automatically using your API key and secret. To override the fetched token, add it to `crypto_bot/.env`:
+For Kraken, a WebSocket token is requested automatically using your API key and secret. To override the fetched token, add it to `crypto_bot/.env`:
 
-  ```env
-  # KRAKEN_WS_TOKEN=your_ws_token  # optional override
-  KRAKEN_API_TOKEN=your_api_token
-  ```
+```env
+# KRAKEN_WS_TOKEN=your_ws_token  # optional override
+```
 
 5. In `crypto_bot/config.yaml` set:
 

--- a/crypto_bot/execution/cex_executor.py
+++ b/crypto_bot/execution/cex_executor.py
@@ -43,7 +43,6 @@ def get_exchange(config) -> Tuple[ccxt.Exchange, Optional[KrakenWSClient]]:
     ws_client: Optional[KrakenWSClient] = None
     api_key = env_or_prompt("API_KEY", "Enter API key: ") or None
     api_secret = env_or_prompt("API_SECRET", "Enter API secret: ") or None
-    api_token = env_or_prompt("KRAKEN_API_TOKEN", "Enter Kraken API token: ") or None
 
     if exchange_name == "coinbase":
         exchange = ccxt.coinbase(
@@ -61,9 +60,7 @@ def get_exchange(config) -> Tuple[ccxt.Exchange, Optional[KrakenWSClient]]:
             ws_token = os.getenv("KRAKEN_WS_TOKEN") if use_private_ws else None
             if use_private_ws and not ws_token and api_key and api_secret:
                 try:
-                    ws_token = kraken.get_ws_token(
-                        api_key, api_secret, api_token or None
-                    )
+                    ws_token = kraken.get_ws_token(api_key, api_secret)
                 except Exception as err:
                     logger.warning("Failed to get WS token: %s", err)
                     use_private_ws = kraken.use_private_ws = False
@@ -73,7 +70,6 @@ def get_exchange(config) -> Tuple[ccxt.Exchange, Optional[KrakenWSClient]]:
                         api_key,
                         api_secret,
                         ws_token=ws_token if use_private_ws else None,
-                        api_token=api_token,
                     )
                 except Exception as err:  # pragma: no cover - optional dependency
                     logger.warning("Failed to initialize Kraken WS client: %s", err)

--- a/crypto_bot/execution/kraken_ws.py
+++ b/crypto_bot/execution/kraken_ws.py
@@ -421,7 +421,6 @@ class KrakenWSClient:
         api_key: Optional[str] = None,
         api_secret: Optional[str] = None,
         ws_token: Optional[str] = None,
-        api_token: Optional[str] = None,
     ):
         if api_key is None:
             api_key = keyring.get_password("kraken", "api_key")
@@ -440,7 +439,6 @@ class KrakenWSClient:
 
         # Tokens can be supplied via environment variables to avoid repeated REST calls
         self.ws_token = ws_token or os.getenv("KRAKEN_WS_TOKEN")
-        self.api_token = api_token or os.getenv("KRAKEN_API_TOKEN")
 
         self.exchange = None
         if self.api_key and self.api_secret:
@@ -521,8 +519,9 @@ class KrakenWSClient:
             raise ValueError("API keys required for private websocket")
 
         params = {}
-        if self.api_token:
-            params["otp"] = self.api_token
+        otp = os.getenv("KRAKEN_OTP")
+        if otp:
+            params["otp"] = otp
 
         resp = self.exchange.privatePostGetWebSocketsToken(params)
         self.token = resp["token"]

--- a/tests/test_cex_executor.py
+++ b/tests/test_cex_executor.py
@@ -233,14 +233,11 @@ def test_get_exchange_websocket(monkeypatch):
 
     monkeypatch.setenv("API_KEY", "key")
     monkeypatch.setenv("API_SECRET", "sec")
-    monkeypatch.setenv("KRAKEN_API_TOKEN", "apitoken")
 
     kraken.use_private_ws = True
     monkeypatch.setattr(cex_executor.kraken, "get_ws_token", lambda *a, **k: "token")
 
     def fake_env_or_prompt(name, prompt):
-        if name == "KRAKEN_WS_TOKEN":
-            return None
         return os.getenv(name, "")
 
     monkeypatch.setattr(cex_executor, "env_or_prompt", fake_env_or_prompt)
@@ -248,10 +245,8 @@ def test_get_exchange_websocket(monkeypatch):
     created = {}
 
     class DummyWSClient:
-        def __init__(
-            self, api_key=None, api_secret=None, ws_token=None, api_token=None
-        ):
-            created["args"] = (api_key, api_secret, ws_token, api_token)
+        def __init__(self, api_key=None, api_secret=None, ws_token=None):
+            created["args"] = (api_key, api_secret, ws_token)
 
     monkeypatch.setattr(cex_executor, "KrakenWSClient", DummyWSClient)
 
@@ -269,7 +264,7 @@ def test_get_exchange_websocket(monkeypatch):
 
     exchange, ws = cex_executor.get_exchange(config)
     assert isinstance(ws, DummyWSClient)
-    expected = ("key", "sec", "token", "apitoken")
+    expected = ("key", "sec", "token")
     assert created["args"] == expected
 
 


### PR DESCRIPTION
## Summary
- drop confusing Kraken API token prompt and env variable
- simplify KrakenWSClient to use only API key/secret and optional KRAKEN_OTP
- update README and tests accordingly

## Testing
- `pytest tests/test_cex_executor.py::test_get_exchange_websocket tests/test_cex_executor.py::test_get_exchange_websocket_missing_creds tests/test_kraken_ws.py::test_reconnect_and_resubscribe tests/test_kraken_ws.py::test_token_refresh_updates_private_subs -q`


------
https://chatgpt.com/codex/tasks/task_e_689d1ab1e6cc8330a47bd163f5d5bd06