### PR TITLE
Rename strategy identifiers to include _bot suffix

### DIFF
--- a/crypto_bot/bot_controller.py
+++ b/crypto_bot/bot_controller.py
@@ -82,12 +82,12 @@ class TradingBotController:
         if trend_file.exists():
             with open(trend_file) as sf:
                 overrides = yaml.safe_load(sf) or {}
-            trend_cfg = data.get("trend", {})
+            trend_cfg = data.get("trend_bot", {})
             if isinstance(trend_cfg, dict):
                 trend_cfg.update(overrides)
             else:
                 trend_cfg = overrides
-            data["trend"] = trend_cfg
+            data["trend_bot"] = trend_cfg
 
         if "symbol" in data:
             data["symbol"] = fix_symbol(data["symbol"])

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -605,12 +605,12 @@ def _load_config_file() -> dict:
     if trend_file.exists():
         with open(trend_file) as sf:
             overrides = yaml.safe_load(sf) or {}
-        trend_cfg = data.get("trend", {})
+        trend_cfg = data.get("trend_bot", {})
         if isinstance(trend_cfg, dict):
             trend_cfg.update(overrides)
         else:
             trend_cfg = overrides
-        data["trend"] = trend_cfg
+        data["trend_bot"] = trend_cfg
 
     if "symbol" in data:
         data["symbol"] = fix_symbol(data["symbol"])
@@ -1940,7 +1940,7 @@ async def execute_signals(ctx: BotContext) -> None:
 
         await refresh_balance(ctx)
 
-        if strategy == "micro_scalp":
+        if strategy == "micro_scalp_bot":
             register_task(asyncio.create_task(_monitor_micro_scalp_exit(ctx, sym)))
 
     if executed == 0:

--- a/crypto_bot/strategy_router.py
+++ b/crypto_bot/strategy_router.py
@@ -552,16 +552,16 @@ def _bandit_context(
 def strategy_name(regime: str, mode: str) -> str:
     """Return the name of the strategy for given regime and mode."""
     if mode == "cex":
-        return "trend" if regime == "trending" else "grid"
+        return "trend_bot" if regime == "trending" else "grid_bot"
     if mode == "onchain":
         return "sniper" if regime in {"breakout", "volatile"} else "dex_scalper"
     if regime == "trending":
-        return "trend"
+        return "trend_bot"
     if regime == "scalp":
-        return "micro_scalp"
+        return "micro_scalp_bot"
     if regime in {"breakout", "volatile"}:
         return "sniper"
-    return "grid"
+    return "grid_bot"
 
 
 def route(

--- a/tasks/refresh_pairs.py
+++ b/tasks/refresh_pairs.py
@@ -63,12 +63,12 @@ def load_config() -> dict:
     if trend_file.exists():
         with open(trend_file) as sf:
             overrides = yaml.safe_load(sf) or {}
-        trend_cfg = data.get("trend", {})
+        trend_cfg = data.get("trend_bot", {})
         if isinstance(trend_cfg, dict):
             trend_cfg.update(overrides)
         else:
             trend_cfg = overrides
-        data["trend"] = trend_cfg
+        data["trend_bot"] = trend_cfg
 
     if "symbol" in data:
         data["symbol"] = fix_symbol(data["symbol"])

--- a/tests/test_auto_optimizer.py
+++ b/tests/test_auto_optimizer.py
@@ -41,7 +41,7 @@ def test_optimize_strategies_writes_best_params(tmp_path, monkeypatch):
         "optimization": {
             "enabled": True,
             "parameter_ranges": {
-                "trend": {"stop_loss": [0.01, 0.02], "take_profit": [0.02, 0.03]}
+                "trend_bot": {"stop_loss": [0.01, 0.02], "take_profit": [0.02, 0.03]}
             },
         },
     }
@@ -55,6 +55,6 @@ def test_optimize_strategies_writes_best_params(tmp_path, monkeypatch):
     saved = json.loads(out_file.read_text())
 
     assert params == saved
-    assert "trend" in saved
-    assert saved["trend"]["stop_loss_pct"] == 0.01
-    assert saved["trend"]["take_profit_pct"] == 0.02
+    assert "trend_bot" in saved
+    assert saved["trend_bot"]["stop_loss_pct"] == 0.01
+    assert saved["trend_bot"]["take_profit_pct"] == 0.02

--- a/tests/test_balance_position_size.py
+++ b/tests/test_balance_position_size.py
@@ -58,6 +58,7 @@ def load_execute_signals():
         "_monitor_micro_scalp_exit": lambda *a, **k: None,
         "BotContext": BotContext,
         "refresh_balance": lambda ctx: asyncio.sleep(0),
+        "Counter": __import__("collections").Counter,
     }
 
     exec(funcs["direction_to_side"], ns)

