### PR TITLE
Persist Supabase credentials and export env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Configure the loader with the following environment variables:
 
 ```ini
 SUPABASE_URL=
-SUPABASE_SERVICE_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
 CT_MODELS_BUCKET=models
 CT_REGIME_PREFIX=models/regime
 CT_SYMBOL=BTCUSDT

--- a/crypto_bot/.env
+++ b/crypto_bot/.env
@@ -20,7 +20,9 @@
 # HELIUS_KEY=your_helius_api_key          # required for Jupiter/Helius registry
 # token_registry.refresh_interval_minutes=720
 # SUPABASE_URL=https://xyzcompany.supabase.co
-# SUPABASE_KEY=your_service_key
+# SUPABASE_SERVICE_ROLE_KEY=your_service_key
+# SUPABASE_KEY=your_service_key          # legacy
+# SUPABASE_API_KEY=your_service_key      # legacy
 # LUNARCRUSH_API_KEY=your_lunarcrush_key  # optional LunarCrush API key
 # TELEGRAM_CHAT_ID=your_telegram_chat_id
 # WALLET_ADDRESS=your_public_wallet_address

--- a/crypto_bot/regime/registry.py
+++ b/crypto_bot/regime/registry.py
@@ -4,7 +4,11 @@ from supabase import create_client
 
 def _client():
     url = os.environ["SUPABASE_URL"]
-    key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ["SUPABASE_KEY"]
+    key = (
+        os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+        or os.environ.get("SUPABASE_SERVICE_KEY")
+        or os.environ["SUPABASE_KEY"]
+    )
     return create_client(url, key)
 
 

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -90,9 +90,13 @@ def test_load_exports_supabase_creds(tmp_path, monkeypatch):
     monkeypatch.setattr(wallet_manager, "CONFIG_FILE", cfg)
     monkeypatch.delenv("SUPABASE_URL", raising=False)
     monkeypatch.delenv("SUPABASE_KEY", raising=False)
+    monkeypatch.delenv("SUPABASE_API_KEY", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
     creds = wallet_manager.load_or_create()
     assert os.environ["SUPABASE_URL"] == "url"
     assert os.environ["SUPABASE_KEY"] == "key"
+    assert os.environ["SUPABASE_API_KEY"] == "key"
+    assert os.environ["SUPABASE_SERVICE_ROLE_KEY"] == "key"
     assert creds["supabase_url"] == "url"
     assert creds["supabase_key"] == "key"
 


### PR DESCRIPTION
## Summary
- persist Supabase URL and service role key to crypto_bot/.env
- expose SUPABASE_SERVICE_ROLE_KEY and legacy vars to current process
- document service role key usage and update tests

## Testing
- `pytest tests/test_wallet_manager.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_689d4da6f2548330afba1b208f9bd85a