### PR TITLE
refactor: consolidate ATR calculation

### DIFF
--- a/crypto_bot/indicators/atr.py
+++ b/crypto_bot/indicators/atr.py
@@ -2,55 +2,39 @@ from __future__ import annotations
 
 import pandas as pd
 
-
-def calc_atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
-    """Return the Average True Range for ``df``.
-
-    Parameters
-    ----------
-    df: pandas.DataFrame
-        Must contain ``high``, ``low`` and ``close`` columns.
-    period: int, default 14
-        Rolling window size.
-    """
-    high, low, close = df["high"], df["low"], df["close"]
-    prev = close.shift(1)
-    tr = pd.concat(
-        [(high - low).abs(), (high - prev).abs(), (low - prev).abs()], axis=1
-    ).max(axis=1)
-    return tr.rolling(period, min_periods=period).mean()
-    """
-    Simple ATR (SMA of True Range). Columns required: 'high', 'low', 'close'.
-    """
-    high = df["high"]
-    low = df["low"]
-    close = df["close"]
-    prev_close = close.shift(1)
-
-    tr = pd.concat(
-        [
-            (high - low).abs(),
-            (high - prev_close).abs(),
-            (low - prev_close).abs(),
-        ],
-        axis=1,
-    ).max(axis=1)
-
-    return tr.rolling(window=period, min_periods=period).mean()
-
-import pandas as pd
-
 from crypto_bot.utils.indicator_cache import cache_series
 
 
 def calc_atr(df: pd.DataFrame, window: int = 14) -> float:
-    """Calculate the Average True Range using cached values."""
-    lookback = window
-    recent = df.iloc[-(lookback + 1) :]
-    high_low = recent["high"] - recent["low"]
-    high_close = (recent["high"] - recent["close"].shift()).abs()
-    low_close = (recent["low"] - recent["close"].shift()).abs()
+    """Return the latest Average True Range (ATR) value.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Data containing ``high``, ``low`` and ``close`` columns.
+    window : int, default 14
+        Number of periods used for the ATR calculation.
+
+    Returns
+    -------
+    float
+        The most recent ATR value. ``0.0`` is returned when required
+        columns are missing or the input is empty.
+    """
+
+    if df.empty or not {"high", "low", "close"}.issubset(df.columns):
+        return 0.0
+
+    high_low = df["high"] - df["low"]
+    high_close = (df["high"] - df["close"].shift()).abs()
+    low_close = (df["low"] - df["close"].shift()).abs()
     tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
-    atr_series = tr.rolling(window).mean()
-    cached = cache_series(f"atr_{window}", df, atr_series, lookback)
+    atr_series = tr.rolling(window, min_periods=window).mean()
+    cached = cache_series(f"atr_{window}", df, atr_series, window)
+    if cached.empty:
+        return 0.0
     return float(cached.iloc[-1])
+
+
+__all__ = ["calc_atr"]
+

--- a/crypto_bot/utils/volatility.py
+++ b/crypto_bot/utils/volatility.py
@@ -3,55 +3,13 @@ from __future__ import annotations
 import math
 import pandas as pd
 
-try:  # pragma: no cover - optional dependency
-    from crypto_bot.indicators.atr import calc_atr  # type: ignore
-except Exception:  # pragma: no cover - best effort
-    calc_atr = None
-
-
-def _fallback_atr(df: pd.DataFrame, period: int) -> pd.Series:
-    """Compute ATR locally when the indicator import fails."""
-    high, low, close = df["high"], df["low"], df["close"]
-    prev = close.shift(1)
-    tr = pd.concat(
-        [(high - low).abs(), (high - prev).abs(), (low - prev).abs()], axis=1
-    ).max(axis=1)
-    return tr.rolling(period, min_periods=period).mean()
 from crypto_bot.indicators.atr import calc_atr
