### PR TITLE
Add on-chain OHLCV support and enable Solana scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ The `crypto_bot/config.yaml` file holds the runtime settings for the bot. Below 
   `onchain_default_quote` (defaults to `USDC`). If a ticker isn't found in the
   registry, the base value must be a valid mint address. If your configuration
   still contains `solana_symbols`, rename that section to `onchain_symbols`.
+  On-chain OHLCV candles are sourced from Jupiter's public price API with a
+  fallback to the latest spot quote when historical data is unavailable.
 * **onchain_default_quote** – quote currency used when appending to entries in
   `onchain_symbols`. Defaults to `USDC`.
 * **allow_short** – enable short selling. Set to `true` only when your exchange account supports short selling.
@@ -450,6 +452,8 @@ symbol_score_weights:
 * **use_numba_scoring** – enable numba acceleration for symbol scoring when available.
 * **arbitrage_enabled** – compare CEX and Solana DEX prices each cycle. See
   `scan_cex_arbitrage` in `crypto_bot/main.py` for multi-exchange support.
+* **solana_scanner.enabled** – continuously discover new Solana pools (enabled by
+  default in `config.example.yaml`).
 * **solana_scanner.gecko_search** – query GeckoTerminal to verify volume for new Solana tokens.
 * **gecko_limit** – maximum simultaneous requests to GeckoTerminal. Reduce this if you encounter HTTP 429 errors.
 * **max_concurrent_tickers** – maximum simultaneous ticker requests.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,6 +13,13 @@ trading:
   hft_symbols: ["BTC/USD","ETH/USD","SOL/USDC","BONK/USDC"]   # seed list, can expand
   exclude_symbols: ["AIBTC/USD"]   # remove noisy/synthetic pairs
 
+# Default on-chain universe and scanner options
+onchain_symbols: ["SOL/USDC"]
+solana_scanner:
+  enabled: true
+  interval_minutes: 0.1
+  max_tokens_per_scan: 50
+
 # === strategies and params ===
 strategies:
   maker_spread:

--- a/crypto_bot/solana/prices.py
+++ b/crypto_bot/solana/prices.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-"""Helper for fetching Solana token prices."""
+"""Helper utilities for Solana token pricing and OHLCV."""
 
 import aiohttp
 import logging
-from typing import List, Dict
+import time
+from typing import List, Dict, List as _List
 
 logger = logging.getLogger(__name__)
 
@@ -31,3 +32,53 @@ async def fetch_solana_prices(symbols: List[str]) -> Dict[str, float]:
                 price = 0.0
             results[sym] = price
     return results
+
+
+async def fetch_onchain_ohlcv(
+    symbol: str,
+    timeframe: str = "1h",
+    limit: int = 100,
+) -> _List[_List[float]]:
+    """Return OHLCV candles for an on-chain ``symbol``.
+
+    Attempts to pull historical candles from the Jupiter price API. When the
+    request fails or returns no data the function falls back to
+    :func:`fetch_solana_prices` and synthesizes a single candle using the latest
+    price. The returned structure matches the CCXT OHLCV format ``[timestamp,
+    open, high, low, close, volume]`` with timestamps expressed in
+    milliseconds.
+    """
+
+    base, _, _ = symbol.partition("/")
+    url = "https://price.jup.ag/v4/candles"
+    params = {"ids[]": base, "interval": timeframe, "limit": limit}
+    try:  # pragma: no cover - network usage
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, params=params, timeout=10) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+        candles = data.get("data", {}).get(base, [])
+        if candles:
+            return [
+                [
+                    int(c.get("t", 0)) * 1000,
+                    float(c.get("o", 0.0)),
+                    float(c.get("h", 0.0)),
+                    float(c.get("l", 0.0)),
+                    float(c.get("c", 0.0)),
+                    float(c.get("v", 0.0)),
+                ]
+                for c in candles
+            ]
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.error("Failed to fetch on-chain OHLCV for %s: %s", symbol, exc)
+
+    # Fallback – synthesize a single candle from the latest price
+    try:
+        price = (await fetch_solana_prices([symbol])).get(symbol, 0.0)
+        if price:
+            ts = int(time.time() * 1000)
+            return [[ts, price, price, price, price, 0.0]]
+    except Exception:
+        pass
+    return []

--- a/crypto_bot/utils/market_loader.py
+++ b/crypto_bot/utils/market_loader.py
@@ -37,6 +37,7 @@ from .token_registry import (
     get_mint_from_gecko,
     fetch_from_helius,
 )
+from crypto_bot.solana.prices import fetch_onchain_ohlcv
 from crypto_bot.strategy.evaluator import get_stream_evaluator, StreamEvaluator
 from crypto_bot.strategy.registry import load_enabled
 from .logger import LOG_DIR, setup_logger
@@ -2313,17 +2314,22 @@ async def update_multi_tf_ohlcv_cache(
                     add_priority(data, sym)
 
                 if gecko_failed or not data or vol < min_volume_usd:
-                    data = await fetch_dex_ohlcv(
-                        exchange,
-                        sym,
-                        timeframe=tf,
-                        limit=sym_l,
-                        min_volume_usd=min_volume_usd,
-                        gecko_res=None,
-                        use_gecko=is_solana,
+                    data = await fetch_onchain_ohlcv(
+                        sym, timeframe=tf, limit=sym_l
                     )
-                    if isinstance(data, Exception) or not data:
-                        continue
+                    if not data:
+                        data = await fetch_dex_ohlcv(
+                            exchange,
+                            sym,
+                            timeframe=tf,
+                            limit=sym_l,
+                            min_volume_usd=min_volume_usd,
+                            gecko_res=None,
+                            use_gecko=is_solana,
+                        )
+                        if isinstance(data, Exception) or not data:
+                            continue
+                    add_priority(data, sym)
 
                 if not data:
                     continue

--- a/schema/scanner.py
+++ b/schema/scanner.py
@@ -66,7 +66,7 @@ class SolanaScannerConfig(BaseModel):
     """Configuration for scanning Solana tokens."""
 
     enabled: bool = Field(
-        default=False, description="Enable Solana token scanner"
+        default=True, description="Enable Solana token scanner"
     )
     interval_minutes: float = Field(
         default=0.1,

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -28,7 +28,7 @@ def test_positive_values_enforced():
 
 def test_solana_scanner_defaults():
     cfg = SolanaScannerConfig()
-    assert cfg.enabled is False
+    assert cfg.enabled is True
     assert cfg.interval_minutes == 0.1
     assert cfg.max_tokens_per_scan == 200
     assert cfg.min_volume_usd == 10.0


### PR DESCRIPTION
## Summary
- add helper to fetch Solana OHLCV via Jupiter with price fallback
- wire on-chain OHLCV loader into market loader and document usage
- enable `solana_scanner` by default and expose on-chain config in sample

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet')*
- `pytest tests/test_market_loader.py::test_fetch_onchain_ohlcv_fallback tests/test_market_loader.py::test_coinbase_usdc_pair_skip tests/test_config_schema.py::test_solana_scanner_defaults -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0a1eecbac83309dcf15c790c3af5e