### PR TITLE
Add missing imports to ML utilities

### DIFF
--- a/crypto_bot/utils/ml_utils.py
+++ b/crypto_bot/utils/ml_utils.py
@@ -1,6 +1,6 @@
 """Utility helpers for optional machine learning dependencies."""
-import importlib
 import base64
+import importlib.util
 import json
 import logging
 import os


### PR DESCRIPTION
## Summary
- Add missing standard-library imports to `ml_utils` for ML availability checks

## Testing
- `python -m py_compile crypto_bot/utils/ml_utils.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis'; No module named 'cointrainer')*

------
https://chatgpt.com/codex/tasks/task_e_689d525b4c3c8330ab27f90a80780a4a