### PR TITLE
feat: add expanded config example and keys

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,72 @@
+# === trading/base ===
+trading:
+  mode: dry_run           # cex | onchain | auto | dry_run
+  exchange: kraken
+  allowed_quotes: [USD, USDT, USDC, EUR]
+  min_ticker_volume: 10000
+  timeframes: ["1m","5m"]
+  backfill:
+    warmup_high_tf: ["1h","4h","1d"]
+    deep_low_tf: true        # backfill 1m/5m history for strategies
+    deep_days: 30
+  hft_enabled: true
+  hft_symbols: ["BTC/USD","ETH/USD","SOL/USDC","BONK/USDC"]   # seed list, can expand
+  exclude_symbols: ["AIBTC/USD"]   # remove noisy/synthetic pairs
+
+# === strategies and params ===
+strategies:
+  maker_spread:
+    enabled: true
+    max_spread_bp: 8              # don’t quote if spread > 8 bps
+    edge_margin_bp: 3             # required extra edge beyond maker fee
+    max_live_quotes: 2
+    queue_timeout_ms: 1500        # cancel if sitting too long
+    cancel_on_obi_flip: true
+
+  breakout:
+    enabled: true
+    tf: "5m"
+    donchian_len: 40
+    keltner_len: 20
+    bbw_pct_max: 15               # BB width in bottom 15th percentile
+    volume_z_min: 1.0
+    atr_mult_stop: 1.2
+    atr_mult_tp: 1.2
+    max_spread_bp: 10
+    time_exit_bars: 12
+
+  mean_revert:
+    enabled: true
+    tf: "1m"
+    ema_len: 50
+    z_entry: 2.0
+    z_exit: 0.5
+    adx_max: 18
+    atr_stop_mult: 1.0
+    max_spread_bp: 8
+    time_exit_bars: 6
+
+# === risk & sizing ===
+risk:
+  vol_horizon_secs: 600           # realized vol window ~10m
+  target_sigma_notional_usd: 150  # $ risk per trade equalized by vol
+  daily_loss_limit_pct: 3.0       # halt for the day after -3%
+  max_consecutive_losses: 3       # cooldown symbol after 3 losses
+  symbol_cooldown_min: 20
+
+# === fees ===
+fees:
+  kraken:
+    taker_bp: 26    # example 0.26%
+    maker_bp: 16    # example 0.16%
+
+# === features ===
+features:
+  ml: false
+  helius: false
+  pump_monitor: false
+  telegram: true
+
+# === telemetry / metrics ===
+telemetry:
+  batch_summary_secs: 60

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -1,3 +1,76 @@
+# === trading/base ===
+trading:
+  mode: dry_run           # cex | onchain | auto | dry_run
+  exchange: kraken
+  allowed_quotes: [USD, USDT, USDC, EUR]
+  min_ticker_volume: 10000
+  timeframes: ["1m","5m"]
+  backfill:
+    warmup_high_tf: ["1h","4h","1d"]
+    deep_low_tf: true        # backfill 1m/5m history for strategies
+    deep_days: 30
+  hft_enabled: true
+  hft_symbols: ["BTC/USD","ETH/USD","SOL/USDC","BONK/USDC"]   # seed list, can expand
+  exclude_symbols: ["AIBTC/USD"]   # remove noisy/synthetic pairs
+
+# === strategies and params ===
+strategies:
+  maker_spread:
+    enabled: true
+    max_spread_bp: 8              # don’t quote if spread > 8 bps
+    edge_margin_bp: 3             # required extra edge beyond maker fee
+    max_live_quotes: 2
+    queue_timeout_ms: 1500        # cancel if sitting too long
+    cancel_on_obi_flip: true
+
+  breakout:
+    enabled: true
+    tf: "5m"
+    donchian_len: 40
+    keltner_len: 20
+    bbw_pct_max: 15               # BB width in bottom 15th percentile
+    volume_z_min: 1.0
+    atr_mult_stop: 1.2
+    atr_mult_tp: 1.2
+    max_spread_bp: 10
+    time_exit_bars: 12
+
+  mean_revert:
+    enabled: true
+    tf: "1m"
+    ema_len: 50
+    z_entry: 2.0
+    z_exit: 0.5
+    adx_max: 18
+    atr_stop_mult: 1.0
+    max_spread_bp: 8
+    time_exit_bars: 6
+
+# === risk & sizing ===
+risk:
+  vol_horizon_secs: 600           # realized vol window ~10m
+  target_sigma_notional_usd: 150  # $ risk per trade equalized by vol
+  daily_loss_limit_pct: 3.0       # halt for the day after -3%
+  max_consecutive_losses: 3       # cooldown symbol after 3 losses
+  symbol_cooldown_min: 20
+
+# === fees ===
+fees:
+  kraken:
+    taker_bp: 26    # example 0.26%
+    maker_bp: 16    # example 0.16%
+
+# === features ===
+features:
+  ml: false
+  helius: false
+  pump_monitor: false
+  telegram: true
+
+# === telemetry / metrics ===
+telemetry:
+  batch_summary_secs: 60
+
 adaptive_scan:
   atr_baseline: 0.005
   enabled: true


### PR DESCRIPTION
## Summary
- provide example configuration covering trading options, strategies, risk limits, fees, feature flags, and telemetry
- merge same configuration block into runtime config

## Testing
- `pytest tests/test_config.py tests/test_config_schema.py` *(fails: module 'crypto_bot.main' has no attribute 'ScannerConfig')*


------
https://chatgpt.com/codex/tasks/task_e_689d5e8fac208330b9ea854857c3fadd