### PR TITLE
fix: refresh Supabase credentials for ML components

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ HELIUS_API_KEY=your_helius_api_key      # required for Jupiter/Helius registry
 MORALIS_KEY=your_moralis_api_key       # optional, for Solana scanner
 BITQUERY_KEY=your_bitquery_api_key     # optional, for Solana scanner
 SUPABASE_URL=https://xyzcompany.supabase.co
-SUPABASE_KEY=your_service_key
+SUPABASE_SERVICE_ROLE_KEY=your_service_key
 LUNARCRUSH_API_KEY=your_lunarcrush_api_key  # optional, LunarCrush social metrics
 token_registry.refresh_interval_minutes=720  # optional cache update interval
 ```
@@ -272,7 +272,7 @@ Each credential can be supplied in `.env`, or if missing, will be requested inte
 admin chats. Omit it to restrict control to the single `chat_id` in the
 configuration file.
 
-`SUPABASE_URL` and `SUPABASE_KEY` are required for downloading models used by `regime_classifier`.
+`SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are required for downloading models used by `regime_classifier`.
 
 ### Solana token registry
 
@@ -1625,7 +1625,7 @@ LightGBM model to Supabase:
 python ml_trainer.py train regime --use-gpu --federated
 ```
 
-Ensure `SUPABASE_URL` and `SUPABASE_KEY` are set in `crypto_bot/.env` so the
+Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set in `crypto_bot/.env` so the
 upload succeeds. Set `use_ml_regime_classifier: true` in
 `crypto_bot/regime/regime_config.yaml` to enable downloads of the trained model
 when the bot starts.

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -2853,6 +2853,9 @@ def _reload_modules() -> None:
 async def main() -> None:
     """Entry point for running the trading bot with error handling."""
     _ensure_user_setup()
+    from crypto_bot.utils.ml_utils import init_ml_components
+
+    init_ml_components()
     _import_internal_modules()
     _reload_modules()
 

--- a/crypto_bot/regime/regime_classifier.py
+++ b/crypto_bot/regime/regime_classifier.py
@@ -92,7 +92,9 @@ PATTERN_WEIGHTS = {
 
 def is_ml_available() -> bool:
     """Return ``True`` if ML dependencies and credentials are available."""
-    if not os.getenv("SUPABASE_URL") or not os.getenv("SUPABASE_KEY"):
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+    if not url or not key:
         return False
     try:  # pragma: no cover - optional dependency
         import lightgbm  # noqa: F401
@@ -221,7 +223,7 @@ async def _download_supabase_model():
     """Download LightGBM model from Supabase and return a Booster."""
     async with _supabase_model_lock:
         url = os.getenv("SUPABASE_URL")
-        key = os.getenv("SUPABASE_KEY")
+        key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
         if not url or not key:
             logger.error("Missing Supabase credentials")
             return None

--- a/crypto_bot/utils/supabase_snapshot.py
+++ b/crypto_bot/utils/supabase_snapshot.py
@@ -23,7 +23,7 @@ def fetch_snapshot(mint: str, bucket: str = "snapshots") -> Optional[dict]:
         credentials/SDK are unavailable.
     """
     url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_KEY")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
     if not url or not key:
         logger.error("Missing Supabase credentials")
         return None

--- a/crypto_bot/wallet_manager.py
+++ b/crypto_bot/wallet_manager.py
@@ -227,7 +227,15 @@ def load_or_create(interactive: bool = False) -> dict:
     os.environ["HELIUS_API_KEY"] = helius_val
     os.environ["HELIUS_KEY"] = helius_val
     os.environ["SUPABASE_URL"] = creds.get("supabase_url", "")
-    os.environ["SUPABASE_KEY"] = creds.get("supabase_key", "")
+    supabase_key = creds.get("supabase_key", "")
+    os.environ["SUPABASE_KEY"] = supabase_key
+    os.environ["SUPABASE_SERVICE_ROLE_KEY"] = supabase_key
+    try:  # refresh ML availability after setting credentials
+        from crypto_bot.utils.ml_utils import init_ml_components
+
+        init_ml_components()
+    except Exception:  # pragma: no cover - optional dependency
+        pass
     os.environ["LUNARCRUSH_API_KEY"] = creds.get("lunarcrush_api_key", "")
 
     # expose selected exchange credentials via generic env vars for ccxt

--- a/tools/train_regime_model.py
+++ b/tools/train_regime_model.py
@@ -61,7 +61,7 @@ def save_model(model, path: Path) -> None:
 
 def upload_to_supabase(path: Path) -> None:
     url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_KEY")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
     if not url or not key:
         LOG.error("Missing Supabase credentials")
         return


### PR DESCRIPTION
## Summary
- read Supabase URL and service role key from environment
- refresh ML availability after prompting for credentials
- document SUPABASE_SERVICE_ROLE_KEY in README

## Testing
- `pytest -q` *(fails: No module named 'fakeredis'; No module named 'cointrainer'; No module named 'crypto_bot.wallet')*
- `PYTHONPATH=. pytest tests/test_wallet_manager.py::test_load_exports_supabase_creds -q`


------
https://chatgpt.com/codex/tasks/task_e_689d1a9118788330b9299f8bf11b9935