### PR TITLE
Fix volatility helpers and filter

### DIFF
--- a/crypto_bot/utils/volatility.py
+++ b/crypto_bot/utils/volatility.py
@@ -1,22 +1,24 @@
+"""Compatibility wrappers for volatility helpers.
+
+This module exposes :func:`calc_atr`, :func:`atr_percent` and
+:func:`normalize_score_by_volatility` while allowing tests to monkeypatch
+``calc_atr`` directly on this module.
+"""
+
 from __future__ import annotations
 
 import math
 import pandas as pd
 
-from crypto_bot.indicators.atr import calc_atr
+from crypto_bot.volatility import atr_percent as _atr_percent, calc_atr as _base_calc_atr
+
+# ``calc_atr`` is defined at module scope so tests can monkeypatch it.
+calc_atr = _base_calc_atr
 
 
 def atr_percent(df: pd.DataFrame, window: int = 14) -> float:
-    """Return ATR as a percentage of the latest close price."""
-
-    atr = calc_atr(df, window)
-    if atr == 0:
-        return 0.0
-
-    price = float(df["close"].iloc[-1])
-    if price == 0 or math.isnan(price):
-        return 0.0
-    return atr / price * 100
+    """Proxy for :func:`crypto_bot.volatility.atr_percent`."""
+    return _atr_percent(df, window)
 
 
 def normalize_score_by_volatility(
@@ -27,8 +29,8 @@ def normalize_score_by_volatility(
 ) -> float:
     """Scale ``raw_score`` based on market volatility.
 
-    The score is multiplied by ``min(current_atr / long_term_atr, 2.0)``. If
-    ATR values are unavailable the original score is returned.
+    This mirrors :func:`crypto_bot.volatility.normalize_score_by_volatility` but
+    references ``calc_atr`` from this module so it can be patched in tests.
     """
 
     if raw_score == 0 or df.empty:
@@ -40,20 +42,9 @@ def normalize_score_by_volatility(
     long_term_atr = calc_atr(df, long_term_window)
     if any(math.isnan(x) or x == 0 for x in (current_atr, long_term_atr)):
         return raw_score
-"""Compatibility layer for volatility helpers.
 
-This module re-exports functions from :mod:`crypto_bot.volatility` so existing
-imports continue to work after the helpers were centralized.
-"""
-
-from __future__ import annotations
-
-import sys
-
-from crypto_bot import volatility as _vol
-
-# Re-export the base module so attribute patches affect the shared implementation.
-sys.modules[__name__] = _vol
+    scale = min(current_atr / long_term_atr, 2.0)
+    return raw_score * scale
 
 
 __all__ = ["atr_percent", "normalize_score_by_volatility", "calc_atr"]

--- a/crypto_bot/volatility.py
+++ b/crypto_bot/volatility.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import pandas as pd
 import ta


### PR DESCRIPTION
## Summary
- import math, pandas and ta in volatility helpers
- simplify volatility filter ATR calculation and funding rate helpers
- add compatibility wrappers for volatility utils

## Testing
- `pytest tests/test_volatility_filter.py tests/test_volatility_utils.py tests/test_volatility_normalization.py tests/test_risk_manager.py tests/test_exit_logic.py`

------
https://chatgpt.com/codex/tasks/task_e_689f7e637f088330bf4b880e380215e2