### PR TITLE
refactor: use shared ATR helper

### DIFF
--- a/crypto_bot/utils/volatility.py
+++ b/crypto_bot/utils/volatility.py
@@ -4,18 +4,7 @@ from __future__ import annotations
 import math
 import pandas as pd
 
-from crypto_bot.utils.indicators import calc_atr as _calc_atr
-
-
-def calc_atr(df: pd.DataFrame, period: int = 14) -> float:
-    """Return the latest ATR value as a float."""
-
-    result = _calc_atr(df, period=period)
-    if isinstance(result, pd.Series):
-        if result.empty:
-            return 0.0
-        return float(result.iloc[-1])
-    return float(result)
+from crypto_bot.indicators import calc_atr
 
 
 def atr_percent(df: pd.DataFrame, period: int = 14) -> float:


### PR DESCRIPTION
## Summary
- use calc_atr from crypto_bot.indicators directly
- drop redundant wrapper

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*

------
https://chatgpt.com/codex/tasks/task_e_689fcde5d96483308a9751920e271f9a