### PR TITLE
Run OHLCV warmups for both 1m and 5m timeframes

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -68,3 +68,13 @@ features:
 # === telemetry / metrics ===
 telemetry:
   batch_summary_secs: 60
+
+timeframes: ['1m','5m']
+
+warmup_candles:
+  '1m': 1000
+  '5m': 600
+
+backfill_days:
+  '1m': 2
+  '5m': 3

--- a/tests/test_ohlcv_cache_manager.py
+++ b/tests/test_ohlcv_cache_manager.py
@@ -1,0 +1,23 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+
+from crypto_bot.data.ohlcv_cache import OHLCVCache
+
+
+class DummyCache(OHLCVCache):
+    async def _fetch_and_store(self, tf, warmup=None, start=None):
+        # Simulate a quick fetch
+        await asyncio.sleep(0)
+
+
+def test_update_intraday_runs_all_timeframes(caplog):
+    cfg = SimpleNamespace(
+        warmup_candles={'1m': 1000, '5m': 600},
+        backfill_days={'1m': 2, '5m': 3},
+    )
+    cache = DummyCache(cfg, logger=logging.getLogger('test'))
+    caplog.set_level('INFO')
+    asyncio.run(cache.update_intraday(['1m', '5m']))
+    assert 'Starting OHLCV update for timeframe 1m' in caplog.text
+    assert 'Starting OHLCV update for timeframe 5m' in caplog.text


### PR DESCRIPTION
## Summary
- document config warmup/backfill settings for both 1m and 5m frames
- add unit test ensuring OHLCV cache updates each timeframe independently

## Testing
- `pytest tests/test_ohlcv_cache_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f73cc9cbc8330b33cdab96bff7670