### PR TITLE
refactor: simplify logger flag initialization

### DIFF
--- a/crypto_bot/utils/ml_utils.py
+++ b/crypto_bot/utils/ml_utils.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 _REQUIRED_PACKAGES: Iterable[str] = ("sklearn", "joblib", "ta")
 
-_LOGGER_ONCE = {"ml_unavailable": False}
 _ml_checked = False
 _LOGGER_ONCE = {
     "ml_unavailable": False,


### PR DESCRIPTION
## Summary
- remove redundant `_LOGGER_ONCE` initialization in `ml_utils`

## Testing
- `pytest tests/test_ml_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d525bb5348330965be0bdd6064923