### PR TITLE
Use single subprocess invocation in wallet setup

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -160,10 +160,9 @@ def _run_wallet_manager() -> None:
             file=sys.stderr,
         )
         sys.exit(2)
-    subprocess.run([sys.executable, "-m", "crypto_bot.wallet_manager"], check=True)
-    code = subprocess.call([sys.executable, "-m", "crypto_bot.wallet_manager"])
-    if code not in (0, None):
-        sys.exit(code)
+    result = subprocess.run([sys.executable, "-m", "crypto_bot.wallet_manager"])
+    if result.returncode not in (0, None):
+        sys.exit(result.returncode)
 
 
 def _ensure_user_setup() -> None:


### PR DESCRIPTION
## Summary
- Run wallet manager once using `subprocess.run`
- Exit when wallet manager returns a non-zero status

## Testing
- `pytest -q` *(fails: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_689d525a02108330bb0d3a57928b22ed