### PR TITLE
Add per-timeframe OHLCV cache updates with locks

### DIFF
--- a/crypto_bot/data/__init__.py
+++ b/crypto_bot/data/__init__.py
@@ -1,2 +1,6 @@
 """Data utilities package for cache management and synchronization."""
 
+from .ohlcv_cache import OHLCVCache
+
+__all__ = ["OHLCVCache"]
+

--- a/crypto_bot/data/ohlcv_cache.py
+++ b/crypto_bot/data/ohlcv_cache.py
@@ -1,0 +1,65 @@
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from .locks import timeframe_lock
+
+
+def utc_now() -> datetime:
+    """Return current UTC datetime."""
+    return datetime.now(timezone.utc)
+
+
+class OHLCVCache:
+    """Manage OHLCV caching with per-timeframe locks."""
+
+    def __init__(self, cfg: Any, logger: logging.Logger | None = None) -> None:
+        self.cfg = cfg
+        self.logger = logger or logging.getLogger(__name__)
+
+    async def update_intraday(self, timeframes: list[str]):
+        """Run per-timeframe updates concurrently."""
+        self.logger.info("Updating OHLCV cache for timeframes: %s", timeframes)
+        tasks: list[asyncio.Task] = []
+        for tf in timeframes:
+            tasks.append(asyncio.create_task(self._update_tf(tf)))
+        await asyncio.gather(*tasks)
+
+    async def _update_tf(self, tf: str) -> None:
+        lock = self._get_timeframe_lock(tf)
+        if lock.locked():
+            self.logger.info("Skip: %s update already running.", tf)
+            return
+
+        async with lock:
+            self.logger.info("Starting OHLCV update for timeframe %s", tf)
+            warmup = self.cfg.warmup_candles.get(tf)
+            backfill = self.cfg.backfill_days.get(tf)
+            start = None
+            if backfill:
+                start = utc_now() - timedelta(days=backfill)
+                self.logger.info(
+                    "Clamping backfill for %s to %s days (%s)",
+                    tf,
+                    backfill,
+                    start.isoformat(),
+                )
+            if warmup:
+                self.logger.info("Clamping warmup candles for %s to %s", tf, warmup)
+
+            await self._fetch_and_store(tf, warmup=warmup, start=start if backfill else None)
+            self.logger.info("Completed OHLCV update for timeframe %s", tf)
+
+    def _get_timeframe_lock(self, tf: str) -> asyncio.Lock:
+        """Return a unique lock for ``tf``."""
+        return timeframe_lock(tf)
+
+    async def _fetch_and_store(
+        self, tf: str, *, warmup: int | None = None, start: datetime | None = None
+    ) -> None:
+        """Fetch and persist OHLCV data for *tf*.
+
+        Subclasses should override this method with concrete implementation.
+        """
+        raise NotImplementedError

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,12 +1,20 @@
 import sys
 import types
+from pathlib import Path
+
+# Ensure local packages (crypto_bot, cointrainer) are importable
+ROOT = Path(__file__).resolve().parent
+SRC = ROOT / "src"
+for path in (ROOT, SRC):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
 
 try:  # use real PyYAML if available
     import yaml  # type: ignore
 except Exception:  # pragma: no cover - fallback stub
-    if 'yaml' not in sys.modules:
-        sys.modules['yaml'] = types.SimpleNamespace(
+    if "yaml" not in sys.modules:
+        sys.modules["yaml"] = types.SimpleNamespace(
             safe_load=lambda *a, **k: {},
-            safe_dump=lambda *a, **k: '',
-            dump=lambda *a, **k: ''
+            safe_dump=lambda *a, **k: "",
+            dump=lambda *a, **k: "",
         )


### PR DESCRIPTION
## Summary
- Add `OHLCVCache` with concurrent per-timeframe intraday updates guarded by individual locks
- Export `OHLCVCache` from data package and ensure local packages are importable via `sitecustomize`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*
- `PYTHONPATH=/workspace/coinTrader2.0:/workspace/coinTrader2.0/src pytest tests/test_wallet.py`

------
https://chatgpt.com/codex/tasks/task_e_689f386ac828833081f85c2df462c844