### PR TITLE
Refactor volatility utilities and add lightweight indicators

### DIFF
--- a/crypto_bot/utils/indicators.py
+++ b/crypto_bot/utils/indicators.py
@@ -1,0 +1,70 @@
+"""Lightweight technical indicators used across the codebase."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _to_series(x) -> pd.Series:
+    """Return ``x`` as a ``pandas.Series`` of ``float64``."""
+
+    if isinstance(x, pd.Series):
+        return x
+    if isinstance(x, (list, tuple, np.ndarray)):
+        return pd.Series(x, dtype="float64")
+    raise TypeError(f"Unsupported input type: {type(x)}")
+
+
+def ema(series: pd.Series, period: int) -> pd.Series:
+    """Exponential moving average with a given ``period``."""
+
+    s = _to_series(series).astype(float)
+    return s.ewm(span=period, adjust=False, min_periods=period).mean()
+
+
+def true_range(high: pd.Series, low: pd.Series, close: pd.Series) -> pd.Series:
+    """Welles Wilder's True Range."""
+
+    high_s, low_s, close_s = map(_to_series, (high, low, close))
+    prev_close = close_s.shift(1)
+    tr1 = high_s - low_s
+    tr2 = (high_s - prev_close).abs()
+    tr3 = (low_s - prev_close).abs()
+    return pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
+
+
+def atr(
+    high: pd.Series, low: pd.Series, close: pd.Series, period: int = 14
+) -> pd.Series:
+    """Average True Range using Wilder's smoothing."""
+
+    tr = true_range(high, low, close)
+    # Wilder's smoothing uses an ``alpha`` of ``1/period``
+    return tr.ewm(alpha=1 / period, adjust=False, min_periods=period).mean()
+
+
+def calc_atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Convenience wrapper around :func:`atr` for OHLC data frames."""
+
+    cols = {"high", "low", "close"}
+    if not cols.issubset(df.columns):
+        msg = f"calc_atr expects columns {cols}, got {list(df.columns)}"
+        raise ValueError(msg)
+    return atr(df["high"], df["low"], df["close"], period=period)
+
+
+def rsi(close: pd.Series, period: int = 14) -> pd.Series:
+    """Relative Strength Index."""
+
+    c = _to_series(close).astype(float)
+    delta = c.diff()
+    up = delta.clip(lower=0.0)
+    down = -delta.clip(upper=0.0)
+    gain = up.ewm(alpha=1 / period, adjust=False, min_periods=period).mean()
+    loss = down.ewm(alpha=1 / period, adjust=False, min_periods=period).mean()
+    rs = gain / loss.replace(0.0, np.nan)
+    return 100.0 - (100.0 / (1.0 + rs))
+
+
+__all__ = ["ema", "true_range", "atr", "calc_atr", "rsi"]

--- a/crypto_bot/volatility.py
+++ b/crypto_bot/volatility.py
@@ -5,7 +5,7 @@ import pandas as pd
 import ta
 
 try:  # pragma: no cover - optional dependency
-    from crypto_bot.indicators.atr import calc_atr  # type: ignore
+    from crypto_bot.utils.indicators import calc_atr  # type: ignore
 except Exception:  # pragma: no cover - best effort
     calc_atr = None
 
@@ -22,9 +22,10 @@ def _atr(df: pd.DataFrame, window: int) -> float:
     if df.empty or not {"high", "low", "close"}.issubset(df.columns):
         return 0.0
 
-    result = (
-        calc_atr(df, window) if calc_atr is not None else _fallback_atr(df, window)
-    )
+    if calc_atr is not None:
+        result = calc_atr(df, window)
+    else:
+        result = _fallback_atr(df, window)
     if isinstance(result, pd.Series):
         if result.empty:
             return 0.0

--- a/crypto_bot/volatility_filter.py
+++ b/crypto_bot/volatility_filter.py
@@ -1,72 +1,145 @@
-"""Helpers for evaluating market volatility."""
+"""Volatility helpers and funding‑rate checks.
+
+This module exposes small utilities used by various strategies when filtering
+symbols based on recent volatility.  It intentionally contains only a minimal
+set of dependencies so it can be imported without triggering heavy modules or
+network calls which previously caused import cycles during test collection.
+
+Two categories of helpers are provided:
+
+``atr_pct`` and ``too_flat`` operate on OHLCV data frames using the lightweight
+indicator functions from :mod:`crypto_bot.utils.indicators`.
+
+``fetch_funding_rate`` and ``too_hot`` query (or mock) funding rates for a
+symbol which is used by some tests to emulate external services.
+"""
+
 from __future__ import annotations
 
-import math
 import os
+from typing import Iterable
 
 import pandas as pd
 import requests
 
-from crypto_bot.indicators.atr import calc_atr as _calc_atr
-from crypto_bot.utils.logger import LOG_DIR, setup_logger
+from crypto_bot.utils.indicators import calc_atr as _calc_atr
+
+# Default API used when ``FUNDING_RATE_URL`` is not provided.  This value is
+# only a placeholder; tests patch the HTTP request so no real network call is
+# performed.
+DEFAULT_FUNDING_URL = (
+    "https://futures.kraken.com/derivatives/api/v3/"
+    + "historical-funding-rates?symbol="
+)
 
 
-logger = setup_logger(__name__, LOG_DIR / "volatility.log")
+def atr_pct(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Return the Average True Range as a percentage of ``close`` price."""
 
