### PR TITLE
Skip unsupported symbols by checking exchange markets

### DIFF
--- a/tests/test_market_loader_quotes.py
+++ b/tests/test_market_loader_quotes.py
@@ -1,0 +1,49 @@
+import asyncio
+import logging
+
+from crypto_bot.utils.market_loader import load_kraken_symbols, load_ohlcv, logger as ml_logger
+
+
+class QuoteExchange:
+    exchange_market_types = {"spot"}
+
+    def load_markets(self):
+        return {
+            "BTC/USD": {"active": True, "type": "spot", "quote": "USD"},
+            "BTC/EUR": {"active": True, "type": "spot", "quote": "EUR"},
+            "BTC/USDT": {"active": True, "type": "spot", "quote": "USDT"},
+            "BTC/JPY": {"active": True, "type": "spot", "quote": "JPY"},
+        }
+
+
+def test_load_kraken_symbols_filters_quotes():
+    ex = QuoteExchange()
+    symbols = asyncio.run(load_kraken_symbols(ex))
+    assert set(symbols) == {"BTC/USD", "BTC/EUR", "BTC/USDT"}
+
+
+class DummyFetchExchange:
+    def __init__(self):
+        self.markets = {"BTC/USD": {"id": "BTC/USD"}}
+        self.rateLimit = 0
+
+    async def fetch_ohlcv(self, symbol, timeframe="1h", limit=100, **kwargs):
+        return [[0, 0, 0, 0, 0, 0]]
+
+    def market(self, symbol):
+        return self.markets[symbol]
+
+
+def test_load_ohlcv_skips_missing_symbol(caplog):
+    ex = DummyFetchExchange()
+
+    async def run():
+        return await load_ohlcv(ex, "ETH/USD")
+
+    with caplog.at_level(logging.DEBUG, logger=ml_logger.name):
+        data = asyncio.run(run())
+    assert data == []
+    messages = [r.getMessage() for r in caplog.records if r.name == ml_logger.name]
+    assert any(
+        "Skipping unsupported symbol ETH/USD: not in markets" in m for m in messages
+    )


### PR DESCRIPTION
## Summary
- restrict Kraken symbol discovery to active USD/USDT/EUR spot markets
- skip symbols missing from exchange.markets and use market ids for OHLCV calls
- add tests for quote filtering and unsupported-symbol handling

## Testing
- `pytest tests/test_market_loader_quotes.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis'; No module named 'cointrainer'; No module named 'crypto_bot.wallet')*

------
https://chatgpt.com/codex/tasks/task_e_689d1abf05a48330884f7d048eb4fd22