### PR TITLE
feat: auto-mode CEX fallback when onchain candidates missing

### DIFF
--- a/crypto_bot/phase_runner.py
+++ b/crypto_bot/phase_runner.py
@@ -29,6 +29,8 @@ class BotContext:
     volatility_factor: float = 1.0
     mempool_monitor: object | None = None
     mempool_cfg: dict | None = None
+    active_universe: list[str] = field(default_factory=list)
+    resolved_mode: str = "auto"
 
 
 class PhaseRunner:


### PR DESCRIPTION
## Summary
- Separate CEX and onchain candidate lists and fall back to CEX when onchain metadata yields no candidates
- Track active universe and resolved mode in bot context and log strategy evaluation start
- Cover auto fallback with unit test

## Testing
- `pytest tests/test_onchain_symbols.py::test_fetch_candidates_adds_onchain -q`
- `pytest tests/test_onchain_symbols.py::test_auto_mode_falls_back_to_cex -q`


------
https://chatgpt.com/codex/tasks/task_e_689d2c2f868083309c5466e243040540