### PR TITLE
Make Helius optional and non-blocking

### DIFF
--- a/crypto_bot/solana/helius_client.py
+++ b/crypto_bot/solana/helius_client.py
@@ -1,0 +1,10 @@
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+HELIUS_API_KEY = os.getenv("HELIUS_API_KEY") or os.getenv("HELIUS_KEY") or ""
+helius_available = bool(HELIUS_API_KEY)
+
+if not helius_available:
+    logger.warning("Helius unavailable; on-chain metadata checks skipped.")

--- a/crypto_bot/solana/token_utils.py
+++ b/crypto_bot/solana/token_utils.py
@@ -6,6 +6,8 @@ from typing import List, Dict, Any
 
 import aiohttp
 
+from crypto_bot.solana.helius_client import HELIUS_API_KEY, helius_available
+
 logger = logging.getLogger(__name__)
 
 MIN_BALANCE_THRESHOLD = float(os.getenv("MIN_BALANCE_THRESHOLD", "0.0"))
@@ -22,11 +24,10 @@ async def get_token_accounts(wallet_address: str, threshold: float | None = None
         Minimum balance required. Defaults to ``MIN_BALANCE_THRESHOLD``.
     """
 
-    api_key = os.getenv("HELIUS_KEY")
-    if not api_key:
-        raise ValueError("HELIUS_KEY environment variable not set")
-
-    url = f"https://mainnet.helius-rpc.com/v1/?api-key={api_key}"
+    if helius_available:
+        url = f"https://mainnet.helius-rpc.com/v1/?api-key={HELIUS_API_KEY}"
+    else:
+        url = "https://api.mainnet-beta.solana.com"
     payload = {
         "jsonrpc": "2.0",
         "id": 1,

--- a/tests/test_token_registry.py
+++ b/tests/test_token_registry.py
@@ -18,8 +18,9 @@ class DummyErr(Exception):
 
 
 def _load_module(monkeypatch, tmp_path):
-    import importlib.util, pathlib
+    import importlib.util, pathlib, sys
 
+    sys.modules.pop("crypto_bot.solana.helius_client", None)
     spec = importlib.util.spec_from_file_location(
         "crypto_bot.utils.token_registry",
         pathlib.Path(__file__).resolve().parents[1]
@@ -238,7 +239,7 @@ def test_fetch_from_helius_4xx(monkeypatch, tmp_path, caplog):
 
 
 def test_fetch_from_helius_no_api_key(monkeypatch, tmp_path, caplog):
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.WARNING)
     monkeypatch.delenv("HELIUS_API_KEY", raising=False)
     monkeypatch.delenv("HELIUS_KEY", raising=False)
     mod = _load_module(monkeypatch, tmp_path)
@@ -252,8 +253,8 @@ def test_fetch_from_helius_no_api_key(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(mod, "aiohttp", aiohttp_mod)
 
     mapping = asyncio.run(mod.fetch_from_helius(["AAA"]))
-    assert mapping == {}
-    assert "Helius disabled (no API key)" in caplog.text
+    assert mapping == {"AAA": "metadata_unknown"}
+    assert "Helius unavailable; on-chain metadata checks skipped." in caplog.text
 
 
 def test_periodic_mint_sanity_check(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- centralize Helius API key handling and warn when unavailable
- skip on-chain metadata lookups when Helius is missing and mark tokens as `metadata_unknown`
- fall back to public Solana RPC for token balances when Helius is absent

## Testing
- `pytest tests/test_token_registry.py::test_fetch_from_helius_no_api_key -q`
- `pytest -q` *(fails: No module named 'cointrainer', 'crypto_bot.wallet')*

------
https://chatgpt.com/codex/tasks/task_e_689d2c48b8cc833096cce21906e61aa2