### PR TITLE
Fix undefined ClientError in websocket watcher

### DIFF
--- a/crypto_bot/solana/watcher.py
+++ b/crypto_bot/solana/watcher.py
@@ -180,6 +180,7 @@ class PoolWatcher:
         self._running = True
         backoff = 1
         last_log = 0
+        ClientError = getattr(aiohttp, "ClientError", Exception)
         async with aiohttp.ClientSession() as session:
             while self._running:
                 reconnect = False


### PR DESCRIPTION
## Summary
- ensure ClientError is defined in solana watcher websocket logic

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689e9fae2e148330a73fcab78a3cc631