### PR TITLE
Ensure cleanup of exchange and websocket resources

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -3099,6 +3099,13 @@ async def _main_impl() -> TelegramNotifier:
             else:
                 with contextlib.suppress(Exception):
                     await asyncio.to_thread(exchange.close)
+        if ws_client and hasattr(ws_client, "close"):
+            if asyncio.iscoroutinefunction(getattr(ws_client, "close")):
+                with contextlib.suppress(Exception):
+                    await ws_client.close()
+            else:
+                with contextlib.suppress(Exception):
+                    await asyncio.to_thread(ws_client.close)
         if telegram_bot:
             telegram_bot.stop()
         for task in list(BACKGROUND_TASKS):


### PR DESCRIPTION
## Summary
- wrap temporary CCXT exchange in `fetch_geckoterminal_ohlcv` with a try/finally and close it
- close `ws_client` in `main` shutdown sequence
- confirmed other utilities already close exchanges or sessions on exit

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet')*


------
https://chatgpt.com/codex/tasks/task_e_689f970d7a1483309ec72b9ae43cf0de