### PR TITLE
Add HFT strategy and risk configuration example

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,72 @@
+# === trading/base ===
+trading:
+  mode: dry_run           # cex | onchain | auto | dry_run
+  exchange: kraken
+  allowed_quotes: [USD, USDT, USDC, EUR]
+  min_ticker_volume: 10000
+  timeframes: ["1m","5m"]
+  backfill:
+    warmup_high_tf: ["1h","4h","1d"]
+    deep_low_tf: true        # backfill 1m/5m history for strategies
+    deep_days: 30
+  hft_enabled: true
+  hft_symbols: ["BTC/USD","ETH/USD","SOL/USDC","BONK/USDC"]   # seed list, can expand
+  exclude_symbols: ["AIBTC/USD"]   # remove noisy/synthetic pairs
+
+# === strategies and params ===
+strategies:
+  maker_spread:
+    enabled: true
+    max_spread_bp: 8              # don’t quote if spread > 8 bps
+    edge_margin_bp: 3             # required extra edge beyond maker fee
+    max_live_quotes: 2
+    queue_timeout_ms: 1500        # cancel if sitting too long
+    cancel_on_obi_flip: true
+
+  breakout:
+    enabled: true
+    tf: "5m"
+    donchian_len: 40
+    keltner_len: 20
+    bbw_pct_max: 15               # BB width in bottom 15th percentile
+    volume_z_min: 1.0
+    atr_mult_stop: 1.2
+    atr_mult_tp: 1.2
+    max_spread_bp: 10
+    time_exit_bars: 12
+
+  mean_revert:
+    enabled: true
+    tf: "1m"
+    ema_len: 50
+    z_entry: 2.0
+    z_exit: 0.5
+    adx_max: 18
+    atr_stop_mult: 1.0
+    max_spread_bp: 8
+    time_exit_bars: 6
+
+# === risk & sizing ===
+risk:
+  vol_horizon_secs: 600           # realized vol window ~10m
+  target_sigma_notional_usd: 150  # $ risk per trade equalized by vol
+  daily_loss_limit_pct: 3.0       # halt for the day after -3%
+  max_consecutive_losses: 3       # cooldown symbol after 3 losses
+  symbol_cooldown_min: 20
+
+# === fees ===
+fees:
+  kraken:
+    taker_bp: 26    # example 0.26%
+    maker_bp: 16    # example 0.16%
+
+# === features ===
+features:
+  ml: false
+  helius: false
+  pump_monitor: false
+  telegram: true
+
+# === telemetry / metrics ===
+telemetry:
+  batch_summary_secs: 60

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -298,6 +298,7 @@ regime_timeframes:
 - 1m
 - 5m
 - 15m
+# === risk & sizing ===
 risk:
   atr_long_window: 40
   atr_period: 10
@@ -314,6 +315,11 @@ risk:
   volume_threshold_ratio: 0.01
   win_rate_threshold: 0.7
   win_rate_boost_factor: 1.5
+  vol_horizon_secs: 600           # realized vol window ~10m
+  target_sigma_notional_usd: 150  # $ risk per trade equalized by vol
+  daily_loss_limit_pct: 3.0       # halt for the day after -3%
+  max_consecutive_losses: 3       # cooldown symbol after 3 losses
+  symbol_cooldown_min: 20
 rl_selector:
   enabled: true
 rsi_overbought_pct: 80
@@ -560,3 +566,68 @@ voting_strategies:
 wallet_address: your_wallet
 ws_failures_before_disable: 1
 ws_ping_interval: 5
