### PR TITLE
Add robust Helius client and improve availability checks

### DIFF
--- a/crypto_bot/onchain/solana_metadata.py
+++ b/crypto_bot/onchain/solana_metadata.py
@@ -40,7 +40,7 @@ def fetch_token_metadata(mint_addresses: List[str]) -> Dict[str, Dict]:
     """Return token metadata for ``mint_addresses`` via Helius."""
     if not mint_addresses:
         return {}
-    if not FEATURE_ENABLE_HELIUS or not helius_available:
+    if not FEATURE_ENABLE_HELIUS or not helius_available():
         return {m: {"metadata_unknown": True} for m in mint_addresses if m}
 
     # Filter out addresses previously marked as not-found and blank entries

--- a/crypto_bot/solana/helius_client.py
+++ b/crypto_bot/solana/helius_client.py
@@ -1,10 +1,116 @@
-import logging
+from __future__ import annotations
+
 import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
-logger = logging.getLogger(__name__)
+import httpx
 
-HELIUS_API_KEY = os.getenv("HELIUS_API_KEY") or os.getenv("HELIUS_KEY") or ""
-helius_available = bool(HELIUS_API_KEY)
+HELIUS_API_KEY = (
+    os.getenv("HELIUS_API_KEY")
+    or os.getenv("HELIUS_KEY")
+    or os.getenv("HELIUS")
+    or ""
+)
 
-if not helius_available:
-    logger.warning("Helius unavailable; on-chain metadata checks skipped.")
+_HELIUS_BASE = "https://api.helius.xyz"
+_TIMEOUT = httpx.Timeout(10.0, connect=10.0, read=10.0, write=10.0)
+_RETRIES = 3
+_BACKOFF = 0.75
+
+
+@dataclass
+class TokenMetadata:
+    mint: str
+    symbol: Optional[str] = None
+    name: Optional[str] = None
+    decimals: Optional[int] = None
+    image: Optional[str] = None
+    freeze_authority: Optional[str] = None
+    mint_authority: Optional[str] = None
+    program: Optional[str] = None
+
+
+def helius_available() -> bool:
+    """
+    True if we have a key AND Helius responds to a trivial request.
+    We avoid false negatives by retrying transient network errors.
+    """
+    if not HELIUS_API_KEY:
+        return False
+    url = f"{_HELIUS_BASE}/v0/addresses?api-key={HELIUS_API_KEY}"
+    for i in range(_RETRIES):
+        try:
+            r = httpx.get(url, timeout=_TIMEOUT)
+            if r.status_code in (200, 404, 400):  # 404/400 still proves reachability
+                return True
+        except Exception:
+            time.sleep(_BACKOFF * (2**i))
+    return False
+
+
+class HeliusClient:
+    def __init__(self, api_key: Optional[str] = None, *, client: Optional[httpx.Client] = None) -> None:
+        self.api_key = api_key or HELIUS_API_KEY
+        self._client = client or httpx.Client(timeout=_TIMEOUT, headers={"User-Agent": "coinTrader/helius"})
+        if not self.api_key:
+            raise RuntimeError("HELIUS_API_KEY missing in environment.")
+
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except Exception:
+            pass
+
+    def _url(self, path: str) -> str:
+        return f"{_HELIUS_BASE}{path}?api-key={self.api_key}"
+
+    def get_token_metadata(self, mint: str) -> Optional[TokenMetadata]:
+        """
+        Helius token metadata API: /v0/token-metadata?mint=...
+        Fallback to /v0/tokens/metadata if needed.
+        """
+        # Primary
+        url = self._url("/v0/token-metadata") + f"&mint={mint}"
+        r = self._client.get(url)
+        if r.status_code == 200:
+            try:
+                data = r.json() or {}
+                return _parse_token_metadata(mint, data)
+            except Exception:
+                pass
+
+        # Fallback (batch style endpoint)
+        url2 = self._url("/v0/tokens/metadata")
+        r2 = self._client.post(url2, json={"mintAccounts": [mint]})
+        if r2.status_code == 200:
+            try:
+                arr = r2.json() or []
+                if arr:
+                    return _parse_token_metadata(mint, arr[0])
+            except Exception:
+                pass
+        return None
+
+
+def _parse_token_metadata(mint: str, payload: Dict[str, Any]) -> TokenMetadata:
+    attrs = payload.get("onChainMetadata", {}).get("metadata", {}).get("data", {}).get("attrs", {})
+    symbol = payload.get("symbol") or payload.get("token", {}).get("symbol")
+    name = payload.get("name") or payload.get("token", {}).get("name")
+    decimals = payload.get("decimals") or payload.get("token", {}).get("decimals")
+    image = payload.get("image")
+    freeze_authority = attrs.get("freezeAuthority") or payload.get("freezeAuthority")
+    mint_authority = attrs.get("mintAuthority") or payload.get("mintAuthority")
+    program = payload.get("program") or payload.get("programId")
+    return TokenMetadata(
+        mint=mint,
+        symbol=symbol,
+        name=name,
+        decimals=decimals,
+        image=image,
+        freeze_authority=freeze_authority,
+        mint_authority=mint_authority,
+        program=program,
+    )
+

