### PR TITLE
refactor strategy loader test with fixture

### DIFF
--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -1,34 +1,42 @@
 import sys
 import types
 
+import pytest
+
 from crypto_bot.strategies.loader import load_strategies
 
 
 def _make_module(name: str) -> types.ModuleType:
     mod = types.ModuleType(f"crypto_bot.strategy.{name}")
+
     class Strategy:
         def __init__(self):
             self.name = name
+
     mod.Strategy = Strategy
     return mod
 
 
-def test_load_strategies_fallback(monkeypatch):
-    # ensure fallback imports from crypto_bot.strategy works
-    for name in ["grid_bot", "trend_bot", "micro_scalp_bot"]:
-        mod = _make_module(name)
-        monkeypatch.setitem(sys.modules, f"crypto_bot.strategy.{name}", mod)
+@pytest.fixture
+def patch_strategy_modules(monkeypatch):
+    def _patch(names):
+        for name in names:
+            mod = _make_module(name)
+            monkeypatch.setitem(sys.modules, f"crypto_bot.strategy.{name}", mod)
 
-    for name in ["grid_bot", "trend_bot", "micro_scalp"]:
-        mod = _make_module(name)
-        monkeypatch.setitem(sys.modules, f"crypto_bot.strategy.{name}", mod)
+    return _patch
+
+
+def test_load_strategies_fallback(patch_strategy_modules):
+    # ensure fallback imports from crypto_bot.strategy works
+    patch_strategy_modules(["grid_bot", "trend_bot", "micro_scalp_bot"])
+    patch_strategy_modules(["grid_bot", "trend_bot", "micro_scalp"])
 
     strategies = load_strategies("cex", ["grid_bot", "trend_bot", "micro_scalp"])
-    for name in ["grid_bot", "trend_bot", "micro_scalp_bot"]:
-        mod = _make_module(name)
-        monkeypatch.setitem(sys.modules, f"crypto_bot.strategy.{name}", mod)
 
+    patch_strategy_modules(["grid_bot", "trend_bot", "micro_scalp_bot"])
     strategies = load_strategies("cex", ["grid_bot", "trend_bot", "micro_scalp_bot"])
+
     assert len(strategies) == 3
     assert sorted(s.name for s in strategies) == [
         "grid_bot",


### PR DESCRIPTION
## Summary
- refactor strategy loader test by extracting repeated monkeypatch loops into a fixture

## Testing
- `pytest tests/test_strategy_loader.py::test_load_strategies_fallback -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac1459a08330885edfb9b842559b