### PR TITLE
Enforce strict CEX markets and configurable denylist

### DIFF
--- a/crypto_bot/config.py
+++ b/crypto_bot/config.py
@@ -27,4 +27,16 @@ class Config:
         default_factory=lambda: ["USD", "USDT", "USDC", "EUR"]
     )
     hft: bool = True
+    strict_cex: bool = False
+    denylist_symbols: List[str] = field(default_factory=list)
+
+
+# Default global configuration used by modules that expect a ``cfg`` object.
+#
+# Individual applications may override or replace this instance at runtime,
+# but providing it here keeps optional modules decoupled from the loader while
+# still allowing them to reference configuration values such as
+# ``denylist_symbols`` or ``strict_cex``.
+cfg = Config()
+
 

--- a/crypto_bot/data/symbol_cache.py
+++ b/crypto_bot/data/symbol_cache.py
@@ -1,35 +1,43 @@
 import json
 import logging
 from pathlib import Path
-from typing import Dict, Iterable, MutableMapping, MutableSequence, Any
-
-DENY = {"AIBTC/USD", "AIBTC:USD"}
-_LOGGED: set[str] = set()
+from typing import Any, Dict, MutableMapping, MutableSequence
 
 logger = logging.getLogger(__name__)
 
+# The cache file lives under ``cache/symbol_cache.json`` relative to the
+# repository root.
 CACHE_FILE = Path(__file__).resolve().parents[2] / "cache" / "symbol_cache.json"
 
-def _maybe_purge(symbol: str) -> bool:
-    if symbol in DENY:
-        if symbol not in _LOGGED:
-            logger.info("Purged denylisted symbol from cache: %s", symbol)
-            _LOGGED.add(symbol)
-        return False
-    return True
+try:  # pragma: no cover - best effort; cfg may not be available in tests
+    from crypto_bot.config import cfg  # type: ignore
+except Exception:  # pragma: no cover - fallback for minimal environments
+    from types import SimpleNamespace
+
+    cfg = SimpleNamespace(denylist_symbols=[])  # type: ignore
+
 
 def purge_denylisted(container: Any) -> Any:
     """Remove denylisted symbols from ``container`` in-place and return it.
 
-    ``container`` may be a list of symbols or a mapping of symbol -> value.
+    ``container`` may be a list of symbols or a mapping of ``symbol -> value``.
+    The denylist is sourced from ``cfg.denylist_symbols`` allowing runtime
+    configuration. Any purged symbol is logged for observability.
     """
+
+    deny = set(getattr(cfg, "denylist_symbols", []) or [])
+    if not deny:
+        return container
     if isinstance(container, MutableSequence):
-        items = [s for s in container if _maybe_purge(str(s))]
-        container[:] = items
+        restored = [s for s in container if s not in deny]
+        for s in set(container).intersection(deny):
+            logger.info("Purged denylisted symbol from cache: %s", s)
+        container[:] = restored
     elif isinstance(container, MutableMapping):
         for key in list(container.keys()):
-            if not _maybe_purge(str(key)):
+            if key in deny:
                 container.pop(key, None)
+                logger.info("Purged denylisted symbol from cache: %s", key)
     return container
 
 def load_cache() -> Dict[str, float]:

--- a/crypto_bot/markets/symbol_service.py
+++ b/crypto_bot/markets/symbol_service.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - the global cfg may not exist in tests
+    from crypto_bot.config import cfg  # type: ignore
+except Exception:  # pragma: no cover - fallback for minimal environments
+    from types import SimpleNamespace
+
+    cfg = SimpleNamespace(strict_cex=False, denylist_symbols=[], allowed_quotes=[], min_volume=0.0)  # type: ignore
+
+
+class SymbolService:
+    """Utility service for generating candidate trading pairs.
+
+    The service operates in "CEX" mode when working with a centralised exchange
+    object that exposes ``list_markets`` and optional ``markets`` attributes.
+    """
+
+    def __init__(self, exchange):
+        self.exchange = exchange
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _quote_ok(self, symbol: str) -> bool:
+        allowed = {str(q).upper() for q in getattr(cfg, "allowed_quotes", []) or []}
+        if not allowed:
+            return True
+        quote = str(symbol).split("/")[-1].upper()
+        return quote in allowed
+
+    def _volume_ok(self, symbol: str) -> bool:  # pragma: no cover - simple heuristic
+        markets = getattr(self.exchange, "markets", {}) or {}
+        info = markets.get(symbol, {}) if isinstance(markets, dict) else {}
+        vol = float(info.get("quoteVolume") or info.get("baseVolume") or 0)
+        min_vol = float(getattr(cfg, "min_volume", 0.0) or 0.0)
+        return vol >= min_vol
+
+    # ------------------------------------------------------------------
+    def get_candidates(self) -> list[str]:
+        """Return candidate symbols for CEX trading.
+
+        When ``cfg.strict_cex`` is enabled the list of markets is sourced
+        directly from the exchange and filtered based on quote and volume
+        checks. A runtime denylist (``cfg.denylist_symbols``) is also applied to
+        exclude problematic pairs such as synthetic indexes.
+        """
+
+        if getattr(cfg, "strict_cex", False):
+            markets = self.exchange.list_markets()  # authoritative symbols
+            allowed = set(
+                m for m in markets if self._quote_ok(m) and self._volume_ok(m)
+            )
+            for bad in getattr(cfg, "denylist_symbols", []) or []:
+                if bad in allowed:
+                    allowed.remove(bad)
+                    logger.info(
+                        "Purged denylisted symbol from candidates: %s", bad
+                    )
+            return sorted(allowed)
+
+        # Non-strict mode falls back to whatever the exchange already knows
+        markets = getattr(self.exchange, "markets", {})
+        if isinstance(markets, dict):
+            symbols = markets.keys()
+        else:
+            symbols = markets or []
+        return sorted(
+            m for m in symbols if self._quote_ok(m) and self._volume_ok(m)
+        )


### PR DESCRIPTION
## Summary
- add strict CEX candidate generation with runtime denylist filtering
- load denylisted symbols from config when restoring symbol cache
- expose `strict_cex` and `denylist_symbols` in config

## Testing
- `PYTHONPATH=/workspace/coinTrader2.0:src pytest tests/test_main_symbols.py`
- `PYTHONPATH=/workspace/coinTrader2.0:src pytest tests/test_wallet.py`
- `PYTHONPATH=/workspace/coinTrader2.0:src pytest` *(fails: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689f387ae108833095ddbd03580d3e05