### PR TITLE
feat: add evaluation gate watchdog

### DIFF
--- a/crypto_bot/engine/evaluation_engine.py
+++ b/crypto_bot/engine/evaluation_engine.py
@@ -1,21 +1,83 @@
 import asyncio
 import logging
-from typing import Awaitable, Callable, Any
+import time
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any, Awaitable, Callable
+
 
 logger = logging.getLogger(__name__)
+
+
+class EvalGate:
+    """Async gate to serialize evaluations with TTL watchdog."""
+
+    def __init__(self, logger: logging.Logger, ttl_sec: int = 120) -> None:
+        self._lock = asyncio.Lock()
+        self._owner: str | None = None
+        self._since: float = 0.0
+        self._logger = logger
+        self._ttl = ttl_sec
+        self._watchdog_task: asyncio.Task | None = None
+
+    @asynccontextmanager
+    async def hold(self, owner: str):
+        await self._lock.acquire()
+        self._owner = owner
+        self._since = time.monotonic()
+        try:
+            yield
+        finally:
+            self._owner = None
+            self._since = 0.0
+            self._lock.release()
+
+    async def start_watchdog(self) -> None:
+        async def _watch() -> None:
+            while True:
+                await asyncio.sleep(5)
+                if self._lock.locked() and self._since > 0:
+                    held = time.monotonic() - self._since
+                    if held > self._ttl:
+                        self._logger.warning(
+                            "Gate held >%ss by %s; forcing release",
+                            self._ttl,
+                            self._owner,
+                        )
+                        try:
+                            self._lock.release()
+                        except RuntimeError:
+                            pass
+                        self._owner = None
+                        self._since = 0.0
+
+        if self._watchdog_task is None:
+            self._watchdog_task = asyncio.create_task(_watch())
 
 
 class StreamEvaluationEngine:
     """Queue based evaluation engine with worker pool logging."""
 
-    def __init__(self, eval_fn: Callable[[str, dict], Awaitable[Any]], concurrency: int = 8):
+    def __init__(
+        self,
+        eval_fn: Callable[[str, dict], Awaitable[Any]],
+        concurrency: int = 8,
+        cfg: Any | None = None,
+        data: Any | None = None,
+    ) -> None:
         self.queue: asyncio.Queue[tuple[str, dict]] = asyncio.Queue()
         self.eval_fn = eval_fn
         self.concurrency = concurrency
         self._workers: list[asyncio.Task] = []
         self._closed = asyncio.Event()
+        self.data = data or SimpleNamespace(ready=lambda symbol, tf: True)
+        ttl = 120
+        if cfg is not None and getattr(cfg, "evaluation", None) is not None:
+            ttl = getattr(cfg.evaluation, "gate_ttl_sec", ttl)
+        self.gate = EvalGate(logger, ttl_sec=ttl)
 
     async def start(self) -> None:
+        await self.gate.start_watchdog()
         for _ in range(self.concurrency):
             self._workers.append(asyncio.create_task(self._worker()))
         logger.info(
@@ -24,38 +86,55 @@ class StreamEvaluationEngine:
             self.queue.qsize(),
         )
 
+    def _symbol_requires_5m(self, ctx: dict) -> bool:
+        timeframes = []
+        if isinstance(ctx, dict):
+            timeframes = ctx.get("timeframes", [])
+        return "5m" in timeframes
+
+    async def _evaluate_symbol(self, symbol: str, ctx: dict) -> None:
+        timeframes = []
+        if isinstance(ctx, dict):
+            timeframes = ctx.get("timeframes", [])
+        res = await asyncio.wait_for(self.eval_fn(symbol, ctx), timeout=8)
+        if isinstance(res, dict):
+            direction = res.get("direction", "none")
+            signal = (
+                "BUY"
+                if direction == "long"
+                else "SELL" if direction == "short" else "NONE"
+            )
+            logger.info(
+                "STRAT %s on %s: signal=%s score=%s reason=%s",
+                res.get("name"),
+                symbol,
+                signal,
+                res.get("score"),
+                res.get("reason", ""),
+            )
+        logger.debug("[EVAL OK] %s", symbol)
+
     async def _worker(self) -> None:
+        logger.info("Evaluation worker online")
         while not self._closed.is_set():
             try:
                 symbol, ctx = await self.queue.get()
             except asyncio.CancelledError:  # pragma: no cover - shutdown
                 return
-            timeframes = []
-            if isinstance(ctx, dict):
-                timeframes = ctx.get("timeframes", [])
-            logger.info("EVAL START %s on %s", symbol, timeframes)
             try:
