### PR TITLE
Add sniper_solana and clean strategy registration

### DIFF
--- a/crypto_bot/meta_selector.py
+++ b/crypto_bot/meta_selector.py
@@ -21,6 +21,7 @@ from crypto_bot.strategy import (
     micro_scalp_bot,
     momentum_bot,
     sniper_bot,
+    sniper_solana,
     solana_scalping,
     trend_bot,
 )
@@ -82,34 +83,27 @@ def _register(module, *names: str) -> None:
     for name in names:
         _STRATEGY_FN_MAP[name] = fn
 
-
-_register(trend_bot, "trend_bot")
-_register(grid_bot, "grid_bot")
-_register(sniper_bot, "sniper_bot")
-_register(dex_scalper, "dex_scalper")
-_register(mean_bot, "mean_bot")
-_register(breakout_bot, "breakout_bot")
-_register(micro_scalp_bot, "micro_scalp_bot")
-_register(sniper_bot, "sniper", "sniper_bot")
-_register(dex_scalper, "dex_scalper", "dex_scalper_bot")
-_register(mean_bot, "mean_bot")
-_register(breakout_bot, "breakout_bot")
-_register(micro_scalp_bot, "micro_scalp_bot")
-_register(momentum_bot, "momentum", "momentum_bot")
-_register(sniper_bot, "sniper_bot")
-_register(dex_scalper, "dex_scalper")
-_register(mean_bot, "mean_bot")
-_register(breakout_bot, "breakout_bot")
-_register(micro_scalp_bot, "micro_scalp_bot")
-_register(momentum_bot, "momentum_bot")
-_register(lstm_bot, "lstm_bot")
-_register(bounce_scalper, "bounce_scalper")
-_register(flash_crash_bot, "flash_crash_bot")
-_register(dip_hunter, "dip_hunter")
-_register(solana_scalping, "solana_scalping")
-_register(meme_wave_bot, "meme_wave_bot")
-_register(dca_bot, "dca_bot")
-_register(cross_chain_arb_bot, "cross_chain_arb_bot")
+# Register each strategy once under its canonical name
+for module, name in [
+    (trend_bot, "trend_bot"),
+    (grid_bot, "grid_bot"),
+    (sniper_solana, "sniper_solana"),
+    (sniper_bot, "sniper_bot"),
+    (dex_scalper, "dex_scalper"),
+    (mean_bot, "mean_bot"),
+    (breakout_bot, "breakout_bot"),
+    (micro_scalp_bot, "micro_scalp_bot"),
+    (momentum_bot, "momentum_bot"),
+    (lstm_bot, "lstm_bot"),
+    (bounce_scalper, "bounce_scalper"),
+    (flash_crash_bot, "flash_crash_bot"),
+    (dip_hunter, "dip_hunter"),
+    (solana_scalping, "solana_scalping"),
+    (meme_wave_bot, "meme_wave_bot"),
+    (dca_bot, "dca_bot"),
+    (cross_chain_arb_bot, "cross_chain_arb_bot"),
+]:
+    _register(module, name)
 
 
 def get_strategy_by_name(

--- a/tests/test_meta_selector.py
+++ b/tests/test_meta_selector.py
@@ -47,6 +47,18 @@ def test_strategy_map_contains_micro_scalp_bot():
 def test_strategy_map_has_no_aliases():
     assert "grid" not in meta_selector._STRATEGY_FN_MAP
     assert "trend" not in meta_selector._STRATEGY_FN_MAP
+    assert "sniper" not in meta_selector._STRATEGY_FN_MAP
+    assert "dex_scalper_bot" not in meta_selector._STRATEGY_FN_MAP
+    assert "momentum" not in meta_selector._STRATEGY_FN_MAP
+
+
+def test_strategy_map_contains_sniper_solana():
+    from crypto_bot.strategy import sniper_solana
+
+    assert (
+        meta_selector._STRATEGY_FN_MAP.get("sniper_solana")
+        is sniper_solana.generate_signal
+    )
 
 
 def test_strategy_map_contains_dca_bot():


### PR DESCRIPTION
## Summary
- Import `sniper_solana` strategy in `meta_selector`
- Register strategies once with canonical names, dropping aliases
- Expand meta selector tests for new strategy and alias removal

## Testing
- `pytest tests/test_meta_selector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac235d54833085a89314a9194fcb