### PR TITLE
Fix ConversationHandler per_message misuse

### DIFF
--- a/crypto_bot/telegram_bot_ui.py
+++ b/crypto_bot/telegram_bot_ui.py
@@ -148,10 +148,14 @@ class TelegramBotUI:
                 CallbackQueryHandler(self.edit_max_trades, pattern=f"^{EDIT_MAX_TRADES}$"),
             ],
             states={
-                EDIT_VALUE: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.set_config_value)]
+                EDIT_VALUE: [
+                    MessageHandler(
+                        filters.TEXT & ~filters.COMMAND, self.set_config_value
+                    )
+                ]
             },
             fallbacks=[],
-            per_message=True,  # eliminate PTBUserWarning
+            per_message=False,
         )
         self.app.add_handler(conv)
         self.app.add_handler(


### PR DESCRIPTION
## Summary
- keep configuration edits functional by switching ConversationHandler to per-message False

## Testing
- `pytest tests/test_telegram_bot_ui.py -vv -s`

------
https://chatgpt.com/codex/tasks/task_e_689f970924208330a5469e9f6d052a59