### PR TITLE
Fix Loguru error formatting in strategy loader

### DIFF
--- a/crypto_bot/strategies/loader.py
+++ b/crypto_bot/strategies/loader.py
@@ -31,7 +31,7 @@ def load_strategies(mode: str, names: list[str] | None = None) -> list:
         strategies.append(inst)
 
     for mod_name, err in errors.items():
-        logger.error("Failed to load strategy %s: %s", mod_name, err)
+        logger.error("Failed to load strategy {}: {}", mod_name, err)
 
     return strategies
 


### PR DESCRIPTION
## Summary
- fix Loguru error message format in strategy loader to use `{}` placeholders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis', ImportError for crypto_bot.main, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac0eee108330b15cfb63d80f59b8