### PR TITLE
Annotate calc_atr wrapper return type

### DIFF
--- a/crypto_bot/volatility_filter.py
+++ b/crypto_bot/volatility_filter.py
@@ -131,8 +131,12 @@ def too_hot(symbol: str, max_funding_rate: float) -> bool:
 
 
 # Keep legacy import path working for existing callers
-def calc_atr(df: pd.DataFrame, period: int = 14):
-    """Compatibility wrapper exposing :func:`calc_atr` under the old import."""
+def calc_atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Compatibility wrapper returning an ATR series for backward compatibility.
+
+    Exposes :func:`calc_atr` under the historical import while mirroring the
+    original return type.
+    """
 
     return _calc_atr(df, period=period)
 


### PR DESCRIPTION
## Summary
- specify that `calc_atr` returns a pandas Series
- clarify `calc_atr` docstring to mention ATR series for compatibility

## Testing
- `pytest tests/test_volatility_filter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ff3345c7883308a5c3599fd352093