### PR TITLE
Remove evaluator summary and time references

### DIFF
--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -18,17 +18,7 @@ async def test_evaluate_batch_handles_outcomes(caplog, monkeypatch):
 
     ctx = types.SimpleNamespace(eval_fn=eval_fn)
 
-    class FakeMonotonic:
-        def __init__(self):
-            self.t = 0.0
-        def __call__(self):
-            val = self.t
-            self.t += 1.0
-            return val
-
     monkeypatch.setattr(evaluator, "DEFAULT_TIMEOUT", 0.01)
-    monkeypatch.setattr(evaluator, "SUMMARY_INTERVAL", 2.5)
-    monkeypatch.setattr(evaluator.time, "monotonic", FakeMonotonic())
 
     with caplog.at_level(logging.INFO):
         results = await evaluator.evaluate_batch(["good", "bad", "slow"], ctx)
@@ -36,11 +26,5 @@ async def test_evaluate_batch_handles_outcomes(caplog, monkeypatch):
     assert results == {"good": {"symbol": "good"}}
     timeout_msg = next(r for r in caplog.records if "[EVAL TIMEOUT] slow" in r.message)
     error_msg = next(r for r in caplog.records if "[EVAL ERROR] bad" in r.message)
-    summary = next(r for r in caplog.records if "Eval stats" in r.message)
     assert timeout_msg
     assert error_msg
-    assert "scanned=3" in summary.message
-    assert "ok=1" in summary.message
-    assert "errors=1" in summary.message
-    assert "timeouts=1" in summary.message
-    assert "signals=1" in summary.message


### PR DESCRIPTION
## Summary
- drop periodic evaluator statistics logging
- simplify evaluate_batch after removing summary interval
- update evaluator test for new behavior

## Testing
- `flake8 crypto_bot/evaluator.py`
- `pytest tests/test_evaluator.py`


------
https://chatgpt.com/codex/tasks/task_e_689e98ddb03883308b0b29aca95adbc8