### PR TITLE
Add default model environment variables

### DIFF
--- a/crypto_bot/.env
+++ b/crypto_bot/.env
@@ -25,3 +25,7 @@
 # TELEGRAM_CHAT_ID=your_telegram_chat_id
 # WALLET_ADDRESS=your_public_wallet_address
 # SOLANA_PRIVATE_KEY="[1,2,3,...]"
+
+# Default model and regime locations
+CT_MODELS_BUCKET=models
+CT_REGIME_PREFIX=models/regime


### PR DESCRIPTION
## Summary
- default CT_MODELS_BUCKET and CT_REGIME_PREFIX in `.env`

## Testing
- `pytest` (fails: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)

------
https://chatgpt.com/codex/tasks/task_e_689d3aad8bfc8330bb6638005e1a86f9