### PR TITLE
Use evaluation gate for cache invalidation scheduling

### DIFF
--- a/crypto_bot/utils/eval_guard.py
+++ b/crypto_bot/utils/eval_guard.py
@@ -1,0 +1,25 @@
+from contextlib import contextmanager
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class EvalGate:
+    def __init__(self):
+        self._busy = False
+
+    def is_busy(self) -> bool:
+        return self._busy
+
+    @contextmanager
+    def hold(self, note: str = ""):
+        self._busy = True
+        try:
+            yield
+        finally:
+            self._busy = False
+            if note:
+                logger.debug(f"[EvalGate] released: {note}")
+
+
+eval_gate = EvalGate()


### PR DESCRIPTION
## Summary
- add EvalGate context manager to track evaluation sections
- schedule deferred cache invalidation when evaluation is active

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet')*


------
https://chatgpt.com/codex/tasks/task_e_689e295a947483308fa7640ef1f42c92