### PR TITLE
refactor: extract ATR indicator

### DIFF
--- a/crypto_bot/indicators/__init__.py
+++ b/crypto_bot/indicators/__init__.py
@@ -1,0 +1,6 @@
+"""Indicator helpers."""
+
+from .atr import calc_atr
+
+__all__ = ["calc_atr"]
+

--- a/crypto_bot/indicators/atr.py
+++ b/crypto_bot/indicators/atr.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+import pandas as pd
+
+
+def calc_atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """
+    Simple ATR (SMA of True Range). Columns required: 'high', 'low', 'close'.
+    """
+    high = df["high"]
+    low = df["low"]
+    close = df["close"]
+    prev_close = close.shift(1)
+
+    tr = pd.concat(
+        [
+            (high - low).abs(),
+            (high - prev_close).abs(),
+            (low - prev_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+
+    return tr.rolling(window=period, min_periods=period).mean()

--- a/crypto_bot/utils/volatility.py
+++ b/crypto_bot/utils/volatility.py
@@ -1,7 +1,6 @@
 import math
 import pandas as pd
-import ta
-from crypto_bot.volatility_filter import calc_atr
+from crypto_bot.indicators.atr import calc_atr
 
 
 def atr_percent(df: pd.DataFrame, window: int = 14) -> float:
@@ -9,13 +8,13 @@ def atr_percent(df: pd.DataFrame, window: int = 14) -> float:
     if df.empty or not {"high", "low", "close"}.issubset(df.columns):
         return 0.0
 
-    series = ta.volatility.average_true_range(
-        df["high"], df["low"], df["close"], window=window
-    )
-    if series.empty:
-        return 0.0
-
-    atr = float(series.iloc[-1])
+    result = calc_atr(df, window)
+    if isinstance(result, pd.Series):
+        if result.empty:
+            return 0.0
+        atr = float(result.iloc[-1])
+    else:
+        atr = float(result)
     price = float(df["close"].iloc[-1])
     if price == 0 or math.isnan(atr) or math.isnan(price):
         return 0.0
@@ -40,11 +39,11 @@ def normalize_score_by_volatility(
     if not {"high", "low", "close"}.issubset(df.columns):
         return raw_score
 
-    current_atr = calc_atr(df, window=current_window)
-    long_term_atr = calc_atr(df, window=long_term_window)
-    if any(
-        math.isnan(x) or x == 0 for x in [current_atr, long_term_atr]
-    ):
+    cur_res = calc_atr(df, current_window)
+    long_res = calc_atr(df, long_term_window)
+    current_atr = float(cur_res.iloc[-1] if isinstance(cur_res, pd.Series) else cur_res)
+    long_term_atr = float(long_res.iloc[-1] if isinstance(long_res, pd.Series) else long_res)
+    if any(math.isnan(x) or x == 0 for x in [current_atr, long_term_atr]):
         return raw_score
 
     scale = min(current_atr / long_term_atr, 2.0)

--- a/crypto_bot/volatility_filter.py
+++ b/crypto_bot/volatility_filter.py
@@ -10,6 +10,7 @@ import requests
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
 from crypto_bot.utils.indicator_cache import cache_series
 from pathlib import Path
+from crypto_bot.indicators.atr import calc_atr as _calc_atr_series
 
 
 logger = setup_logger(__name__, LOG_DIR / "volatility.log")
@@ -51,13 +52,8 @@ def fetch_funding_rate(symbol: str) -> float:
 def calc_atr(df: pd.DataFrame, window: int = 14) -> float:
     """Calculate the Average True Range using cached values."""
     lookback = window
-    recent = df.iloc[-(lookback + 1) :]
-    high_low = recent["high"] - recent["low"]
-    high_close = (recent["high"] - recent["close"].shift()).abs()
-    low_close = (recent["low"] - recent["close"].shift()).abs()
-    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
-    atr_series = tr.rolling(window).mean()
-    cached = cache_series(f"atr_{window}", df, atr_series, lookback)
+    series = _calc_atr_series(df, period=window)
+    cached = cache_series(f"atr_{window}", df, series, lookback)
     return float(cached.iloc[-1])
 
 


### PR DESCRIPTION
## Summary
- add ATR indicator module for shared use
- rework volatility utilities to pull ATR from new indicators module
- wire volatility filter to use shared ATR calculation

## Testing
- `pytest tests/test_risk_manager.py`
- `pytest tests/test_volatility_utils.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sklearn.gaussian_process'; 'sklearn' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689f738a9260833093cff5feb75fa05d