-DEFAULT_FUNDING_URL = "https://funding.example.com"
+    atr = _calc_atr(df, period=period)
+    return (atr / df["close"]).fillna(0.0)
+
+
+def too_flat(
+    df: pd.DataFrame,
+    atr_period: int = 14,
+    threshold: float = 0.004,
+) -> bool:
+    """Heuristic to detect markets with very low volatility.
+
+    The median ATR% of the last ``atr_period`` values is compared against
+    ``threshold``.  When insufficient data is provided the function returns
+    ``True`` as a conservative default.
+
+    For backwards compatibility the second positional argument may be a float
+    representing ``threshold`` (the old signature). In that case ``atr_period``
+    defaults to ``14``.
+    """
+
+    # Backwards compatibility for legacy ``too_flat(df, threshold)`` usage.
+    if isinstance(atr_period, float) and threshold == 0.004:
+        threshold = atr_period
+        atr_period = 14
+
+    if len(df) < max(atr_period, 20):
+        return True
+    ap = atr_pct(df, period=atr_period).iloc[-atr_period:].median()
+    return float(ap) < threshold
 
 
 def fetch_funding_rate(symbol: str) -> float:
-    """Return the current funding rate for ``symbol``."""
+    """Return the current funding rate for ``symbol``.
+
+    The function honours the ``MOCK_FUNDING_RATE`` environment variable which
+    allows tests to provide deterministic values.  When a real request is made
+    the JSON response is parsed with best‑effort handling for several common
+    shapes used by funding‑rate APIs.
+    """
+
     mock = os.getenv("MOCK_FUNDING_RATE")
     if mock is not None:
         try:
             return float(mock)
         except ValueError:
             return 0.0
-    try:
-        base_url = os.getenv("FUNDING_RATE_URL", DEFAULT_FUNDING_URL)
-        url = f"{base_url}{symbol}" if "?" in base_url else f"{base_url}?pair={symbol}"
+
+    base_url = os.getenv("FUNDING_RATE_URL", DEFAULT_FUNDING_URL)
+    url = f"{base_url}{symbol}"
+
+    try:  # pragma: no cover - network best effort
         resp = requests.get(url, timeout=5)
         resp.raise_for_status()
         data = resp.json()
-        if isinstance(data, dict):
-            if "result" in data and isinstance(data["result"], dict):
-                first = next(iter(data["result"].values()), {})
-                return float(first.get("fr", 0.0))
-            if "rates" in data and isinstance(data["rates"], list) and data["rates"]:
-                last = data["rates"][-1]
-                if isinstance(last, dict):
-                    return float(last.get("relativeFundingRate", 0.0))
-                first = data["rates"][0]
-                if isinstance(first, dict):
-                    return float(first.get("relativeFundingRate", 0.0))
-            return float(data.get("rate", 0.0))
-    except Exception as exc:
-        logger.error("Failed to fetch funding rate: %s", exc)
+    except Exception:
+        return 0.0
+
+    if isinstance(data, dict):
+        # Shape: {"rates": [{"relativeFundingRate": 0.01}, ...]}
+        rates = data.get("rates")
+        if isinstance(rates, Iterable):
+            for item in reversed(list(rates)):
+                if isinstance(item, dict) and "relativeFundingRate" in item:
+                    try:
+                        return float(item["relativeFundingRate"])
+                    except (TypeError, ValueError):
+                        break
+
+        # Shape: {"result": {"symbol": {"fr": 0.01}}}
+        result = data.get("result")
+        if isinstance(result, dict):
+            first = next(iter(result.values()), {})
+            if isinstance(first, dict) and "fr" in first:
+                try:
+                    return float(first["fr"])
+                except (TypeError, ValueError):
+                    pass
+
+        # Shape: {"rate": 0.01}
+        if "rate" in data:
+            try:
+                return float(data["rate"])
+            except (TypeError, ValueError):
+                pass
+
     return 0.0
 
 
-def calc_atr_cached(df: pd.DataFrame, window: int = 14) -> float:
-    """Calculate the Average True Range using cached values."""
-    return float(_calc_atr(df, window))
-
-
-# Backwards compatibility: external code may still import ``calc_atr``
-calc_atr = calc_atr_cached
-
-
-def too_flat(df: pd.DataFrame, min_atr_pct: float) -> bool:
-    """Return True if ATR is below ``min_atr_pct`` of price."""
-    atr = calc_atr_cached(df)
-    price = float(df["close"].iloc[-1])
-    if price == 0 or math.isnan(price):
-        return True
-    return bool(atr / price < min_atr_pct)
-
-
 def too_hot(symbol: str, max_funding_rate: float) -> bool:
-    """Return True when funding rate exceeds ``max_funding_rate``."""
-    rate = fetch_funding_rate(symbol)
-    return bool(rate > max_funding_rate)
+    """Return ``True`` when the funding rate exceeds ``max_funding_rate``."""
 
+    return float(fetch_funding_rate(symbol)) > max_funding_rate
+
+
+def calc_atr(df: pd.DataFrame, period: int = 14):
+    """Compatibility wrapper exposing :func:`calc_atr` under the old import."""
+
+    return _calc_atr(df, period=period)
+
+
+__all__ = [
+    "atr_pct",
+    "too_flat",
+    "fetch_funding_rate",
+    "too_hot",
+    "calc_atr",
+]


### PR DESCRIPTION
## Summary
- add lightweight `indicators` module with EMA, ATR, and RSI helpers
- simplify `volatility_filter` using new ATR percent and funding-rate utilities
- unify volatility normalization to use series-based ATR and support legacy calls

## Testing
- `ruff check -v crypto_bot/volatility_filter.py crypto_bot/utils/indicators.py crypto_bot/utils/volatility.py crypto_bot/volatility.py`
- `flake8 --count crypto_bot/volatility_filter.py crypto_bot/utils/indicators.py crypto_bot/utils/volatility.py crypto_bot/volatility.py`
- `pytest tests/test_volatility_filter.py tests/test_volatility_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f94dab4988330b1478c5e0f8d75c0