### PR TITLE
Ensure single shutdown notification after cleanup

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -3146,10 +3146,9 @@ async def main() -> None:
         if notifier:
             notifier.notify(f"❌ Bot stopped: {exc}")
     finally:
-        if notifier:
-            notifier.notify("Bot shutting down")
         logger.info("Bot shutting down")
         await shutdown()
+        if notifier:
             notifier.notify(f"Bot shutting down: {reason}")
         logger.info("Bot shutting down: %s", reason)
 


### PR DESCRIPTION
## Summary
- Send shutdown notification only once after bot cleanup
- Guard notification with a notifier check in `main`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet')*


------
https://chatgpt.com/codex/tasks/task_e_68a0ac0bbd848330a327c2bb5ff09c43