### PR TITLE
refactor: decouple volatility utils from filter

### DIFF
--- a/crypto_bot/indicators/atr.py
+++ b/crypto_bot/indicators/atr.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def calc_atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Return the Average True Range for ``df``.
+
+    Parameters
+    ----------
+    df: pandas.DataFrame
+        Must contain ``high``, ``low`` and ``close`` columns.
+    period: int, default 14
+        Rolling window size.
+    """
+    high, low, close = df["high"], df["low"], df["close"]
+    prev = close.shift(1)
+    tr = pd.concat(
+        [(high - low).abs(), (high - prev).abs(), (low - prev).abs()], axis=1
+    ).max(axis=1)
+    return tr.rolling(period, min_periods=period).mean()

--- a/crypto_bot/utils/volatility.py
+++ b/crypto_bot/utils/volatility.py
@@ -1,7 +1,22 @@
+from __future__ import annotations
+
 import math
 import pandas as pd
-import ta
-from crypto_bot.volatility_filter import calc_atr
+
+try:  # pragma: no cover - optional dependency
+    from crypto_bot.indicators.atr import calc_atr  # type: ignore
+except Exception:  # pragma: no cover - best effort
+    calc_atr = None
+
+
+def _fallback_atr(df: pd.DataFrame, period: int) -> pd.Series:
+    """Compute ATR locally when the indicator import fails."""
+    high, low, close = df["high"], df["low"], df["close"]
+    prev = close.shift(1)
+    tr = pd.concat(
+        [(high - low).abs(), (high - prev).abs(), (low - prev).abs()], axis=1
+    ).max(axis=1)
+    return tr.rolling(period, min_periods=period).mean()
 
 
 def atr_percent(df: pd.DataFrame, window: int = 14) -> float:
@@ -9,8 +24,8 @@ def atr_percent(df: pd.DataFrame, window: int = 14) -> float:
     if df.empty or not {"high", "low", "close"}.issubset(df.columns):
         return 0.0
 
-    series = ta.volatility.average_true_range(
-        df["high"], df["low"], df["close"], window=window
+    series = (
+        calc_atr(df, period=window) if calc_atr is not None else _fallback_atr(df, window)
     )
     if series.empty:
         return 0.0
@@ -30,8 +45,8 @@ def normalize_score_by_volatility(
 ) -> float:
     """Scale ``raw_score`` based on market volatility.
 
-    The function compares the current ATR to a long‑term average (default
-    20‑period). The score is multiplied by
+    The function compares the current ATR to a long-term average (default
+    20-period). The score is multiplied by
     ``min(current_atr / long_term_avg_atr, 2.0)``. If ATR values are
     unavailable, the raw score is returned unchanged.
     """
@@ -40,12 +55,17 @@ def normalize_score_by_volatility(
     if not {"high", "low", "close"}.issubset(df.columns):
         return raw_score
 
-    current_atr = calc_atr(df, window=current_window)
-    long_term_atr = calc_atr(df, window=long_term_window)
-    if any(
-        math.isnan(x) or x == 0 for x in [current_atr, long_term_atr]
-    ):
+    calc = calc_atr if calc_atr is not None else _fallback_atr
+    current_series = calc(df, period=current_window)
+    long_series = calc(df, period=long_term_window)
+    if current_series.empty or long_series.empty:
+        return raw_score
+
+    current_atr = float(current_series.iloc[-1])
+    long_term_atr = float(long_series.iloc[-1])
+    if any(math.isnan(x) or x == 0 for x in (current_atr, long_term_atr)):
         return raw_score
 
     scale = min(current_atr / long_term_atr, 2.0)
     return raw_score * scale
+


### PR DESCRIPTION
## Summary
- add standalone `calc_atr` indicator
- use ATR indicator with local fallback in volatility utilities

## Testing
- `PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: No module named 'sklearn.gaussian_process'; 'sklearn' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689f739867d48330b639c82535a0db1d