### PR TITLE
fix: register solana sniper strategy

### DIFF
--- a/crypto_bot/strategy/loader.py
+++ b/crypto_bot/strategy/loader.py
@@ -2,7 +2,10 @@ import importlib, pkgutil, traceback, logging
 from typing import Any, Dict, Iterable, List, Optional
 
 logger = logging.getLogger(__name__)
-DEFAULT_ENABLED = {"grid", "trend", "micro_scalp", "sniper_solana"}
+# Default strategy modules enabled when ``load_strategies`` is called without
+# an explicit ``enabled`` list.  These names must match the actual module names
+# within :mod:`crypto_bot.strategy`.
+DEFAULT_ENABLED = {"grid_bot", "trend_bot", "micro_scalp_bot", "sniper_solana"}
 
 class _SimpleRegistry:
     def __init__(self):

--- a/crypto_bot/strategy/sniper_solana.py
+++ b/crypto_bot/strategy/sniper_solana.py
@@ -15,4 +15,15 @@ except Exception:  # noqa: BLE001 - fallback stub for tests
         """Fallback no-op when the full implementation is unavailable."""
         return {}
 
-__all__ = ["generate_signal", "on_trade_filled", "regime_filter"]
+
+class Strategy:
+    """Strategy wrapper so :func:`load_strategies` can auto-register it."""
+
+    def __init__(self):
+        self.name = "sniper_solana"
+        self.generate_signal = generate_signal
+        self.regime_filter = regime_filter
+        self.on_trade_filled = on_trade_filled
+
+
+__all__ = ["generate_signal", "on_trade_filled", "regime_filter", "Strategy"]


### PR DESCRIPTION
## Summary
- reference actual module names in strategy loader defaults
- expose sniper_solana module as discoverable strategy

## Testing
- `pytest tests/test_strategy_router.py` *(fails: AttributeError: module 'sniper_bot' has no attribute 'generate_signal')*
- `pytest tests/test_sniper_solana_strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_689f97052e448330bd7b223afd513fbe