--- a/tests/test_bandit.py
+++ b/tests/test_bandit.py
@@ -28,7 +28,7 @@ def test_route_uses_bandit(monkeypatch):
 
     def fake_select(ctx, arms, symbol):
         calls["arms"] = list(arms)
-        return "grid"
+        return "grid_bot"
 
     from crypto_bot import selector
 
@@ -37,12 +37,12 @@ def test_route_uses_bandit(monkeypatch):
 
     cfg = {
         "timeframe": "1h",
-        "strategy_router": {"regimes": {"trending": ["trend", "grid"]}},
+        "strategy_router": {"regimes": {"trending": ["trend_bot", "grid_bot"]}},
         "bandit": {"enabled": True},
     }
     fn = route("trending", "cex", cfg)
 
-    assert calls.get("arms") == ["trend", "grid"]
+    assert calls.get("arms") == ["trend_bot", "grid_bot"]
     assert fn.__name__ == grid_bot.generate_signal.__name__
 
 

--- a/tests/test_cooldown_manager.py
+++ b/tests/test_cooldown_manager.py
@@ -6,7 +6,7 @@ from crypto_bot.cooldown_manager import configure, in_cooldown, mark_cooldown, c
 def test_cooldown_resets(monkeypatch):
     configure(10)
     cooldowns.clear()
-    mark_cooldown("XBT/USDT", "trend")
-    assert in_cooldown("XBT/USDT", "trend") is True
-    cooldowns["XBT/USDT_trend"] -= timedelta(seconds=11)
-    assert in_cooldown("XBT/USDT", "trend") is False
+    mark_cooldown("XBT/USDT", "trend_bot")
+    assert in_cooldown("XBT/USDT", "trend_bot") is True
+    cooldowns["XBT/USDT_trend_bot"] -= timedelta(seconds=11)
+    assert in_cooldown("XBT/USDT", "trend_bot") is False

--- a/tests/test_frontend_api.py
+++ b/tests/test_frontend_api.py
@@ -34,7 +34,7 @@ def test_positions_endpoint(tmp_path, monkeypatch):
 
 
 def test_strategy_performance_endpoint(tmp_path, monkeypatch):
-    data = {"trend": {"bot": [{"symbol": "BTC", "pnl": 1}]}}
+    data = {"trend_bot": {"bot": [{"symbol": "BTC", "pnl": 1}]}}
     f = tmp_path / "perf.json"
     f.write_text(json.dumps(data))
     monkeypatch.setattr(api, "PERFORMANCE_FILE", f)

--- a/tests/test_meta_selector.py
+++ b/tests/test_meta_selector.py
@@ -39,7 +39,7 @@ def test_choose_best_fallback(tmp_path, monkeypatch):
 
 def test_strategy_map_contains_micro_scalp():
     assert (
-        meta_selector._STRATEGY_FN_MAP.get("micro_scalp")
+        meta_selector._STRATEGY_FN_MAP.get("micro_scalp_bot")
         is micro_scalp_bot.generate_signal
     )
 

--- a/tests/test_pnl_logging.py
+++ b/tests/test_pnl_logging.py
@@ -68,6 +68,7 @@ def load_handle_exits_exit():
         "refresh_balance": _refresh,
         "pnl_logger": types.SimpleNamespace(log_pnl=_log_pnl),
         "regime_pnl_tracker": types.SimpleNamespace(log_trade=_log_trade),
+        "state": {},
     }
 
     exec(funcs["opposite_side"], ns)
@@ -112,6 +113,7 @@ def load_monitor_exit():
         "refresh_balance": _refresh,
         "pnl_logger": types.SimpleNamespace(log_pnl=_log_pnl),
         "regime_pnl_tracker": types.SimpleNamespace(log_trade=_log_trade),
+        "state": {},
     }
 
     exec(funcs["opposite_side"], ns)
@@ -153,6 +155,7 @@ def load_force_exit_all():
         "pnl_logger": types.SimpleNamespace(log_pnl=_log_pnl),
         "regime_pnl_tracker": types.SimpleNamespace(log_trade=_log_trade),
         "logger": __import__("logging").getLogger("test"),
+        "state": {},
     }
 
     exec(funcs["opposite_side"], ns)
@@ -170,7 +173,7 @@ async def test_handle_exits_logs_pnl():
                 "entry_price": 100.0,
                 "entry_time": "t",
                 "regime": "bull",
-                "strategy": "trend",
+                "strategy": "trend_bot",
                 "confidence": 1.0,
                 "pnl": 0.0,
                 "size": 1.0,
