### PR TITLE
Simplify meta selector registrations

### DIFF
--- a/crypto_bot/meta_selector.py
+++ b/crypto_bot/meta_selector.py
@@ -105,23 +105,6 @@ for module, name in [
 ]:
     _register(module, name)
 
-_register(trend_bot, "trend_bot")
-_register(grid_bot, "grid_bot")
-_register(sniper_bot, "sniper", "sniper_bot")
-_register(dex_scalper, "dex_scalper", "dex_scalper_bot")
-_register(mean_bot, "mean_bot")
-_register(breakout_bot, "breakout_bot")
-_register(micro_scalp_bot, "micro_scalp_bot")
-_register(momentum_bot, "momentum", "momentum_bot")
-_register(lstm_bot, "lstm_bot")
-_register(bounce_scalper, "bounce_scalper")
-_register(flash_crash_bot, "flash_crash_bot")
-_register(dip_hunter, "dip_hunter")
-_register(solana_scalping, "solana_scalping")
-_register(meme_wave_bot, "meme_wave_bot")
-_register(dca_bot, "dca_bot")
-_register(cross_chain_arb_bot, "cross_chain_arb_bot")
-
 
 def get_strategy_by_name(
     name: str,
@@ -217,4 +200,4 @@ def choose_best(regime: str) -> Callable[[pd.DataFrame], tuple]:
             scores = ml_scores
 
     best = max(scores.items(), key=lambda x: x[1])[0]
-    return _STRATEGY_FN_MAP.get(best, strategy_for(regime))
+    return _STRATEGY_FN_MAP.get(best) or strategy_for(regime)


### PR DESCRIPTION
## Summary
- import json so `_load` can read strategy performance logs
- register each strategy once under its canonical name
- avoid unnecessary evaluation of fallback strategy in `choose_best`

## Testing
- `pytest tests/test_meta_selector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0b1cfe2848330a790e72185e165f1