### PR TITLE
Await initial OHLCV tasks and adjust backfill timing

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -244,6 +244,8 @@ NEW_SOLANA_TOKENS: set[str] = set()
 CROSS_ARB_TASKS: set[asyncio.Task] = set()
 # Track all spawned background tasks for coordinated shutdown
 BACKGROUND_TASKS: list[asyncio.Task] = []
+# Track pending OHLCV tasks during startup
+pending_tasks: list[asyncio.Task] = []
 
 
 def register_task(task: asyncio.Task | None) -> asyncio.Task | None:
@@ -966,6 +968,8 @@ async def initial_scan(
         logger.info("Initial scan %.1f%% complete", pct)
         if notifier and config.get("telegram", {}).get("status_updates", True):
             notifier.notify(f"Initial scan {pct:.1f}% complete")
+    if pending_tasks:
+        await asyncio.gather(*pending_tasks, return_exceptions=True)
 
     return
 

--- a/crypto_bot/utils/market_loader.py
+++ b/crypto_bot/utils/market_loader.py
@@ -7,7 +7,7 @@ import inspect
 import time
 import os
 from pathlib import Path
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 import yaml
 import pandas as pd
 import numpy as np
@@ -132,7 +132,7 @@ MAX_RETRY_DELAY = 3600
 # Default timeout when fetching OHLCV data
 OHLCV_TIMEOUT = 60
 # Default timeout when fetching OHLCV data over WebSocket
-WS_OHLCV_TIMEOUT = 60
+WS_OHLCV_TIMEOUT = 120
 # REST requests occasionally face Cloudflare delays up to a minute
 REST_OHLCV_TIMEOUT = 90
 # Number of consecutive failures allowed before disabling a symbol
@@ -1990,6 +1990,8 @@ async def update_multi_tf_ohlcv_cache(
         clear_regime_cache = lambda *_a, **_k: None
 
     limit = int(limit)
+    if start_since is None:
+        start_since = int((datetime.utcnow() - timedelta(days=2)).timestamp() * 1000)
     # Use the limit provided by the caller
 
     # Ensure warmup candles satisfy strategy indicator lookbacks. This will


### PR DESCRIPTION
## Summary
- Track pending OHLCV tasks during startup and await them before entering the main loop to prevent premature shutdown.
- Increase WebSocket OHLCV timeout and use a dynamic two-day backfill window based on current UTC time.

## Testing
- `PYTHONPATH=. pytest tests/test_wallet.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'cointrainer')*

------
https://chatgpt.com/codex/tasks/task_e_68a0cc16a5c08330a29d5cad6dd4dcd5