### PR TITLE
feat: resolve kraken markets and close ccxt cleanly

### DIFF
--- a/crypto_bot/backtest/backtest_runner.py
+++ b/crypto_bot/backtest/backtest_runner.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Dict, Iterable, List, Optional
 
+import asyncio
 import logging
 import os
 from crypto_bot.utils.market_loader import fetch_geckoterminal_ohlcv, timeframe_seconds
@@ -130,7 +131,9 @@ class BacktestRunner:
     @lru_cache(maxsize=None)
     def _cached_fetch(symbol: str, timeframe: str, since: int, limit: int) -> pd.DataFrame:
         if symbol.endswith("/USDC"):
-            data = fetch_geckoterminal_ohlcv(symbol, timeframe=timeframe, limit=limit)
+            data = asyncio.run(
+                fetch_geckoterminal_ohlcv(symbol, timeframe=timeframe, limit=limit)
+            )
             df = pd.DataFrame(
                 data or [],
                 columns=["timestamp", "open", "high", "low", "close", "volume"],
@@ -146,10 +149,12 @@ class BacktestRunner:
 
     def _fetch_data(self) -> pd.DataFrame:
         if self.config.symbol.endswith("/USDC"):
-            data = fetch_geckoterminal_ohlcv(
-                self.config.symbol,
-                timeframe=self.config.timeframe,
-                limit=self.config.limit,
+            data = asyncio.run(
+                fetch_geckoterminal_ohlcv(
+                    self.config.symbol,
+                    timeframe=self.config.timeframe,
+                    limit=self.config.limit,
+                )
             )
             df = pd.DataFrame(
                 data or [],

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -1169,7 +1169,7 @@ async def scan_arbitrage(exchange: object, config: dict) -> list[str]:
     if fetch_geckoterminal_ohlcv:
         for sym in pairs:
             try:
-                data = fetch_geckoterminal_ohlcv(sym, limit=1)
+                data = await fetch_geckoterminal_ohlcv(sym, limit=1)
             except Exception:
                 data = None
             if data:

--- a/crypto_bot/utils/market_loader.py
+++ b/crypto_bot/utils/market_loader.py
@@ -23,10 +23,7 @@ from tenacity import (
     before_sleep_log,
 )
 
-try:  # pragma: no cover - optional dependency
-    import ccxt.pro as ccxt  # type: ignore
-except Exception:  # pragma: no cover - fall back to standard ccxt
-    import ccxt  # type: ignore
+import ccxt.async_support as ccxt  # type: ignore
 
 try:  # optional redis for caching
     import redis  # type: ignore
@@ -197,6 +194,72 @@ COINGECKO_IDS = {
     "ETH": "ethereum",
     "SOL": "solana",
 }
+
+
+# --- NEW: resolve markets only to what the exchange actually lists ---
+def resolve_listed_symbol(exchange, base: str, allowed_quotes: list[str]) -> str | None:
+    """Return the first listed symbol for *base* across ``allowed_quotes``."""
+    markets = getattr(exchange, "markets", {}) or {}
+    for q in allowed_quotes:
+        sym = f"{base}/{q}"
+        if sym in markets:
+            return sym
+    for m in markets.values():
+        try:
+            if m.get("base") == base and m.get("quote") in allowed_quotes:
+                return m.get("symbol")
+        except Exception:
+            continue
+    return None
+
+
+# --- NEW: safe closing helpers for ccxt / aiohttp ---
+async def _safe_exchange_close(exchange, where: str = ""):
+    """Attempt to close ``exchange`` without raising."""
+    close = getattr(exchange, "close", None)
+    if not close:
+        return
+    try:
+        if inspect.iscoroutinefunction(close):
+            await close()
+        else:
+            close()
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:  # pragma: no cover - best effort
+        logger.warning(f"Exchange.close() failed {where}: {e!r}")
+
+
+async def fetch_ohlcv_block(exchange_id: str, bases: list[str], timeframe: str, limit: int,
+                            allowed_quotes: list[str]):
+    """Fetch OHLCV for ``bases`` on ``exchange_id`` over ``timeframe``."""
+    ex = getattr(ccxt, exchange_id)({"enableRateLimit": True})
+    try:
+        await ex.load_markets()
+        results = {}
+        bases_dedup = list(dict.fromkeys(bases))
+        for base in bases_dedup:
+            symbol = resolve_listed_symbol(ex, base, allowed_quotes)
+            if not symbol:
+                logger.debug(
+                    f"Skipping {base}: no listed market on {exchange_id} for quotes {allowed_quotes}"
+                )
+                continue
+            try:
+                candles = await ex.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+                if candles:
+                    results[symbol] = candles
+                else:
+                    logger.debug(f"No candles returned for {symbol} @ {timeframe}")
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    f"fetch_ohlcv failed for {symbol} @ {timeframe}: {e!r}"
+                )
+        return results
+    finally:
+        await _safe_exchange_close(ex, where=f"{exchange_id}:{timeframe}")
 
 # Cache GeckoTerminal pool addresses and metadata per symbol
 # Mapping: symbol -> (pool_addr, volume, reserve, price, limit)
@@ -1675,49 +1738,44 @@ async def fetch_dex_ohlcv(
 
 
 # --- Back-compat: GeckoTerminal OHLCV wrapper using CCXT (real fetch, no stubs) ---
-def fetch_geckoterminal_ohlcv(
+async def fetch_geckoterminal_ohlcv(
     symbol: str,
     timeframe: str = "1h",
     since: Optional[int] = None,
     limit: int = 500,
     exchange: Any = None,
 ) -> List[List[float]]:
-    """
-    Compatibility wrapper for older code paths that expected a GeckoTerminal OHLCV loader.
-    This uses CCXT to fetch OHLCV from the active exchange (or the provided `exchange`).
-    Returns CCXT-standard rows: [timestamp_ms, open, high, low, close, volume].
-    """
+    """Fetch OHLCV using CCXT, resolving symbols to listed markets."""
     if exchange is not None and hasattr(exchange, "fetch_ohlcv"):
-        return exchange.fetch_ohlcv(symbol, timeframe=timeframe, since=since, limit=limit)
-
-    if ccxt is None:
-        raise RuntimeError(
-            "ccxt is required for OHLCV fetching. Install ccxt or pass an exchange instance."
+        fetch_fn = getattr(exchange, "fetch_ohlcv")
+        if asyncio.iscoroutinefunction(fetch_fn):
+            return await fetch_fn(symbol, timeframe=timeframe, since=since, limit=limit)
+        return await asyncio.to_thread(
+            fetch_fn, symbol, timeframe, since, limit
         )
 
-    # Choose exchange from ENV (fallback to kraken, which supports OHLCV for many pairs)
     ex_name = os.environ.get("EXCHANGE", "kraken").lower()
     ex_cls = getattr(ccxt, ex_name, None) or getattr(ccxt, "kraken")
     ex = ex_cls({"enableRateLimit": True})
     try:
-        return ex.fetch_ohlcv(symbol, timeframe=timeframe, since=since, limit=limit)
+        await ex.load_markets()
+        base, _, quote = symbol.partition("/")
+        allowed = [quote, "USD", "USDT", "EUR"]
+        allowed = [q for i, q in enumerate(allowed) if q and q not in allowed[:i]]
+        resolved = resolve_listed_symbol(ex, base, allowed)
+        if not resolved:
+            logger.debug(
+                f"Skipping {base}: no listed market on {ex_name} for quotes {allowed}"
+            )
+            return []
+        symbol = resolved
+        if asyncio.iscoroutinefunction(ex.fetch_ohlcv):
+            return await ex.fetch_ohlcv(symbol, timeframe=timeframe, since=since, limit=limit)
+        return await asyncio.to_thread(
+            ex.fetch_ohlcv, symbol, timeframe, since, limit
+        )
     finally:
-        close = getattr(ex, "close", None)
-        if close:
-            if inspect.iscoroutinefunction(close):
-                try:
-                    asyncio.run(close())
-                except RuntimeError:
-                    # Event loop already running; schedule close and let it cleanup later
-                    try:
-                        asyncio.get_running_loop().create_task(close())
-                    except RuntimeError:
-                        pass
-            else:
-                try:
-                    close()
-                except Exception:
-                    pass
+        await _safe_exchange_close(ex, where=f"{ex_name}:{timeframe}")
 
 
 async def update_ohlcv_cache(

--- a/tests/test_refresh_pairs.py
+++ b/tests/test_refresh_pairs.py
@@ -18,7 +18,9 @@ ml_mod.fetch_order_book_async = lambda *_a, **_k: None
 ml_mod.load_ohlcv_parallel = lambda *_a, **_k: None
 ml_mod.update_ohlcv_cache = lambda *_a, **_k: None
 ml_mod.update_multi_tf_ohlcv_cache = lambda *_a, **_k: None
-ml_mod.fetch_geckoterminal_ohlcv = lambda *_a, **_k: None
+async def _dummy_gecko(*_a, **_k):
+    return None
+ml_mod.fetch_geckoterminal_ohlcv = _dummy_gecko
 ml_mod.get_kraken_listing_date = lambda *_a, **_k: None
 sys.modules.setdefault("crypto_bot.utils.market_loader", ml_mod)
 

--- a/tests/test_refresh_pairs_cache.py
+++ b/tests/test_refresh_pairs_cache.py
@@ -14,7 +14,9 @@ ml_mod.fetch_order_book_async = lambda *_a, **_k: None
 ml_mod.load_ohlcv_parallel = lambda *_a, **_k: None
 ml_mod.update_ohlcv_cache = lambda *_a, **_k: None
 ml_mod.update_multi_tf_ohlcv_cache = lambda *_a, **_k: None
-ml_mod.fetch_geckoterminal_ohlcv = lambda *_a, **_k: None
+async def _dummy_gecko(*_a, **_k):
+    return None
+ml_mod.fetch_geckoterminal_ohlcv = _dummy_gecko
 ml_mod.get_kraken_listing_date = lambda *_a, **_k: None
 sys.modules.setdefault("crypto_bot.utils.market_loader", ml_mod)
 import tasks.refresh_pairs as rp

--- a/tests/test_scan_arbitrage.py
+++ b/tests/test_scan_arbitrage.py
@@ -14,7 +14,7 @@ def test_scan_arbitrage_profitable(monkeypatch):
     cex_prices = {"SOL/USDC": 10.0}
     dex_prices = {"SOL/USDC": 11.0}
 
-    def fake_gecko(*_a, **_k):
+    async def fake_gecko(*_a, **_k):
         price = dex_prices["SOL/USDC"]
         return [[0, price, price, price, price, 0]]
 
@@ -31,7 +31,7 @@ def test_scan_arbitrage_not_profitable(monkeypatch):
     cex_prices = {"SOL/USDC": 10.0}
     dex_prices = {"SOL/USDC": 10.04}
 
-    def fake_gecko2(*_a, **_k):
+    async def fake_gecko2(*_a, **_k):
         price = dex_prices["SOL/USDC"]
         return [[0, price, price, price, price, 0]]
 

--- a/tests/test_sniper_filters.py
+++ b/tests/test_sniper_filters.py
@@ -34,9 +34,12 @@ def test_volume_spike_filter(tmp_path, monkeypatch):
     event = make_event()
     cfg = {"safety": {}, "risk": {}, "scoring": {}}
 
+    async def fake_gecko(*a, **k):
+        return [[0, 1, 1, 1, 1, 10]], 0.0, 0.0
+
     monkeypatch.setattr(
         "crypto_bot.solana.sniper_solana.fetch_geckoterminal_ohlcv",
-        lambda *a, **k: ([[0, 1, 1, 1, 1, 10]], 0.0, 0.0),
+        fake_gecko,
     )
     monkeypatch.setattr(
         "crypto_bot.solana.sniper_solana.detect_patterns",
@@ -67,9 +70,12 @@ def test_ml_confidence_filter(tmp_path, monkeypatch):
     event = make_event()
     cfg = {"safety": {}, "risk": {}, "scoring": {}}
 
+    async def fake_gecko2(*a, **k):
+        return [[0, 1, 1, 1, 1, 10]], 0.0, 0.0
+
     monkeypatch.setattr(
         "crypto_bot.solana.sniper_solana.fetch_geckoterminal_ohlcv",
-        lambda *a, **k: ([[0, 1, 1, 1, 1, 10]], 0.0, 0.0),
+        fake_gecko2,
     )
     monkeypatch.setattr(
         "crypto_bot.solana.sniper_solana.detect_patterns",


### PR DESCRIPTION
## Summary
- add helpers to resolve exchange-listed symbols and safely close ccxt exchanges
- convert gecko OHLCV fetcher to async and select available Kraken quotes
- await Gecko OHLCV in scan_arbitrage and backtest runner

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager')*
- `pytest tests/test_market_loader.py::test_fetch_geckoterminal_ohlcv_uses_exchange -q`

------
https://chatgpt.com/codex/tasks/task_e_689fbe9893d883308308cf0366d9f741