### PR TITLE
Disable per-message mode in Telegram conversation handler

### DIFF
--- a/crypto_bot/telegram_bot_ui.py
+++ b/crypto_bot/telegram_bot_ui.py
@@ -151,7 +151,7 @@ class TelegramBotUI:
                 EDIT_VALUE: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.set_config_value)]
             },
             fallbacks=[],
-            per_message=True,
+            per_message=False,
         )
         self.app.add_handler(conv)
         self.app.add_handler(


### PR DESCRIPTION
## Summary
- avoid per-message warning in Telegram UI by disabling per-message mode in ConversationHandler

## Testing
- `pip install fakeredis -q`
- `PYTHONPATH=.:src pytest -q` *(fails: ModuleNotFoundError: No module named 'cointrainer.io')*

------
https://chatgpt.com/codex/tasks/task_e_689d2c68d2748330a875da6e5ecf8d30