### PR TITLE
refactor: streamline evaluation engine startup

### DIFF
--- a/crypto_bot/engine/evaluation_engine.py
+++ b/crypto_bot/engine/evaluation_engine.py
@@ -86,11 +86,6 @@ class StreamEvaluationEngine:
     async def start(self) -> None:
         # read enabled list from config if available
         enabled = set(getattr(self.cfg, "strategies", {}).get("enabled", [])) or None
-        self.strategies, self.strategy_import_errors = load_strategies(enabled=enabled)
-        from crypto_bot.strategy import load_strategies
-
-        # read enabled list from config if available
-        enabled = set(getattr(self.cfg, "strategies", {}).get("enabled", [])) or None
         self.strategies, self.strategy_import_errors = load_strategies(
             enabled=enabled
         )


### PR DESCRIPTION
## Summary
- remove redundant strategy loading and inline import in evaluation engine startup
- use single enabled lookup when loading strategies

## Testing
- `pytest tests/test_evaluator.py::test_evaluate_batch_handles_outcomes -q`
- `pytest tests/test_eval_queue.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f6830d5688330b7cc5bda163db95b