### PR TITLE
feat: whitelist quote currencies

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -557,6 +557,11 @@ def _load_config_file() -> dict:
     trading_cfg.setdefault("hft_symbols", [])
     trading_cfg.setdefault("exclude_symbols", [])
     data["trading"] = trading_cfg
+    data.setdefault("allowed_quotes", allowed_quotes)
+    sf_cfg = data.get("symbol_filter", {}) or {}
+    if allowed_quotes:
+        sf_cfg.setdefault("quote_whitelist", allowed_quotes)
+    data["symbol_filter"] = sf_cfg
     data.setdefault("exchange", exchange_id)
     data.setdefault("timeframes", timeframes)
     data.setdefault("execution_mode", trading_mode)

--- a/crypto_bot/utils/symbol_utils.py
+++ b/crypto_bot/utils/symbol_utils.py
@@ -145,9 +145,10 @@ async def get_filtered_symbols(exchange, config) -> tuple[list[tuple[str, float]
 
     mode = config.get("mode", "cex")
     sf = config.get("symbol_filter", {})
-    allowed_quotes = {
-        str(q).upper() for q in (config.get("allowed_quotes") or [])
-    }
+    allowed_quotes_cfg = config.get("allowed_quotes") or config.get("trading", {}).get(
+        "allowed_quotes"
+    )
+    allowed_quotes = {str(q).upper() for q in (allowed_quotes_cfg or [])}
     markets: dict[str, dict] = {}
     if mode == "cex" and hasattr(exchange, "list_markets"):
         markets = exchange.list_markets()


### PR DESCRIPTION
## Summary
- allow fallback to `trading.allowed_quotes` for quote whitelisting
- propagate `allowed_quotes` into root config and symbol filter
- test filtering by allowed quote currency

## Testing
- `pytest tests/test_symbol_pre_filter.py::test_quote_whitelist tests/test_config.py::test_load_config_returns_dict -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09cfb07348330a14cb36621a4d866