### PR TITLE
Refactor meta selector strategy names to module names

### DIFF
--- a/crypto_bot/meta_selector.py
+++ b/crypto_bot/meta_selector.py
@@ -83,21 +83,21 @@ def _register(module, *names: str) -> None:
         _STRATEGY_FN_MAP[name] = fn
 
 
-_register(trend_bot, "trend", "trend_bot")
-_register(grid_bot, "grid", "grid_bot")
-_register(sniper_bot, "sniper", "sniper_bot")
-_register(dex_scalper, "dex_scalper", "dex_scalper_bot")
+_register(trend_bot, "trend_bot")
+_register(grid_bot, "grid_bot")
+_register(sniper_bot, "sniper_bot")
+_register(dex_scalper, "dex_scalper")
 _register(mean_bot, "mean_bot")
 _register(breakout_bot, "breakout_bot")
-_register(micro_scalp_bot, "micro_scalp", "micro_scalp_bot")
-_register(momentum_bot, "momentum", "momentum_bot")
+_register(micro_scalp_bot, "micro_scalp_bot")
+_register(momentum_bot, "momentum_bot")
 _register(lstm_bot, "lstm_bot")
-_register(bounce_scalper, "bounce_scalper", "bounce_scalper_bot")
+_register(bounce_scalper, "bounce_scalper")
 _register(flash_crash_bot, "flash_crash_bot")
 _register(dip_hunter, "dip_hunter")
-_register(solana_scalping, "solana_scalping", "solana_scalping_bot")
+_register(solana_scalping, "solana_scalping")
 _register(meme_wave_bot, "meme_wave_bot")
-_register(dca_bot, "dca", "dca_bot")
+_register(dca_bot, "dca_bot")
 _register(cross_chain_arb_bot, "cross_chain_arb_bot")
 
 

--- a/tests/test_bandit.py
+++ b/tests/test_bandit.py
@@ -28,7 +28,7 @@ def test_route_uses_bandit(monkeypatch):
 
     def fake_select(ctx, arms, symbol):
         calls["arms"] = list(arms)
-        return "grid"
+        return "grid_bot"
 
     from crypto_bot import selector
 
@@ -37,12 +37,12 @@ def test_route_uses_bandit(monkeypatch):
 
     cfg = {
         "timeframe": "1h",
-        "strategy_router": {"regimes": {"trending": ["trend", "grid"]}},
+        "strategy_router": {"regimes": {"trending": ["trend_bot", "grid_bot"]}},
         "bandit": {"enabled": True},
     }
     fn = route("trending", "cex", cfg)
 
-    assert calls.get("arms") == ["trend", "grid"]
+    assert calls.get("arms") == ["trend_bot", "grid_bot"]
     assert fn.__name__ == grid_bot.generate_signal.__name__
 
 

--- a/tests/test_meta_selector.py
+++ b/tests/test_meta_selector.py
@@ -37,11 +37,16 @@ def test_choose_best_fallback(tmp_path, monkeypatch):
     assert fn.__name__ == strategy_for("sideways").__name__
 
 
-def test_strategy_map_contains_micro_scalp():
+def test_strategy_map_contains_micro_scalp_bot():
     assert (
-        meta_selector._STRATEGY_FN_MAP.get("micro_scalp")
+        meta_selector._STRATEGY_FN_MAP.get("micro_scalp_bot")
         is micro_scalp_bot.generate_signal
     )
+
+
+def test_strategy_map_has_no_aliases():
+    assert "grid" not in meta_selector._STRATEGY_FN_MAP
+    assert "trend" not in meta_selector._STRATEGY_FN_MAP
 
 
 def test_strategy_map_contains_dca_bot():

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -15,10 +15,10 @@ def _make_module(name: str) -> types.ModuleType:
 
 def test_load_strategies_fallback(monkeypatch):
     # ensure fallback imports from crypto_bot.strategy works
-    for name in ["grid", "trend", "micro_scalp"]:
+    for name in ["grid_bot", "trend_bot", "micro_scalp_bot"]:
         mod = _make_module(name)
         monkeypatch.setitem(sys.modules, f"crypto_bot.strategy.{name}", mod)
 
-    strategies = load_strategies("cex", ["grid", "trend", "micro_scalp"])
+    strategies = load_strategies("cex", ["grid_bot", "trend_bot", "micro_scalp_bot"])
     assert len(strategies) == 3
     assert all(hasattr(s, "name") for s in strategies)

--- a/tests/test_strategy_router.py
+++ b/tests/test_strategy_router.py
@@ -57,12 +57,12 @@ from crypto_bot.strategy import (
 SAMPLE_CFG = {
     "strategy_router": {
         "regimes": {
-            "trending": ["trend", "momentum_bot"],
-            "sideways": ["grid"],
+            "trending": ["trend_bot", "momentum_bot"],
+            "sideways": ["grid_bot"],
             "mean-reverting": ["dip_hunter", "stat_arb_bot"],
             "breakout": ["breakout_bot"],
             "volatile": ["sniper_bot", "momentum_bot"],
-            "scalp": ["micro_scalp"],
+            "scalp": ["micro_scalp_bot"],
             "bounce": ["bounce_scalper"],
         }
     }
@@ -142,7 +142,7 @@ def test_route_returns_lstm_bot():
 
 
 def test_route_handles_none_df_map():
-    cfg = {"strategy_router": {"regimes": {"trending": ["trend"]}}}
+    cfg = {"strategy_router": {"regimes": {"trending": ["trend_bot"]}}}
     fn = route("trending", "cex", cfg, df_map=None)
     assert fn.__name__ == trend_bot.generate_signal.__name__
     score, direction = fn(None)
@@ -280,7 +280,7 @@ def test_fastpath_breakout(tmp_path, monkeypatch):
         "breakout_bandwidth_zscore": -0.84,
         "breakout_volume_multiplier": 2,
         "trend_adx_threshold": 1000
-    }}, "regime": {"sideways": ["grid"]}}
+    }}, "regime": {"sideways": ["grid_bot"]}}
 
     close = list(range(10))
     volume = [1] * 9 + [10]
@@ -295,7 +295,7 @@ def test_fastpath_trend(tmp_path):
         "breakout_max_bandwidth": 0,
         "breakout_volume_multiplier": 100,
         "trend_adx_threshold": 5
-    }}, "regime": {"trending": ["trend"]}}
+    }}, "regime": {"trending": ["trend_bot"]}}
     # create rising series so ADX > threshold
     vals = list(range(10))
     df = make_df(vals, [1]*10)
@@ -434,7 +434,7 @@ def test_route_mempool_blocks_signal(monkeypatch):
             return True
 
     cfg = {
-        "strategy_router": {"regimes": {"scalp": ["micro_scalp"]}},
+        "strategy_router": {"regimes": {"scalp": ["micro_scalp_bot"]}},
         "micro_scalp": {"fresh_cross_only": False, "min_vol_z": 0},
         "mempool_monitor": {"enabled": True, "suspicious_fee_threshold": 1},
     }


### PR DESCRIPTION
## Summary
- use module names only in meta_selector strategy map
- update tests and configurations to reference `*_bot` strategy modules

## Testing
- `pytest tests/test_meta_selector.py -q`
- `pytest tests/test_strategy_router.py -q`
- `pytest tests/test_bandit.py -q`
- `pytest tests/test_strategy_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a24e965c83309bcf6613e639dc7f