-import ta
-
-
-def _atr(df: pd.DataFrame, window: int) -> float:
-    """Return the latest ATR value for ``df`` using TA library.
-
-    A lightweight helper to avoid importing :mod:`crypto_bot.volatility_filter`,
-    which would otherwise create a circular dependency during module import.
-    """
-    if df.empty or not {"high", "low", "close"}.issubset(df.columns):
-        return 0.0
-
-    series = (
-        calc_atr(df, period=window) if calc_atr is not None else _fallback_atr(df, window)
-    result = calc_atr(df, window)
-    if isinstance(result, pd.Series):
-        if result.empty:
-            return 0.0
-        atr = float(result.iloc[-1])
-    else:
-        atr = float(result)
-    series = ta.volatility.average_true_range(
-        df["high"], df["low"], df["close"], window=window
-    )
-    if series.empty:
-        return 0.0
-
-    value = float(series.iloc[-1])
-    return 0.0 if math.isnan(value) else value
 
 
 def atr_percent(df: pd.DataFrame, window: int = 14) -> float:
     """Return ATR as a percentage of the latest close price."""
-    atr = _atr(df, window)
+
+    atr = calc_atr(df, window)
     if atr == 0:
         return 0.0
 
@@ -69,37 +27,23 @@ def normalize_score_by_volatility(
 ) -> float:
     """Scale ``raw_score`` based on market volatility.
 
-    The function compares the current ATR to a long-term average (default
-    20-period). The score is multiplied by
-    ``min(current_atr / long_term_avg_atr, 2.0)``. If ATR values are
-    unavailable, the raw score is returned unchanged.
+    The score is multiplied by ``min(current_atr / long_term_atr, 2.0)``. If
+    ATR values are unavailable the original score is returned.
     """
+
     if raw_score == 0 or df.empty:
         return raw_score
     if not {"high", "low", "close"}.issubset(df.columns):
         return raw_score
 
-    calc = calc_atr if calc_atr is not None else _fallback_atr
-    current_series = calc(df, period=current_window)
-    long_series = calc(df, period=long_term_window)
-    if current_series.empty or long_series.empty:
-        return raw_score
-
-    current_atr = float(current_series.iloc[-1])
-    long_term_atr = float(long_series.iloc[-1])
+    current_atr = calc_atr(df, current_window)
+    long_term_atr = calc_atr(df, long_term_window)
     if any(math.isnan(x) or x == 0 for x in (current_atr, long_term_atr)):
-    cur_res = calc_atr(df, current_window)
-    long_res = calc_atr(df, long_term_window)
-    current_atr = float(cur_res.iloc[-1] if isinstance(cur_res, pd.Series) else cur_res)
-    long_term_atr = float(long_res.iloc[-1] if isinstance(long_res, pd.Series) else long_res)
-    if any(math.isnan(x) or x == 0 for x in [current_atr, long_term_atr]):
-    current_atr = _atr(df, window=current_window)
-    long_term_atr = _atr(df, window=long_term_window)
-    if any(
-        math.isnan(x) or x == 0 for x in [current_atr, long_term_atr]
-    ):
         return raw_score
 
     scale = min(current_atr / long_term_atr, 2.0)
     return raw_score * scale
+
+
+__all__ = ["atr_percent", "normalize_score_by_volatility", "calc_atr"]
 

--- a/crypto_bot/volatility_filter.py
+++ b/crypto_bot/volatility_filter.py
@@ -8,9 +8,6 @@ import pandas as pd
 import requests
 
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
-from crypto_bot.utils.indicator_cache import cache_series
-from pathlib import Path
-from crypto_bot.indicators.atr import calc_atr as _calc_atr_series
 from crypto_bot.indicators.atr import calc_atr
 
 
@@ -48,15 +45,6 @@ def fetch_funding_rate(symbol: str) -> float:
     except Exception as exc:
         logger.error("Failed to fetch funding rate: %s", exc)
     return 0.0
-
-
-def calc_atr(df: pd.DataFrame, window: int = 14) -> float:
-    """Calculate the Average True Range using cached values."""
-    lookback = window
-    series = _calc_atr_series(df, period=window)
-    cached = cache_series(f"atr_{window}", df, series, lookback)
-    return float(cached.iloc[-1])
-
 
 def too_flat(df: pd.DataFrame, min_atr_pct: float) -> bool:
     """Return True if ATR is below ``min_atr_pct`` of price."""


### PR DESCRIPTION
## Summary
- simplify ATR indicator implementation
- reuse shared ATR logic in volatility filter and helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn.gaussian_process'; 'sklearn' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689f78bf6ee48330b768294bc5c75da3