### PR TITLE
Refactor imports in main

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -1,26 +1,22 @@
 from __future__ import annotations
 
-import os
-from dotenv import load_dotenv
-
-import sys
 import asyncio
 import contextlib
-import time
-import subprocess
-import os
-from dotenv import load_dotenv
-from pathlib import Path
-from datetime import datetime
-from collections import deque, OrderedDict
-from dataclasses import dataclass, field
 import inspect
-import re
 import logging
+import os
+import re
+import subprocess
+import sys
+import time
+from collections import OrderedDict, deque
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
 from typing import Any
 
+from dotenv import load_dotenv
 import aiohttp
-
 try:
     import ccxt  # type: ignore
 except Exception:  # pragma: no cover - optional dependency


### PR DESCRIPTION
## Summary
- Deduplicate and reorder imports in `crypto_bot/main.py` so only one `import os` and one `from dotenv import load_dotenv` remain
- Organize imports into standard library, third-party, and local sections

## Testing
- `pytest tests/test_main_telegram.py` *(fails: AttributeError: update_multi_tf_ohlcv_cache)*

------
https://chatgpt.com/codex/tasks/task_e_689d52588cbc8330a482a13f9591e2ca