### PR TITLE
test: share dummy aiohttp helpers

### DIFF
--- a/tests/dummy_aiohttp.py
+++ b/tests/dummy_aiohttp.py
@@ -1,0 +1,49 @@
+class DummyResp:
+    def __init__(self, data=None, status=200):
+        self._data = data
+        self.status = status
+
+    async def json(self, content_type=None):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def __await__(self):
+        async def _self():
+            return self
+        return _self().__await__()
+
+
+class DummySession:
+    def __init__(self, data=None):
+        self.data = data
+        self.url = None
+        self.params = None
+        self.payload = None
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def get(self, url, params=None, timeout=10):
+        self.url = url
+        self.params = params
+        return DummyResp(self.data)
+
+    def post(self, url, json=None, timeout=10):
+        self.url = url
+        self.payload = json
+        return DummyResp(self.data)
+
+    async def close(self):
+        self.closed = True

--- a/tests/test_utils_lunarcrush_client.py
+++ b/tests/test_utils_lunarcrush_client.py
@@ -2,36 +2,16 @@ import asyncio
 import pytest
 
 from crypto_bot.utils.lunarcrush_client import LunarCrushClient
+from tests.dummy_aiohttp import DummySession
 
-class DummyResp:
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-    async def json(self):
-        return {}
-
-    def raise_for_status(self):
-        pass
-
-class DummySession:
-    def __init__(self):
-        self.last_params = None
-        self.closed = False
-    def get(self, url, params=None, timeout=10):
-        self.last_params = params
-        return DummyResp()
-
-    async def close(self):
-        self.closed = True
 
 def test_env_key_used(monkeypatch):
-    session = DummySession()
+    session = DummySession({})
     monkeypatch.setenv("LUNARCRUSH_API_KEY", "envkey")
+
     async def fake_get_session(self):
         return session
+
     monkeypatch.setattr(LunarCrushClient, "_get_session", fake_get_session)
 
     client = LunarCrushClient()
@@ -41,4 +21,4 @@ def test_env_key_used(monkeypatch):
 
     asyncio.run(_run())
 
-    assert session.last_params["key"] == "envkey"
+    assert session.params["key"] == "envkey"


### PR DESCRIPTION
## Summary
- centralize reusable DummyResp/DummySession helpers for aiohttp tests
- refactor lunarcrush and token registry monitor tests to reuse shared helpers

## Testing
- `pytest tests/test_utils_lunarcrush_client.py tests/test_token_registry_monitor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689fa6a7e4048330a8f4edb2469f6dad