### PR TITLE
Add candidate symbol summary logging

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -1096,9 +1096,18 @@ async def fetch_candidates(ctx: BotContext) -> None:
         except Exception as exc:  # pragma: no cover - best effort
             logger.error("Solana scanner failed: %s", exc)
 
+    total_candidates = len(symbols)
     symbols = [(s, sc) for s, sc in symbols if s not in no_data_symbols]
     ctx.active_universe = [s for s, _ in symbols]
     ctx.resolved_mode = resolved_mode
+
+    logger.info(
+        "Symbol summary: total=%d selected=%d filtered=%d first=%s",
+        total_candidates,
+        len(symbols),
+        total_candidates - len(symbols),
+        [s for s, _ in symbols[:5]],
+    )
 
     symbol_names = [s for s, _ in symbols]
     avg_atr = compute_average_atr(

--- a/tests/test_fetch_candidates_logging.py
+++ b/tests/test_fetch_candidates_logging.py
@@ -42,6 +42,7 @@ def test_fetch_candidates_logs_batch(monkeypatch, caplog):
 
     assert ctx.current_batch == ["BTC/USDT"]
     assert "Current batch" in caplog.text
+    assert "Symbol summary" in caplog.text
 
 
 def test_fetch_candidates_dedupes_and_filters(monkeypatch):


### PR DESCRIPTION
## Summary
- log symbol selection summary in `fetch_candidates`
- verify logging in unit test

## Testing
- `pytest -q` (fails: No module named 'fakeredis', etc.)
- `pytest tests/test_fetch_candidates_logging.py::test_fetch_candidates_logs_batch -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0cb8e1f5c8330adefec599f001213