+
+# === trading/base ===
+trading:
+  mode: dry_run           # cex | onchain | auto | dry_run
+  exchange: kraken
+  allowed_quotes: [USD, USDT, USDC, EUR]
+  min_ticker_volume: 10000
+  timeframes: ["1m","5m"]
+  backfill:
+    warmup_high_tf: ["1h","4h","1d"]
+    deep_low_tf: true        # backfill 1m/5m history for strategies
+    deep_days: 30
+  hft_enabled: true
+  hft_symbols: ["BTC/USD","ETH/USD","SOL/USDC","BONK/USDC"]   # seed list, can expand
+  exclude_symbols: ["AIBTC/USD"]   # remove noisy/synthetic pairs
+
+# === strategies and params ===
+strategies:
+  maker_spread:
+    enabled: true
+    max_spread_bp: 8              # don’t quote if spread > 8 bps
+    edge_margin_bp: 3             # required extra edge beyond maker fee
+    max_live_quotes: 2
+    queue_timeout_ms: 1500        # cancel if sitting too long
+    cancel_on_obi_flip: true
+
+  breakout:
+    enabled: true
+    tf: "5m"
+    donchian_len: 40
+    keltner_len: 20
+    bbw_pct_max: 15               # BB width in bottom 15th percentile
+    volume_z_min: 1.0
+    atr_mult_stop: 1.2
+    atr_mult_tp: 1.2
+    max_spread_bp: 10
+    time_exit_bars: 12
+
+  mean_revert:
+    enabled: true
+    tf: "1m"
+    ema_len: 50
+    z_entry: 2.0
+    z_exit: 0.5
+    adx_max: 18
+    atr_stop_mult: 1.0
+    max_spread_bp: 8
+    time_exit_bars: 6
+
+# === fees ===
+fees:
+  kraken:
+    taker_bp: 26    # example 0.26%
+    maker_bp: 16    # example 0.16%
+
+# === features ===
+features:
+  ml: false
+  helius: false
+  pump_monitor: false
+  telegram: true
+
+# === telemetry / metrics ===
+telemetry:
+  batch_summary_secs: 60

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -487,15 +487,59 @@ def _load_config_file() -> dict:
     with open(CONFIG_PATH) as f:
         logger.info("Loading config from %s", CONFIG_PATH)
         data = yaml.safe_load(f) or {}
-    exchange_id = data.get("exchange") or os.getenv("EXCHANGE")
-    timeframes = data.get("timeframes")
-    trading_mode = data.get("execution_mode")
+    trading_cfg = data.get("trading", {}) or {}
+    exchange_id = data.get("exchange") or trading_cfg.get("exchange") or os.getenv("EXCHANGE")
+    timeframes = data.get("timeframes") or trading_cfg.get("timeframes")
+    trading_mode = data.get("execution_mode") or trading_cfg.get("mode")
+    allowed_quotes = trading_cfg.get("allowed_quotes", [])
     logger.info(
-        "Exchange=%s timeframes=%s mode=%s",
+        "Exchange=%s timeframes=%s mode=%s allowed_quotes=%s hft=%s",
         exchange_id,
         timeframes,
         trading_mode,
+        allowed_quotes,
+        trading_cfg.get("hft_enabled", False),
     )
+    trading_cfg.setdefault("allowed_quotes", [])
+    trading_cfg.setdefault("min_ticker_volume", 0)
+    backfill_cfg = trading_cfg.get("backfill", {}) or {}
+    backfill_cfg.setdefault("warmup_high_tf", [])
+    backfill_cfg.setdefault("deep_low_tf", False)
+    backfill_cfg.setdefault("deep_days", 0)
+    trading_cfg["backfill"] = backfill_cfg
+    trading_cfg.setdefault("hft_enabled", False)
+    trading_cfg.setdefault("hft_symbols", [])
+    trading_cfg.setdefault("exclude_symbols", [])
+    data["trading"] = trading_cfg
+    data.setdefault("exchange", exchange_id)
+    data.setdefault("timeframes", timeframes)
+    data.setdefault("execution_mode", trading_mode)
+
+    risk_cfg = data.get("risk", {}) or {}
+    risk_cfg.setdefault("vol_horizon_secs", 0)
+    risk_cfg.setdefault("target_sigma_notional_usd", 0)
+    risk_cfg.setdefault("daily_loss_limit_pct", 0)
+    risk_cfg.setdefault("max_consecutive_losses", 0)
+    risk_cfg.setdefault("symbol_cooldown_min", 0)
+    data["risk"] = risk_cfg
+
+    fees_cfg = data.get("fees", {}) or {}
+    kraken_cfg = fees_cfg.get("kraken", {}) or {}
+    kraken_cfg.setdefault("taker_bp", 0)
+    kraken_cfg.setdefault("maker_bp", 0)
+    fees_cfg["kraken"] = kraken_cfg
+    data["fees"] = fees_cfg
+
+    feat_cfg = data.get("features", {}) or {}
+    feat_cfg.setdefault("ml", False)
+    feat_cfg.setdefault("helius", False)
+    feat_cfg.setdefault("pump_monitor", False)
+    feat_cfg.setdefault("telegram", False)
+    data["features"] = feat_cfg
+
+    tele_cfg = data.get("telemetry", {}) or {}
+    tele_cfg.setdefault("batch_summary_secs", 0)
+    data["telemetry"] = tele_cfg
 
     data = replace_placeholders(data)
 


### PR DESCRIPTION
## Summary
- add `config.example.yaml` capturing trading, strategy, risk, fee, feature and telemetry settings
- sync `crypto_bot/config.yaml` with new HFT and strategy sections and risk defaults
- update config loader to read new sections, set defaults and log HFT/quote info

## Testing
- `pytest tests/test_config.py -q` *(fails: TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_689d5e9c5db48330871874eec140391b