### PR TITLE
Improve error logging for Jupiter token fetch

### DIFF
--- a/crypto_bot/utils/token_registry.py
+++ b/crypto_bot/utils/token_registry.py
@@ -217,9 +217,9 @@ async def load_token_mints(
             mapping = await fetch_from_jupiter()
             if mapping:
                 break
-        except Exception as exc:  # pragma: no cover - network failures
-            logger.error(
-                "Failed to fetch Jupiter tokens (attempt %d/3): %s", attempt + 1, exc
+        except Exception:  # pragma: no cover - network failures
+            logger.exception(
+                "Failed to fetch Jupiter tokens (attempt %d/3)", attempt + 1
             )
         if attempt < 2:
             await asyncio.sleep(0.5 * 2**attempt)


### PR DESCRIPTION
## Summary
- log token fetch failures with `logger.exception` to capture trace

## Testing
- `ruff check crypto_bot/utils/token_registry.py --ignore F841`

------
https://chatgpt.com/codex/tasks/task_e_689e9fafd1d083308a983b36c48fe55f