@@ -195,7 +198,7 @@ async def test_handle_exits_logs_pnl():
     await handle_exits(ctx)
 
     assert calls.get("pnl") is not None
-    assert calls.get("trade") == ("bull", "trend", 10.0)
+    assert calls.get("trade") == ("bull", "trend_bot", 10.0)
 
 
 @pytest.mark.asyncio
@@ -241,7 +244,7 @@ async def test_force_exit_all_logs_pnl():
             "XBT/USDT": {
                 "side": "buy",
                 "entry_price": 100.0,
-                "strategy": "trend",
+                "strategy": "trend_bot",
                 "regime": "bull",
                 "confidence": 0.9,
                 "size": 1.0,
@@ -263,5 +266,5 @@ async def test_force_exit_all_logs_pnl():
     await force_exit(ctx)
 
     assert calls.get("pnl") is not None
-    assert calls.get("trade") == ("bull", "trend", 10.0)
+    assert calls.get("trade") == ("bull", "trend_bot", 10.0)
 

--- a/tests/test_regime_pnl_tracker.py
+++ b/tests/test_regime_pnl_tracker.py
@@ -24,12 +24,12 @@ def test_compute_weights_normalizes(tmp_path, monkeypatch):
 
     rpt.log_trade("breakout", "scalper", 1.0)
     rpt.log_trade("breakout", "scalper", 1.5)
-    rpt.log_trade("breakout", "grid", 0.5)
+    rpt.log_trade("breakout", "grid_bot", 0.5)
 
     weights = rpt.compute_weights("breakout", log)
-    assert set(weights.keys()) == {"scalper", "grid"}
+    assert set(weights.keys()) == {"scalper", "grid_bot"}
     assert abs(sum(weights.values()) - 1.0) < 1e-6
-    assert weights["scalper"] > weights["grid"]
+    assert weights["scalper"] > weights["grid_bot"]
 
 
 def test_recent_win_rate(tmp_path, monkeypatch):

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -15,10 +15,10 @@ def _make_module(name: str) -> types.ModuleType:
 
 def test_load_strategies_fallback(monkeypatch):
     # ensure fallback imports from crypto_bot.strategy works
-    for name in ["grid", "trend", "micro_scalp"]:
+    for name in ["grid_bot", "trend_bot", "micro_scalp_bot"]:
         mod = _make_module(name)
         monkeypatch.setitem(sys.modules, f"crypto_bot.strategy.{name}", mod)
 
-    strategies = load_strategies("cex", ["grid", "trend", "micro_scalp"])
+    strategies = load_strategies("cex", ["grid_bot", "trend_bot", "micro_scalp_bot"])
     assert len(strategies) == 3
     assert all(hasattr(s, "name") for s in strategies)

--- a/tests/test_strategy_router.py
+++ b/tests/test_strategy_router.py
@@ -57,12 +57,12 @@ from crypto_bot.strategy import (
 SAMPLE_CFG = {
     "strategy_router": {
         "regimes": {
-            "trending": ["trend", "momentum_bot"],
-            "sideways": ["grid"],
+            "trending": ["trend_bot", "momentum_bot"],
+            "sideways": ["grid_bot"],
             "mean-reverting": ["dip_hunter", "stat_arb_bot"],
             "breakout": ["breakout_bot"],
             "volatile": ["sniper_bot", "momentum_bot"],
-            "scalp": ["micro_scalp"],
+            "scalp": ["micro_scalp_bot"],
             "bounce": ["bounce_scalper"],
         }
     }
@@ -142,7 +142,7 @@ def test_route_returns_lstm_bot():
 
 
 def test_route_handles_none_df_map():
-    cfg = {"strategy_router": {"regimes": {"trending": ["trend"]}}}
+    cfg = {"strategy_router": {"regimes": {"trending": ["trend_bot"]}}}
     fn = route("trending", "cex", cfg, df_map=None)
     assert fn.__name__ == trend_bot.generate_signal.__name__
     score, direction = fn(None)
@@ -280,7 +280,7 @@ def test_fastpath_breakout(tmp_path, monkeypatch):
         "breakout_bandwidth_zscore": -0.84,
         "breakout_volume_multiplier": 2,
         "trend_adx_threshold": 1000
-    }}, "regime": {"sideways": ["grid"]}}
+    }}, "regime": {"sideways": ["grid_bot"]}}
 
     close = list(range(10))
     volume = [1] * 9 + [10]
@@ -295,7 +295,7 @@ def test_fastpath_trend(tmp_path):
         "breakout_max_bandwidth": 0,
         "breakout_volume_multiplier": 100,
         "trend_adx_threshold": 5