-                res = await asyncio.wait_for(self.eval_fn(symbol, ctx), timeout=8)
-                if isinstance(res, dict):
-                    direction = res.get("direction", "none")
-                    signal = (
-                        "BUY"
-                        if direction == "long"
-                        else "SELL" if direction == "short" else "NONE"
-                    )
-                    logger.info(
-                        "STRAT %s on %s: signal=%s score=%s reason=%s",
-                        res.get("name"),
-                        symbol,
-                        signal,
-                        res.get("score"),
-                        res.get("reason", ""),
-                    )
-                logger.debug("[EVAL OK] %s", symbol)
-            except asyncio.TimeoutError:
-                logger.warning("[EVAL TIMEOUT] %s", symbol)
-            except Exception as exc:  # pragma: no cover - best effort
-                logger.exception("[EVAL ERROR] %s: %s", symbol, exc)
+                needs_5m = self._symbol_requires_5m(ctx)
+                if not self.data.ready(symbol, "1m"):
+                    logger.debug("EVAL SKIP %s: 1m warmup not met", symbol)
+                    continue
+                if needs_5m and not self.data.ready(symbol, "5m"):
+                    logger.debug("EVAL SKIP %s: 5m warmup not met", symbol)
+                    continue
+
+                async with self.gate.hold(f"{symbol}"):
+                    logger.info("EVAL START %s", symbol)
+                    await self._evaluate_symbol(symbol, ctx)
+            except Exception:
+                logger.exception("Evaluator crashed on %s", symbol)
             finally:
                 self.queue.task_done()
 
@@ -84,82 +163,4 @@ def get_stream_evaluator() -> StreamEvaluationEngine:
     if _STREAM_EVAL is None:
         raise RuntimeError("EvaluationEngine not initialized")
     return _STREAM_EVAL
-import threading
-from typing import Any, Awaitable, Callable
 
-from crypto_bot.utils.eval_guard import eval_gate
-
-logger = logging.getLogger(__name__)
-
-
-def _has_ohlcv(ctx: Any, symbol: str, timeframe: str, warmup_met: bool = True) -> bool:
-    """Return True if OHLCV data for *symbol*/*timeframe* exists and meets warmup."""
-    cache = getattr(ctx, "df_cache", {}) or {}
-    tf_cache = cache.get(timeframe, {}) or {}
-    df = tf_cache.get(symbol)
-    if df is None or getattr(df, "empty", True):
-        return False
-    if warmup_met:
-        warm_map = getattr(ctx, "config", {}).get("warmup_candles", {}) or {}
-        required = int(warm_map.get(timeframe, 0) or 0)
-        if required and len(df) < required:
-            return False
-    return True
-
-
-class GatedEvaluationEngine:
-    """Evaluate strategies with gate protection and warmup checks."""
-
-    def __init__(self, ttl: float = 120.0):
-        self.ttl = ttl
-
-    async def _watchdog(self, symbol: str, strat: str) -> None:
-        try:
-            await asyncio.sleep(self.ttl)
-        except asyncio.CancelledError:  # pragma: no cover - watchdog cancelled
-            return
-        if eval_gate.is_busy():
-            logger.warning(
-                "Gate held >%ds by %s/%s; force-releasing",
-                self.ttl,
-                symbol,
-                strat,
-            )
-            eval_gate._busy = False  # force release
-
-    async def evaluate(
-        self,
-        symbol: str,
-        strategy: Callable[[str, Any], Awaitable[Any]],
-        ctx: Any,
-    ) -> Any:
-        """Evaluate *strategy* for *symbol* using *ctx* with gate management."""
-        if not _has_ohlcv(ctx, symbol, "1m", warmup_met=True):
-            logger.debug(
-                "EVAL SKIP %s: prerequisites not met (missing 5m or warmup)", symbol
-            )
-            return None
-        needs_5m = False
-        try:
-            lookback = getattr(strategy, "required_lookback")()
-            needs_5m = "5m" in (lookback or {})
-        except Exception:  # pragma: no cover - strategy missing hook
-            needs_5m = False
-        if needs_5m and not _has_ohlcv(ctx, symbol, "5m", warmup_met=True):
-            logger.debug(
-                "EVAL SKIP %s: prerequisites not met (missing 5m or warmup)", symbol
-            )
-            return None
-
-        strat_name = getattr(strategy, "__name__", str(strategy))
-        owner = threading.get_ident()
-        logger.debug("Gate acquire by %s/%s (owner=%s)", symbol, strat_name, owner)
-        watchdog = asyncio.create_task(self._watchdog(symbol, strat_name))
-        try:
-            with eval_gate.hold(f"{symbol}/{strat_name}"):
-                return await strategy(symbol, ctx)
-        finally:
-            watchdog.cancel()
-            logger.debug(
-                "Gate release by %s/%s (owner=%s)", symbol, strat_name, owner
-            )


### PR DESCRIPTION
## Summary
- add EvalGate context manager with TTL watchdog for evaluation lock
- guard StreamEvaluationEngine worker with gate and warmup checks

## Testing
- `pytest tests/test_evaluator.py tests/test_eval_queue.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis'; ModuleNotFoundError: No module named 'cointrainer'; ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*


------
https://chatgpt.com/codex/tasks/task_e_689f385bcf54833098512bd42c6f1bf2