### PR TITLE
Use Loguru-style formatting in evaluation engine

### DIFF
--- a/crypto_bot/engine/evaluation_engine.py
+++ b/crypto_bot/engine/evaluation_engine.py
@@ -43,7 +43,7 @@ class EvalGate:
                     held = time.monotonic() - self._since
                     if held > self._ttl:
                         self._logger.warning(
-                            "Gate held >%ss by %s; forcing release",
+                            "Gate held >{}s by {}; forcing release",
                             self._ttl,
                             self._owner,
                         )
@@ -116,7 +116,7 @@ class StreamEvaluationEngine:
         for idx in range(workers):
             task = asyncio.create_task(self._worker(), name=f"eval-worker-{idx}")
             self._workers.append(task)
-        logger.info("Evaluation workers online: %d", len(self._workers))
+        logger.info("Evaluation workers online: {}", len(self._workers))
 
     def _symbol_requires_5m(self, ctx: dict) -> bool:
         if isinstance(ctx, dict):
@@ -133,14 +133,14 @@ class StreamEvaluationEngine:
                 else "SELL" if direction == "short" else "NONE"
             )
             logger.info(
-                "STRAT %s on %s: signal=%s score=%s reason=%s",
+                "STRAT {} on {}: signal={} score={} reason={}",
                 res.get("name"),
                 symbol,
                 signal,
                 res.get("score"),
                 res.get("reason", ""),
             )
-        logger.debug("[EVAL OK] %s", symbol)
+        logger.debug("[EVAL OK] {}", symbol)
 
     async def _worker(self) -> None:
         if self.gate is None or self.data is None:
@@ -155,17 +155,17 @@ class StreamEvaluationEngine:
             try:
                 needs_5m = self._symbol_requires_5m(ctx)
                 if not self.data.ready(symbol, "1m"):
-                    logger.debug("EVAL SKIP %s: 1m warmup not met", symbol)
+                    logger.debug("EVAL SKIP {}: 1m warmup not met", symbol)
                     continue
                 if needs_5m and not self.data.ready(symbol, "5m"):
-                    logger.debug("EVAL SKIP %s: 5m warmup not met", symbol)
+                    logger.debug("EVAL SKIP {}: 5m warmup not met", symbol)
                     continue
 
                 async with self.gate.hold(f"{symbol}"):
-                    logger.info("EVAL START %s", symbol)
+                    logger.info("EVAL START {}", symbol)
                     await self._evaluate_symbol(symbol, ctx)
             except Exception:
-                logger.exception("Evaluator crashed on %s", symbol)
+                logger.exception("Evaluator crashed on {}", symbol)
             finally:
                 self.queue.task_done()
         await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- switch evaluation engine logging to Loguru's `{}` formatting

## Testing
- `pytest tests/test_evaluator.py -q`
- `pytest tests/test_evaluator.py tests/test_logger.py -q` *(fails: module 'crypto_bot.utils' has no attribute 'telegram')*


------
https://chatgpt.com/codex/tasks/task_e_68a0a0af93b883308dfa844985ffcd1e