### PR TITLE
Set cex trading mode and disable Solana scanner

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -1,6 +1,6 @@
 # === trading/base ===
 trading:
-  mode: dry_run           # cex | onchain | auto | dry_run
+  mode: cex           # cex | onchain | auto | dry_run
   exchange: kraken
   allowed_quotes: [USD, USDT, USDC, EUR]
   min_ticker_volume: 10000
@@ -319,22 +319,7 @@ ohlcv_timeout: 5
 redis_url: null
 onchain_default_quote: USDC
 onchain_min_volume_usd: 5000
-onchain_symbols:
-- SOL/USDC
-- BONK/USDC
-- AI16Z/USDC
-- BERA/USDC
-- EUROP/USDC
-- FARTCOIN/USDC
-- RLUSD/USDC
-- USDG/USDC
-- VIRTUAL/USDC
-- XMR/USDC
-- MELANIA/USDC
-- PENGU/USDC
-- USDR/USDC
-- USTC/USDC
-- TRUMP/USDC
+onchain_symbols: []
 optimization:
   enabled: true
   interval_days: 0.1
@@ -485,7 +470,7 @@ solana_scanner:
     bitquery: YOUR_KEY
     moralis: YOUR_KEY
     lunarcrush_api_key: YOUR_KEY
-  enabled: true
+  enabled: false
   gecko_search: true
   interval_minutes: 0.1
   max_tokens_per_scan: 50


### PR DESCRIPTION
## Summary
- default to centralized exchange trading mode
- clear onchain_symbols and disable Solana scanner

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `MODE=cex python -m crypto_bot.wallet_manager` *(fails: KeyboardInterrupt during setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a1ebf64483309a7e00d4a7510c93