### PR TITLE
Deduplicate symbol queue before batching

### DIFF
--- a/tests/test_fetch_candidates_logging.py
+++ b/tests/test_fetch_candidates_logging.py
@@ -42,3 +42,38 @@ def test_fetch_candidates_logs_batch(monkeypatch, caplog):
 
     assert ctx.current_batch == ["BTC/USDT"]
     assert "Current batch" in caplog.text
+
+
+def test_fetch_candidates_dedupes_and_filters(monkeypatch):
+    df = pd.DataFrame({"high": [1, 2], "low": [0, 1], "close": [1, 2]})
+    ctx = BotContext(
+        positions={},
+        df_cache={"1h": {"BTC/USDT": df}},
+        regime_cache={},
+        config={"timeframe": "1h", "symbols": ["BTC/USDT"], "symbol_batch_size": 5},
+    )
+
+    class DummyExchange:
+        def list_markets(self):
+            return ["BTC/USDT", "ETH/USDT"]
+
+    ctx.exchange = DummyExchange()
+
+    async def fake_get_filtered_symbols(ex, cfg):
+        return [
+            ("ETH/USDT", 2.0),
+            ("BTC/USDT", 1.0),
+            ("DOGE/USDT", 0.5),
+            ("ETH/USDT", 0.1),
+        ], []
+
+    monkeypatch.setattr(main, "symbol_priority_queue", deque())
+    monkeypatch.setattr(main, "get_filtered_symbols", fake_get_filtered_symbols)
+    monkeypatch.setattr(main, "calc_atr", lambda df, window=14: 0.02)
+    monkeypatch.setattr(main, "get_market_regime", lambda *_a, **_k: "unknown")
+    monkeypatch.setattr(main, "compute_average_atr", lambda *_a, **_k: 0.01)
+
+    asyncio.run(main.fetch_candidates(ctx))
+
+    assert ctx.current_batch == ["BTC/USDT", "ETH/USDT"]
+    assert len(ctx.current_batch) == len(set(ctx.current_batch))


### PR DESCRIPTION
## Summary
- Remove duplicates from `symbol_priority_queue` while maintaining order
- Filter priority queue against exchange-listed markets before building evaluation batches
- Test that candidate batches are unique and contain only listed symbols

## Testing
- `pytest tests/test_fetch_candidates_logging.py::test_fetch_candidates_logs_batch tests/test_fetch_candidates_logging.py::test_fetch_candidates_dedupes_and_filters -q`


------
https://chatgpt.com/codex/tasks/task_e_68a07a19a408833087532714a5be8e7a