-    }}, "regime": {"trending": ["trend"]}}
+    }}, "regime": {"trending": ["trend_bot"]}}
     # create rising series so ADX > threshold
     vals = list(range(10))
     df = make_df(vals, [1]*10)
@@ -434,7 +434,7 @@ def test_route_mempool_blocks_signal(monkeypatch):
             return True
 
     cfg = {
-        "strategy_router": {"regimes": {"scalp": ["micro_scalp"]}},
+        "strategy_router": {"regimes": {"scalp": ["micro_scalp_bot"]}},
         "micro_scalp": {"fresh_cross_only": False, "min_vol_z": 0},
         "mempool_monitor": {"enabled": True, "suspicious_fee_threshold": 1},
     }

--- a/tests/test_strategy_weights.py
+++ b/tests/test_strategy_weights.py
@@ -8,24 +8,24 @@ from crypto_bot.risk.risk_manager import RiskManager, RiskConfig
 def test_compute_strategy_weights_normalizes(tmp_path):
     file = tmp_path / "pnl.csv"
     data = [
-        {"strategy": "trend", "pnl": 1},
-        {"strategy": "trend", "pnl": -0.5},
-        {"strategy": "grid", "pnl": 2},
-        {"strategy": "grid", "pnl": 2},
+        {"strategy": "trend_bot", "pnl": 1},
+        {"strategy": "trend_bot", "pnl": -0.5},
+        {"strategy": "grid_bot", "pnl": 2},
+        {"strategy": "grid_bot", "pnl": 2},
     ]
     pd.DataFrame(data).to_csv(file, index=False)
     weights = compute_strategy_weights(file, scoring_method="sharpe")
-    assert set(weights.keys()) == {"trend", "grid"}
+    assert set(weights.keys()) == {"trend_bot", "grid_bot"}
     total = sum(weights.values())
     assert abs(total - 1.0) < 1e-6
-    assert weights["trend"] > weights["grid"]
+    assert weights["trend_bot"] > weights["grid_bot"]
 
 
 def test_risk_manager_updates_tracker():
     cfg = RiskConfig(max_drawdown=1, stop_loss_pct=0.01, take_profit_pct=0.01)
     rm = RiskManager(cfg)
-    rm.update_allocation({"trend": 0.6, "grid": 0.4})
-    assert rm.capital_tracker.allocation == {"trend": 0.6, "grid": 0.4}
+    rm.update_allocation({"trend_bot": 0.6, "grid_bot": 0.4})
+    assert rm.capital_tracker.allocation == {"trend_bot": 0.6, "grid_bot": 0.4}
 
 
 def test_compute_drawdown_basic():

--- a/tools/adjust_scanner_tokens.py
+++ b/tools/adjust_scanner_tokens.py
@@ -24,12 +24,12 @@ def load_config() -> dict:
     if trend_file.exists():
         with open(trend_file) as sf:
             overrides = yaml.safe_load(sf) or {}
-        trend_cfg = data.get("trend", {})
+        trend_cfg = data.get("trend_bot", {})
         if isinstance(trend_cfg, dict):
             trend_cfg.update(overrides)
         else:
             trend_cfg = overrides
-        data["trend"] = trend_cfg
+        data["trend_bot"] = trend_cfg
     if "symbol" in data:
         data["symbol"] = fix_symbol(data["symbol"])
     if "symbols" in data:

--- a/tools/test_telegram.py
+++ b/tools/test_telegram.py
@@ -24,12 +24,12 @@ def load_config() -> dict:
     if trend_file.exists():
         with open(trend_file) as sf:
             overrides = yaml.safe_load(sf) or {}
-        trend_cfg = data.get("trend", {})
+        trend_cfg = data.get("trend_bot", {})
         if isinstance(trend_cfg, dict):
             trend_cfg.update(overrides)
         else:
             trend_cfg = overrides
-        data["trend"] = trend_cfg
+        data["trend_bot"] = trend_cfg
 
     if "symbol" in data:
         data["symbol"] = fix_symbol(data["symbol"])


### PR DESCRIPTION
## Summary
- return `trend_bot`, `grid_bot` and `micro_scalp_bot` from the router
- update configs, utilities and tests to expect new strategy names
- adjust main trading loop to monitor micro-scalp exits by new name

## Testing
- `pytest tests/test_strategy_router.py tests/test_strategy_loader.py -q`
- `pytest tests/test_strategy_weights.py tests/test_regime_pnl_tracker.py tests/test_pnl_logging.py tests/test_bandit.py tests/test_auto_optimizer.py tests/test_frontend_api.py tests/test_cooldown_manager.py tests/test_meta_selector.py tests/test_balance_position_size.py -q` *(fails: missing `cointrainer` package and NameError/Assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a2509e948330b8b505f80a9b1e47