### PR TITLE
Fix ConversationHandler per_message warning

### DIFF
--- a/crypto_bot/telegram_bot_ui.py
+++ b/crypto_bot/telegram_bot_ui.py
@@ -151,7 +151,7 @@ class TelegramBotUI:
                 EDIT_VALUE: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.set_config_value)]
             },
             fallbacks=[],
-            per_message=False,
+            per_message=True,  # eliminate PTBUserWarning
         )
         self.app.add_handler(conv)
         self.app.add_handler(


### PR DESCRIPTION
## Summary
- set `per_message=True` on `ConversationHandler` to eliminate PTBUserWarning

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sklearn.gaussian_process'; 'sklearn' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689f740799f08330927e3c8c8bacfae3