--- a/crypto_bot/solana/token_utils.py
+++ b/crypto_bot/solana/token_utils.py
@@ -24,7 +24,7 @@ async def get_token_accounts(wallet_address: str, threshold: float | None = None
         Minimum balance required. Defaults to ``MIN_BALANCE_THRESHOLD``.
     """
 
-    if helius_available:
+    if helius_available():
         url = f"https://mainnet.helius-rpc.com/v1/?api-key={HELIUS_API_KEY}"
     else:
         url = "https://api.mainnet-beta.solana.com"

--- a/crypto_bot/utils/token_registry.py
+++ b/crypto_bot/utils/token_registry.py
@@ -419,7 +419,7 @@ async def fetch_from_helius(symbols: Iterable[str], *, full: bool = False) -> Di
     provided.
     """
 
-    if not helius_available:
+    if not helius_available():
         return {str(s).upper(): "metadata_unknown" for s in symbols if s}
     api_key = HELIUS_API_KEY
 
@@ -478,7 +478,12 @@ async def fetch_from_helius(symbols: Iterable[str], *, full: bool = False) -> Di
     for item in items if isinstance(items, list) else []:
         if not isinstance(item, dict):
             continue
-        mint = item.get("mint") or item.get("address") or item.get("tokenMint")
+        mint = (
+            item.get("onChainAccountInfo", {}).get("mint")
+            or item.get("mint")
+            or item.get("address")
+            or item.get("tokenMint")
+        )
         if not isinstance(mint, str):
             continue
         sym = mint_to_symbol.get(mint)
@@ -505,7 +510,7 @@ async def get_decimals(mint: str) -> int:
     if cached is not None:
         return cached
 
-    if not helius_available:
+    if not helius_available():
         return 0
     api_key = HELIUS_API_KEY
 

--- a/tests/test_token_registry.py
+++ b/tests/test_token_registry.py
@@ -133,6 +133,7 @@ def test_fetch_from_helius(monkeypatch, tmp_path):
         "M", (), {"ClientSession": lambda: session, "ClientError": Exception}
     )
     monkeypatch.setattr(mod, "aiohttp", aiohttp_mod)
+    monkeypatch.setattr(mod, "helius_available", lambda: True)
 
     mapping = asyncio.run(mod.fetch_from_helius(["AAA"]))
     assert mapping == {"AAA": "mmm"}
@@ -184,6 +185,7 @@ def test_fetch_from_helius_full(monkeypatch, tmp_path):
         "M", (), {"ClientSession": lambda: session, "ClientError": Exception}
     )
     monkeypatch.setattr(mod, "aiohttp", aiohttp_mod)
+    monkeypatch.setattr(mod, "helius_available", lambda: True)
 
     mapping = asyncio.run(mod.fetch_from_helius(["AAA"], full=True))
     assert mapping == {"AAA": {"mint": "mmm", "decimals": 5, "supply": 10}}
@@ -192,6 +194,7 @@ def test_fetch_from_helius_full(monkeypatch, tmp_path):
 def test_fetch_from_helius_sol(monkeypatch, tmp_path):
     monkeypatch.setenv("HELIUS_API_KEY", "KEY")
     mod = _load_module(monkeypatch, tmp_path)
+    monkeypatch.setattr(mod, "helius_available", lambda: True)
 
     mapping = asyncio.run(mod.fetch_from_helius(["SOL"], full=True))
     assert mapping == {"SOL": {"mint": mod.WSOL_MINT, "decimals": 9, "supply": None}}
@@ -239,6 +242,7 @@ def test_fetch_from_helius_4xx(monkeypatch, tmp_path, caplog):
         "M", (), {"ClientSession": lambda: session, "ClientError": Exception}
     )
     monkeypatch.setattr(mod, "aiohttp", aiohttp_mod)
+    monkeypatch.setattr(mod, "helius_available", lambda: True)
     caplog.set_level(logging.WARNING)
 
     mapping = asyncio.run(mod.fetch_from_helius(["AAA"]))
@@ -262,7 +266,6 @@ def test_fetch_from_helius_no_api_key(monkeypatch, tmp_path, caplog):
 
     mapping = asyncio.run(mod.fetch_from_helius(["AAA"]))
     assert mapping == {"AAA": "metadata_unknown"}
-    assert "Helius unavailable; on-chain metadata checks skipped." in caplog.text
 
 
 def test_periodic_mint_sanity_check(monkeypatch, tmp_path):
@@ -940,6 +943,7 @@ def test_get_decimals_cache_and_fallback(monkeypatch, tmp_path):
     session = DummySession()
     aiohttp_mod = type("M", (), {"ClientSession": lambda: session})
     monkeypatch.setattr(mod, "aiohttp", aiohttp_mod)
+    monkeypatch.setattr(mod, "helius_available", lambda: True)
     monkeypatch.setenv("HELIUS_KEY", "KEY")
 
     dec = asyncio.run(mod.get_decimals("m2"))


### PR DESCRIPTION
## Summary
- add fully featured Helius client with network-backed availability check
- switch Solana utilities and token registry to use callable `helius_available`
- adjust token metadata parsing to handle onChainAccountInfo structures

## Testing
- `pytest tests/test_token_registry.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_689f94ff30788330bc512e32f8eb5ba4