### PR TITLE
Add universe builder safeguard for auto mode

### DIFF
--- a/crypto_bot/utils/symbol_utils.py
+++ b/crypto_bot/utils/symbol_utils.py
@@ -27,6 +27,7 @@ _last_refresh: float = 0.0
 _CACHE_INVALIDATION_LOCK = Lock()
 _LAST_INVALIDATION_TS = 0.0
 _INVALIDATION_DEBOUNCE_SEC = 10.0
+_AUTO_FALLBACK_WARNED = False
 
 
 def invalidate_symbol_cache() -> None:
@@ -166,5 +167,20 @@ async def get_filtered_symbols(exchange, config) -> tuple[list[tuple[str, float]
         quote_whitelist,
         min_vol,
     )
+
+    mode = config.get("mode", "cex")
+    cex_candidates = [s for s, _ in scored]
+    active_universe = cex_candidates if mode == "cex" else list(onchain_syms)
+    if not active_universe:
+        if mode == "auto" and cex_candidates:
+            global _AUTO_FALLBACK_WARNED
+            if not _AUTO_FALLBACK_WARNED:
+                logger.warning("Universe empty; falling back to CEX mode")
+                _AUTO_FALLBACK_WARNED = True
+            config["mode"] = "cex"
+        else:
+            raise RuntimeError(
+                f"Universe is empty (mode={mode}). Check on-chain metadata provider and liquidity filters."
+            )
 
     return scored, onchain_syms

--- a/tests/test_universe_guard.py
+++ b/tests/test_universe_guard.py
@@ -1,0 +1,36 @@
+import asyncio
+import logging
+import types
+import pytest
+
+from crypto_bot.utils import symbol_utils as su
+
+@pytest.fixture(autouse=True)
+def reset_symbol_utils(monkeypatch):
+    su._cached_symbols = None
+    su._last_refresh = 0
+    su._LAST_INVALIDATION_TS = 0
+    monkeypatch.setattr(su, "_AUTO_FALLBACK_WARNED", False, raising=False)
+    yield
+
+def test_auto_mode_falls_back_to_cex(monkeypatch, caplog):
+    async def fake_filter_symbols(exchange, symbols, config):
+        return [("BTC/USDT", 1.0)], []
+    monkeypatch.setattr(su, "filter_symbols", fake_filter_symbols, raising=False)
+    cfg = {"mode": "auto", "symbol_filter": {}, "symbols": ["BTC/USDT"]}
+    ex = types.SimpleNamespace(markets={})
+    caplog.set_level(logging.WARNING)
+    scored, onchain = asyncio.run(su.get_filtered_symbols(ex, cfg))
+    assert scored == [("BTC/USDT", 1.0)]
+    assert onchain == []
+    assert cfg["mode"] == "cex"
+    assert "falling back to CEX" in caplog.text
+
+def test_empty_universe_raises(monkeypatch):
+    async def fake_filter_symbols(exchange, symbols, config):
+        return [("BTC/USDT", 1.0)], []
+    monkeypatch.setattr(su, "filter_symbols", fake_filter_symbols, raising=False)
+    cfg = {"mode": "onchain", "symbol_filter": {}, "symbols": ["BTC/USDT"]}
+    ex = types.SimpleNamespace(markets={})
+    with pytest.raises(RuntimeError, match=r"Universe is empty \(mode=onchain\)"):
+        asyncio.run(su.get_filtered_symbols(ex, cfg))


### PR DESCRIPTION
## Summary
- protect universe builder from returning no symbols
- warn and fall back to CEX in auto mode when on-chain symbols are empty
- cover auto-mode fallback and empty-universe error with new tests

## Testing
- `pytest tests/test_universe_guard.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis'; No module named 'cointrainer'; No module named 'crypto_bot.wallet')*


------
https://chatgpt.com/codex/tasks/task_e_689d2c7bd19c8330b8f854dbccd84df0