### PR TITLE
Log continuous evaluation loop counts

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -2935,8 +2935,14 @@ async def _main_impl() -> MainResult:
         ctx.timing = await runner.run(ctx)
 
     try:
+        logger.info("Continuous evaluation loop started")
         while True:
             await run_evaluation_cycle()
+            logger.info(
+                "Active universe: %d symbols, current batch: %d symbols",
+                len(getattr(ctx, "active_universe", []) or []),
+                len(getattr(ctx, "current_batch", []) or []),
+            )
             await asyncio.sleep(config.get("loop_interval_minutes", 1) * 60)
 
 


### PR DESCRIPTION
## Summary
- Log start of continuous evaluation loop
- Report sizes of active_universe and current_batch after each evaluation cycle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis', 'cointrainer')*

------
https://chatgpt.com/codex/tasks/task_e_68a0cb8b94b0833092f8b9a919b279e4