### PR TITLE
Add evaluation worker and dry-run trade logging

### DIFF
--- a/crypto_bot/engine/evaluation_engine.py
+++ b/crypto_bot/engine/evaluation_engine.py
@@ -1,0 +1,86 @@
+import asyncio
+import logging
+from typing import Awaitable, Callable, Any
+
+logger = logging.getLogger(__name__)
+
+
+class EvaluationEngine:
+    """Queue based evaluation engine with worker pool logging."""
+
+    def __init__(self, eval_fn: Callable[[str, dict], Awaitable[Any]], concurrency: int = 8):
+        self.queue: asyncio.Queue[tuple[str, dict]] = asyncio.Queue()
+        self.eval_fn = eval_fn
+        self.concurrency = concurrency
+        self._workers: list[asyncio.Task] = []
+        self._closed = asyncio.Event()
+
+    async def start(self) -> None:
+        for _ in range(self.concurrency):
+            self._workers.append(asyncio.create_task(self._worker()))
+        logger.info(
+            "Evaluation workers online: %d; queue=%d",
+            self.concurrency,
+            self.queue.qsize(),
+        )
+
+    async def _worker(self) -> None:
+        while not self._closed.is_set():
+            try:
+                symbol, ctx = await self.queue.get()
+            except asyncio.CancelledError:  # pragma: no cover - shutdown
+                return
+            timeframes = []
+            if isinstance(ctx, dict):
+                timeframes = ctx.get("timeframes", [])
+            logger.info("EVAL START %s on %s", symbol, timeframes)
+            try:
+                res = await asyncio.wait_for(self.eval_fn(symbol, ctx), timeout=8)
+                if isinstance(res, dict):
+                    direction = res.get("direction", "none")
+                    signal = (
+                        "BUY"
+                        if direction == "long"
+                        else "SELL" if direction == "short" else "NONE"
+                    )
+                    logger.info(
+                        "STRAT %s on %s: signal=%s score=%s reason=%s",
+                        res.get("name"),
+                        symbol,
+                        signal,
+                        res.get("score"),
+                        res.get("reason", ""),
+                    )
+                logger.debug("[EVAL OK] %s", symbol)
+            except asyncio.TimeoutError:
+                logger.warning("[EVAL TIMEOUT] %s", symbol)
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.exception("[EVAL ERROR] %s: %s", symbol, exc)
+            finally:
+                self.queue.task_done()
+
+    async def enqueue(self, symbol: str, ctx: dict) -> None:
+        await self.queue.put((symbol, ctx))
+
+    async def drain(self) -> None:
+        await self.queue.join()
+
+    async def stop(self) -> None:
+        self._closed.set()
+        for w in self._workers:
+            w.cancel()
+        await asyncio.gather(*self._workers, return_exceptions=True)
+
+
+_STREAM_EVAL: EvaluationEngine | None = None
+
+
+def set_stream_evaluator(evaluator: EvaluationEngine) -> None:
+    global _STREAM_EVAL
+    _STREAM_EVAL = evaluator
+
+
+def get_stream_evaluator() -> EvaluationEngine:
+    if _STREAM_EVAL is None:
+        raise RuntimeError("EvaluationEngine not initialized")
+    return _STREAM_EVAL

