### PR TITLE
Refactor volatility utilities for float ATR

### DIFF
--- a/crypto_bot/utils/volatility.py
+++ b/crypto_bot/utils/volatility.py
@@ -1,25 +1,32 @@
 """Utility helpers for dealing with volatility values."""
-
 from __future__ import annotations
 
 import math
 import pandas as pd
 
-from crypto_bot.utils.indicators import calc_atr
 from crypto_bot.utils.indicators import calc_atr as _calc_atr
 
-# expose for monkeypatching in tests
-calc_atr = _calc_atr
+
+def calc_atr(df: pd.DataFrame, period: int = 14) -> float:
+    """Return the latest ATR value as a float."""
+
+    result = _calc_atr(df, period=period)
+    if isinstance(result, pd.Series):
+        if result.empty:
+            return 0.0
+        return float(result.iloc[-1])
+    return float(result)
 
 
 def atr_percent(df: pd.DataFrame, period: int = 14) -> float:
     """Return ATR as percentage of the latest close price."""
+
     if df.empty or "close" not in df:
         return 0.0
     price = float(df["close"].iloc[-1])
     if price == 0 or math.isnan(price):
         return 0.0
-    atr = calc_atr(df, period=period).iloc[-1]
+    atr = calc_atr(df, period=period)
     return 0.0 if math.isnan(atr) else float(atr / price * 100.0)
 
 
@@ -30,53 +37,39 @@ def normalize_score_by_volatility(
     floor: float = 0.25,
     ceil: float = 2.0,
 ) -> float:
-    """Scale ``score`` by the recent volatility of ``df``.
-
-    ``atr_period`` determines the look‑back window for the ATR calculation. The
-    resulting ATR percentage is mapped to the range ``[floor, ceil]`` and the
-    ``score`` is multiplied by this factor. When insufficient data is supplied
-    the ``floor`` multiplier is applied.
-    """
-
-    if isinstance(score, pd.DataFrame):
-        df, score = score, float(df)
-        current_window, long_term_window = 5, 20
-        current_atr = calc_atr(df, current_window)
-        long_term_atr = calc_atr(df, long_term_window)
-        if any(math.isnan(x) or x == 0 for x in (current_atr, long_term_atr)):
-            return score
-        scale = min(current_atr / long_term_atr, 2.0)
-        return score * scale
-
-    if len(df) < atr_period + 1:
-        return floor * score
-    """Scale a score by ATR%% to adjust for volatility.
+    """Scale ``score`` by ATR%% to adjust for volatility.
 
     Accepts either ``(score, df)`` or the legacy ``(df, score)`` positional
     order. Returns ``score`` scaled to the range ``[floor, ceil]`` based on
-    ATR%%.
+    ATR%%. When insufficient data is supplied the ``floor`` multiplier is
+    applied.
     """
+
+    # Support legacy ``(df, score)`` order
     if isinstance(score, pd.DataFrame) and not isinstance(df, pd.DataFrame):
-        score, df = df, score
+        df, score = score, df
+
     if not isinstance(df, pd.DataFrame):
         raise TypeError("df must be a pandas DataFrame")
+
     score_f = float(score)
-    if len(df) < atr_period + 1:
+    if df.empty or "close" not in df:
         return floor * score_f
-    atr_pct = (calc_atr(df, period=atr_period) / df["close"]).iloc[-1]
+
+    price = float(df["close"].iloc[-1])
+    if price == 0 or math.isnan(price):
+        return floor * score_f
+
+    atr = calc_atr(df, period=atr_period)
+    if atr == 0 or math.isnan(atr):
+        return floor * score_f
+
+    atr_pct = atr / price
     low, high = 0.001, 0.03  # 0.1% .. 3% daily-ish
     x = max(min(float(atr_pct), high), low)
     k = (x - low) / (high - low)  # 0..1
     factor = floor + k * (ceil - floor)
     return score_f * factor
 
-    atr_pct = (calc_atr(df, period=atr_period) / df["close"]).iloc[-1]
-    low, high = 0.001, 0.03  # 0.1% .. 3% daily-ish
-    x = max(min(float(atr_pct), high), low)
-    k = (x - low) / (high - low)
-    factor = floor + k * (ceil - floor)
-    return score * factor
 
-
-__all__ = ["normalize_score_by_volatility", "calc_atr"]
 __all__ = ["atr_percent", "normalize_score_by_volatility", "calc_atr"]

--- a/tests/test_volatility_utils.py
+++ b/tests/test_volatility_utils.py
@@ -15,10 +15,10 @@ def _dummy_df():
 
 def test_normalize_low_high(monkeypatch):
     def fake_atr_low(df, period=14):
-        return df["close"] * 0.001
+        return float(df["close"].iloc[-1]) * 0.001
 
     def fake_atr_high(df, period=14):
-        return df["close"] * 0.03
+        return float(df["close"].iloc[-1]) * 0.03
 
     df = _dummy_df()
     monkeypatch.setattr(vol, "calc_atr", fake_atr_low)
@@ -29,8 +29,9 @@ def test_normalize_low_high(monkeypatch):
 
 def test_accepts_legacy_order(monkeypatch):
     def fake_atr(df, period=14):
-        return df["close"] * 0.01
+        return float(df["close"].iloc[-1]) * 0.01
 
     monkeypatch.setattr(vol, "calc_atr", fake_atr)
     df = _dummy_df()
-    assert vol.normalize_score_by_volatility(df, 1.0) == pytest.approx(1.0)
+    expected = vol.normalize_score_by_volatility(1.0, df)
+    assert vol.normalize_score_by_volatility(df, 1.0) == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- simplify ATR import and expose a single `calc_atr` wrapper returning a float
- clean up volatility helpers: float-based `atr_percent` and unified `normalize_score_by_volatility`
- update volatility utility tests for float `calc_atr` return values

## Testing
- `pytest tests/test_volatility_utils.py -q`
- `pytest -q` *(fails: SyntaxError in `crypto_bot/volatility_filter.py` and other import issues)*

------
https://chatgpt.com/codex/tasks/task_e_689fa6a406e083309c09e683a80eb99b