### PR TITLE
Remove redundant imports from GeckoTerminal OHLCV fetcher

### DIFF
--- a/crypto_bot/utils/market_loader.py
+++ b/crypto_bot/utils/market_loader.py
@@ -1656,15 +1656,6 @@ async def fetch_dex_ohlcv(
 
 
 # --- Back-compat: GeckoTerminal OHLCV wrapper using CCXT (real fetch, no stubs) ---
-from typing import Optional, Any, List
-import os
-
-try:
-    import ccxt  # type: ignore
-except Exception:
-    ccxt = None
-
-
 def fetch_geckoterminal_ohlcv(
     symbol: str,
     timeframe: str = "1h",


### PR DESCRIPTION
## Summary
- remove duplicated typing, os, and ccxt imports near `fetch_geckoterminal_ohlcv`
- rely on module-level imports for GeckoTerminal OHLCV fetch helper

## Testing
- `python -m py_compile crypto_bot/utils/market_loader.py`
- `pytest` *(fails: 21 errors during collection, missing cointrainer, wallet modules, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689f6831e0988330ac6d398eafa4ecce