### PR TITLE
Use standard logging in evaluation engine and surface strategy load errors

### DIFF
--- a/crypto_bot/strategies/loader.py
+++ b/crypto_bot/strategies/loader.py
@@ -5,7 +5,9 @@ from loguru import logger
 from crypto_bot.strategy.loader import load_strategies as _load_strategies
 
 
-def load_strategies(mode: str, names: list[str] | None = None) -> list:
+def load_strategies(
+    mode: str, names: list[str] | None = None, return_errors: bool = False
+) -> list | tuple[list, dict]:
     """Return a list of instantiated strategy objects.
 
     Parameters
@@ -33,6 +35,8 @@ def load_strategies(mode: str, names: list[str] | None = None) -> list:
     for mod_name, err in errors.items():
         logger.error("Failed to load strategy {}: {}", mod_name, err)
 
+    if return_errors:
+        return strategies, errors
     return strategies
 
 


### PR DESCRIPTION
## Summary
- Switch evaluation engine to Python's standard logging so output goes to bot.log
- Expose strategy import errors and include them in RuntimeError when no strategies load

## Testing
- `pytest tests/test_strategy_loader.py -q`
- `python -m py_compile crypto_bot/engine/evaluation_engine.py crypto_bot/strategies/loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0babf84448330bfd2ac0595002f1f