### PR TITLE
Fix onchain sniper strategy naming

### DIFF
--- a/crypto_bot/strategy_router.py
+++ b/crypto_bot/strategy_router.py
@@ -554,14 +554,13 @@ def strategy_name(regime: str, mode: str) -> str:
     if mode == "cex":
         return "trend_bot" if regime == "trending" else "grid_bot"
     if mode == "onchain":
-        return "sniper_bot" if regime in {"breakout", "volatile"} else "dex_scalper"
+        return "sniper_solana" if regime in {"breakout", "volatile"} else "dex_scalper"
     if regime == "trending":
         return "trend_bot"
     if regime == "scalp":
         return "micro_scalp_bot"
     if regime in {"breakout", "volatile"}:
         return "sniper_bot"
-        return "sniper"
     return "grid_bot"
 
 


### PR DESCRIPTION
## Summary
- route breakout/volatile on-chain regimes to `sniper_solana`
- drop unreachable fallback `sniper` return value

## Testing
- `pytest tests/test_strategy_router.py -q`
- `pytest tests/test_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac20613883308cc3403ddf8dc309