### PR TITLE
Defer ML initialization until credentials

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -3003,13 +3003,8 @@ def _reload_modules() -> None:
 async def main() -> None:
     """Entry point for running the trading bot with error handling."""
     _ensure_user_setup()
-    from crypto_bot.utils.ml_utils import init_ml_components
-
-    init_ml_components()
     _import_internal_modules()
     _reload_modules()
-
-    logger.info("ML components available: %s", ML_AVAILABLE)
 
     notifier: TelegramNotifier | None = None
     try:


### PR DESCRIPTION
## Summary
- Add `_ml_checked` flag and trainer import check to ML utilities so environment is evaluated once and missing trainer logs only once
- Remove eager ML initialization from `main` to let credential loading trigger ML setup later

## Testing
- `PYTHONPATH=src:. pytest` *(fails: No module named 'crypto_bot.wallet')*

------
https://chatgpt.com/codex/tasks/task_e_689d4dbedbac833083009280181dba22