--- a/crypto_bot/execution/order_executor.py
+++ b/crypto_bot/execution/order_executor.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+from typing import Any, Dict, Optional
+
+from . import cex_executor
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_trade_async(
+    exchange: Any,
+    ws_client: Any,
+    symbol: str,
+    side: str,
+    amount: float,
+    notifier: Any,
+    *,
+    dry_run: bool = True,
+    use_websocket: bool = False,
+    config: Optional[Dict] = None,
+    score: float = 0.0,
+    reason: str = "",
+    trading_paused: bool = False,
+) -> Dict:
+    """Wrapper around :mod:`cex_executor` adding detailed logging."""
+
+    if trading_paused:
+        logger.info("Trading is paused; signal suppressed (use 'start' to resume)")
+        return {}
+
+    if dry_run:
+        price = None
+        if exchange is not None and hasattr(exchange, "fetch_ticker"):
+            try:
+                fetch = getattr(exchange, "fetch_ticker")
+                if asyncio.iscoroutinefunction(fetch):
+                    ticker = await fetch(symbol)
+                else:
+                    ticker = await asyncio.to_thread(fetch, symbol)
+                price = ticker.get("last") or ticker.get("close")
+            except Exception:  # pragma: no cover - best effort
+                price = None
+        logger.info(
+            "DRY-RUN: would place %s %.4f %s @ %s; reason=%s",
+            side.upper(),
+            amount,
+            symbol,
+            price,
+            reason,
+        )
+        return {
+            "symbol": symbol,
+            "side": side,
+            "amount": amount,
+            "price": price,
+            "dry_run": True,
+        }
+
+    return await cex_executor.execute_trade_async(
+        exchange,
+        ws_client,
+        symbol,
+        side,
+        amount,
+        notifier,
+        dry_run=False,
+        use_websocket=use_websocket,
+        config=config,
+        score=score,
+    )

--- a/crypto_bot/strategy/evaluator.py
+++ b/crypto_bot/strategy/evaluator.py
@@ -1,61 +1,11 @@
-from __future__ import annotations
-import asyncio
-import logging
-from typing import Callable, Awaitable, Dict, Any
+from crypto_bot.engine.evaluation_engine import (
+    EvaluationEngine as StreamEvaluator,
+    get_stream_evaluator,
+    set_stream_evaluator,
+)
 
-logger = logging.getLogger(__name__)
-
-class StreamEvaluator:
-    """
-    Push symbols into an asyncio.Queue as soon as their OHLCV warmup is ready.
-    One or more worker tasks consume and run strategy evaluation immediately.
-    """
-    def __init__(self, eval_fn: Callable[[str, Dict[str, Any]], Awaitable[None]], concurrency: int = 8):
-        self.queue: asyncio.Queue[tuple[str, dict]] = asyncio.Queue()
-        self.eval_fn = eval_fn
-        self.concurrency = concurrency
-        self._workers: list[asyncio.Task] = []
-        self._closed = asyncio.Event()
-
-    async def start(self):
-        for i in range(self.concurrency):
-            self._workers.append(asyncio.create_task(self._worker(i)))
-
-    async def _worker(self, idx: int):
-        while not self._closed.is_set():
-            try:
-                symbol, ctx = await self.queue.get()
-            except asyncio.CancelledError:
-                return
-            try:
-                await asyncio.wait_for(self.eval_fn(symbol, ctx), timeout=8)
-                logger.debug(f"[EVAL OK] {symbol}")
-            except asyncio.TimeoutError:
-                logger.warning(f"[EVAL TIMEOUT] {symbol}")
-            except Exception as e:
-                logger.exception(f"[EVAL ERROR] {symbol}: {e}")
-            finally:
-                self.queue.task_done()
-
-    async def enqueue(self, symbol: str, ctx: dict):
-        await self.queue.put((symbol, ctx))
-
-    async def drain(self):
-        await self.queue.join()
-
-    async def stop(self):
-        self._closed.set()
-        for w in self._workers:
-            w.cancel()
-        await asyncio.gather(*self._workers, return_exceptions=True)
-
-STREAM_EVALUATOR: StreamEvaluator | None = None
-
-def set_stream_evaluator(evaluator: StreamEvaluator) -> None:
-    global STREAM_EVALUATOR
-    STREAM_EVALUATOR = evaluator
-
-def get_stream_evaluator() -> StreamEvaluator:
-    if STREAM_EVALUATOR is None:
-        raise RuntimeError("StreamEvaluator not initialized")
-    return STREAM_EVALUATOR
+__all__ = [
+    "StreamEvaluator",
+    "get_stream_evaluator",
+    "set_stream_evaluator",
+]


### PR DESCRIPTION
## Summary
- add EvaluationEngine that logs worker startup, queued symbols and strategy results
- log dry-run trade intentions and pause state in order executor
- forward strategy name and pause status to order executor when executing trades

## Testing
- `pip install fakeredis`
- `PYTHONPATH=src:. pytest` *(fails: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689e938815d883308b165023d30bd49d