### PR TITLE
Avoid duplicate evaluation in StreamEvaluator

### DIFF
--- a/crypto_bot/strategy/evaluator.py
+++ b/crypto_bot/strategy/evaluator.py
@@ -29,7 +29,6 @@ class StreamEvaluator:
                 return
             try:
                 await asyncio.wait_for(self.eval_fn(symbol, ctx), timeout=8)
-                await self.eval_fn(symbol, ctx)
                 logger.debug(f"[EVAL OK] {symbol}")
             except asyncio.TimeoutError:
                 logger.warning(f"[EVAL TIMEOUT] {symbol}")


### PR DESCRIPTION
## Summary
- Call `eval_fn` only once per symbol in `StreamEvaluator`
- Use `asyncio.wait_for` for timeout handling and log success or timeout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e3aaf626c83308b30af1cea9e1835