### PR TITLE
Tune warmup and scan parameters

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -381,7 +381,7 @@ safety:
   max_error_count: 10
   restart_on_error: true
 scalp_timeframe: 1m
-scan_deep_top: 100
+scan_deep_top: 30
 scan_in_background: true
 scan_lookback_limit: 700
 scan_markets: true
@@ -592,8 +592,8 @@ backfill_days:
   '1m': 2
   '5m': 3
 warmup_candles:
-  '1m': 1000
-  '5m': 600
+  '1m': 600
+  '5m': 300
 allowed_quotes: ['USD','USDT','USDC','EUR']
 hft: true
 token_registry:


### PR DESCRIPTION
## Summary
- reduce deep scan symbol count to 30
- shorten 1m/5m warmup candles to 600/300
- keep 150 candle cycle lookback and 1m/5m timeframes

## Testing
- `pytest -q` *(fails: No module named 'fakeredis' and 'cointrainer')*
- `pytest tests/test_config.py tests/test_config_schema.py tests/test_backfill_warmup.py tests/test_update_caches.py tests/test_warmup_guard.py tests/test_ohlcv_cache_manager.py -q`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a0cd9f40348330bab6033c0b6a64dd