### PR TITLE
Add ML startup self-check

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -30,6 +30,8 @@ import yaml
 from dotenv import dotenv_values
 from pydantic import ValidationError
 
+from crypto_bot.ml.selfcheck import log_ml_status_once
+
 # Internal project modules are imported lazily in `_import_internal_modules()`
 
 
@@ -67,6 +69,7 @@ symbol_utils = None  # type: ignore
 calc_atr = None  # type: ignore
 is_market_pumping = None  # type: ignore
 maybe_refresh_model = None  # type: ignore
+cooldown_configure = None  # type: ignore
 
 
 @contextlib.asynccontextmanager
@@ -2627,6 +2630,7 @@ async def _main_impl() -> TelegramNotifier:
 
     max_open_trades = config.get("max_open_trades", 1)
     position_guard = OpenPositionGuard(max_open_trades)
+    log_ml_status_once()
     rotator = PortfolioRotator()
 
     mode = user.get("mode", config.get("mode", "auto"))

--- a/crypto_bot/ml/selfcheck.py
+++ b/crypto_bot/ml/selfcheck.py
@@ -1,0 +1,28 @@
+import logging
+import os
+
+_logged = False
+
+
+def log_ml_status_once() -> None:
+    """Log ML package and Supabase environment status once."""
+    global _logged
+    if _logged:
+        return
+    _logged = True
+    log = logging.getLogger("crypto_bot.ml")
+    try:  # pragma: no cover - optional dependency
+        import cointrader_trainer  # noqa: F401
+        pkg = True
+    except ImportError:  # pragma: no cover - package missing
+        pkg = False
+    url_ok = bool(os.getenv("SUPABASE_URL"))
+    key_ok = bool(
+        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        or os.getenv("SUPABASE_KEY")
+        or os.getenv("SUPABASE_API_KEY")
+        or os.getenv("SUPABASE_ANON_KEY")
+    )
+    log.info(
+        "ML status: package=%s supabase_url=%s key_present=%s", pkg, url_ok, key_ok
+    )

--- a/tests/test_ml_selfcheck.py
+++ b/tests/test_ml_selfcheck.py
@@ -1,0 +1,34 @@
+import importlib
+import sys
+import logging
+
+import pytest
+
+from crypto_bot.ml import selfcheck
+
+
+@pytest.fixture(autouse=True)
+def reload_selfcheck():
+    importlib.reload(selfcheck)
+
+
+def test_log_ml_status_once_logs_once(monkeypatch, caplog):
+    for var in [
+        "SUPABASE_URL",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "SUPABASE_KEY",
+        "SUPABASE_API_KEY",
+        "SUPABASE_ANON_KEY",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setitem(sys.modules, "cointrader_trainer", None)
+    caplog.set_level(logging.INFO, logger="crypto_bot.ml")
+
+    selfcheck.log_ml_status_once()
+    assert (
+        "ML status: package=False supabase_url=False key_present=False" in caplog.text
+    )
+
+    caplog.clear()
+    selfcheck.log_ml_status_once()
+    assert "ML status" not in caplog.text


### PR DESCRIPTION
## Summary
- add `log_ml_status_once` to report ML package and Supabase env status
- invoke ML status log once before strategy initialization
- test ML self-check logging

## Testing
- `pytest tests/test_ml_selfcheck.py tests/test_ml_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4dc7c95c83309121aa6f062dac84