### PR TITLE
Log shutdown reason and notify before cleanup

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -3147,11 +3147,16 @@ async def main() -> None:
         if notifier:
             notifier.notify(f"❌ Bot stopped: {exc}")
     finally:
-        logger.info("Bot shutting down")
-        await shutdown()
+        msg = f"Bot shutting down: {reason}"
+        logger.info(msg)
         if notifier:
-            notifier.notify(f"Bot shutting down: {reason}")
-        logger.info("Bot shutting down: %s", reason)
+            notifier.notify(msg)
+        try:
+            await shutdown()
+        except Exception as exc:  # pragma: no cover - cleanup error
+            logger.exception("Error during shutdown: %s", exc)
+        finally:
+            logger.info("Shutdown complete")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- Log shutdown reason and notify user before invoking cleanup
- Wrap shutdown sequence with error handling to report cleanup issues

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis'; No module named 'cointrainer')*


------
https://chatgpt.com/codex/tasks/task_e_68a0cb921a788330bf30ec84c83b072b