### PR TITLE
Add Solana sniping clients and strategy

### DIFF
--- a/crypto_bot/solana/jupiter_client.py
+++ b/crypto_bot/solana/jupiter_client.py
@@ -1,0 +1,63 @@
+import os
+import aiohttp
+import asyncio
+from typing import Any, Dict, Optional
+from loguru import logger
+
+JUPITER_BASE = os.getenv("JUPITER_BASE_URL", "https://api.jup.ag")
+
+
+class JupiterClient:
+    def __init__(self, session: Optional[aiohttp.ClientSession] = None):
+        self._ext_session = session
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def __aenter__(self):
+        if self._ext_session:
+            self._session = self._ext_session
+        else:
+            self._session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15))
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if not self._ext_session and self._session:
+            await self._session.close()
+
+    @property
+    def session(self) -> aiohttp.ClientSession:
+        assert self._session is not None, "JupiterClient used outside of async context manager"
+        return self._session
+
+    async def quote(self, input_mint: str, output_mint: str, amount: int, slippage_bps: int = 150) -> Optional[Dict[str, Any]]:
+        params = {
+            "inputMint": input_mint,
+            "outputMint": output_mint,
+            "amount": str(amount),
+            "slippageBps": str(slippage_bps),
+            "onlyDirectRoutes": "false",
+        }
+        try:
+            async with self.session.get(f"{JUPITER_BASE}/v6/quote", params=params) as r:
+                if r.status != 200:
+                    logger.debug(f"Jupiter quote HTTP {r.status}")
+                    return None
+                data = await r.json()
+                routes = data.get("data") or []
+                return routes[0] if routes else None
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"Jupiter.quote failed: {e!r}")
+            return None
+
+    async def swap_instructions(self, route: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        try:
+            async with self.session.post(f"{JUPITER_BASE}/v6/swap-instructions", json={"route": route}) as r:
+                if r.status != 200:
+                    return None
+                return await r.json()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"Jupiter.swap_instructions failed: {e!r}")
+            return None

--- a/crypto_bot/solana/raydium_client.py
+++ b/crypto_bot/solana/raydium_client.py
@@ -1,72 +1,49 @@
-from __future__ import annotations
-
-import time
+import aiohttp
+import asyncio
 from typing import Any, Dict, Optional
+from loguru import logger
 
-import httpx
-
-# Public Raydium API endpoints shift occasionally. We try multiple.
-_RAYDIUM_ENDPOINTS = [
-    "https://api.raydium.io/v2/main/pairs",
-    "https://api.raydium.io/pairs",
-    "https://api-v3.raydium.io/pools",
-]
-_TIMEOUT = httpx.Timeout(10.0, connect=10.0, read=10.0, write=10.0)
+RAYDIUM_BASE = "https://api.raydium.io"
 
 
 class RaydiumClient:
-    def __init__(self, client: Optional[httpx.Client] = None) -> None:
-        self._c = client or httpx.Client(timeout=_TIMEOUT, headers={"User-Agent": "coinTrader/raydium"})
+    def __init__(self, session: Optional[aiohttp.ClientSession] = None):
+        self._ext_session = session
+        self._session: Optional[aiohttp.ClientSession] = None
 
-    def close(self) -> None:
+    async def __aenter__(self):
+        if self._ext_session:
+            self._session = self._ext_session
+        else:
+            self._session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15))
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if not self._ext_session and self._session:
+            await self._session.close()
+
+    @property
+    def session(self) -> aiohttp.ClientSession:
+        assert self._session is not None, "RaydiumClient used outside of async context manager"
+        return self._session
+
+    async def pools_by_mint(self, mint: str) -> list[Dict[str, Any]]:
         try:
-            self._c.close()
-        except Exception:
-            pass
+            async with self.session.get(f"{RAYDIUM_BASE}/v2/main/pairs", params={"mint1": mint}) as r:
+                if r.status != 200:
+                    return []
+                data = await r.json()
+                return data if isinstance(data, list) else []
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"Raydium.pools_by_mint failed: {e!r}")
+            return []
 
-    def _fetch_json(self, url: str) -> Optional[Dict[str, Any]]:
-        try:
-            r = self._c.get(url)
-            if r.status_code == 200:
-                return r.json()
-        except Exception:
-            return None
-        return None
-
-    def get_pairs(self) -> list[dict]:
-        for base in _RAYDIUM_ENDPOINTS:
-            data = self._fetch_json(base)
-            if not data:
-                continue
-            # The shapes differ; normalize to a list of dicts with keys we need.
-            if isinstance(data, dict) and "data" in data:
-                arr = data["data"]
-            elif isinstance(data, list):
-                arr = data
-            else:
-                arr = []
-            out = []
-            for p in arr:
-                out.append(
-                    {
-                        "address": p.get("ammId") or p.get("id") or p.get("address"),
-                        "baseMint": p.get("baseMint") or p.get("base_mint"),
-                        "quoteMint": p.get("quoteMint") or p.get("quote_mint"),
-                        "liquidityUsd": float(p.get("liquidityUsd") or p.get("liquidity_usd") or 0.0),
-                        "volume24hUsd": float(p.get("volume24hUsd") or p.get("volume_24h_usd") or 0.0),
-                        "price": float(p.get("price") or p.get("midPrice") or 0.0),
-                    }
-                )
-            if out:
-                return out
-            time.sleep(0.5)
-        return []
-
-    def best_pool_for_mint(self, base_mint: str, *, min_liquidity_usd: float = 5000.0) -> Optional[dict]:
-        pools = self.get_pairs()
-        candidates = [p for p in pools if (p.get("baseMint") == base_mint or p.get("quoteMint") == base_mint)]
-        candidates = [p for p in candidates if p.get("liquidityUsd", 0.0) >= min_liquidity_usd]
+    async def best_pool_for_mint(self, mint: str, *, min_liquidity_usd: float = 5000.0) -> Optional[Dict[str, Any]]:
+        pools = await self.pools_by_mint(mint)
+        candidates = [p for p in pools if float(p.get("liquidityUsd", 0) or 0) >= min_liquidity_usd]
         if not candidates:
             return None
-        candidates.sort(key=lambda p: (p.get("volume24hUsd", 0.0), p.get("liquidityUsd", 0.0)), reverse=True)
+        candidates.sort(key=lambda p: float(p.get("volume24hUsd", 0) or 0), reverse=True)
         return candidates[0]


### PR DESCRIPTION
## Summary
- Implement async Helius client with batch metadata fetch and availability check
- Add Jupiter and Raydium clients for routing and pool data
- Refactor Solana sniper strategy to run an on-chain task outside OHLCV loop

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis'; IndentationError in tests/test_token_registry.py)*

------
https://chatgpt.com/codex/tasks/task_e_689fbed8d83c8330879df73c3d130ad1