### PR TITLE
Enable per-message handling in Telegram bot UI

### DIFF
--- a/crypto_bot/telegram_bot_ui.py
+++ b/crypto_bot/telegram_bot_ui.py
@@ -151,7 +151,7 @@ class TelegramBotUI:
                 EDIT_VALUE: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.set_config_value)]
             },
             fallbacks=[],
-            per_message=False,
+            per_message=True,  # eliminate PTBUserWarning
         )
         self.app.add_handler(conv)
         self.app.add_handler(


### PR DESCRIPTION
## Summary
- set `per_message=True` in Telegram `ConversationHandler` to avoid PTBUserWarning

## Testing
- `pytest tests/test_telegram_bot_ui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689f740e36808330b1336eb56d68fea7