### PR TITLE
Ensure 1m/5m timeframes logged for OHLCV updates

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -907,7 +907,8 @@ async def initial_scan(
     )
 
     tfs = sf.get("initial_timeframes", config.get("timeframes", ["1h"]))
-    tf_sec = timeframe_seconds(None, min(tfs, key=lambda t: timeframe_seconds(None, t)))
+    tfs = sorted(set(tfs) | {"1m", "5m"}, key=lambda t: timeframe_seconds(None, t))
+    tf_sec = timeframe_seconds(None, tfs[0])
     lookback_since = int(time.time() * 1000 - scan_limit * tf_sec * 1000)
 
     history_since = int((time.time() - 365 * 86400) * 1000)
@@ -930,6 +931,8 @@ async def initial_scan(
 
         async with symbol_cache_guard():
             async with OHLCV_LOCK:
+                for tf in tfs:
+                    logger.info("Starting OHLCV update for timeframe %s", tf)
                 state.df_cache = await update_multi_tf_ohlcv_cache(
                     exchange,
                     state.df_cache,
@@ -1319,13 +1322,20 @@ async def _update_caches_impl(ctx: BotContext) -> None:
         if ctx.volatility_factor > 5:
             max_concurrent = max(1, max_concurrent // 2)
 
+    tfs = sorted(
+        set(ctx.config.get("timeframes", [])) | {"1m", "5m"},
+        key=lambda t: timeframe_seconds(None, t),
+    )
+
     async with OHLCV_LOCK:
         try:
+            for tf in tfs:
+                logger.info("Starting OHLCV update for timeframe %s", tf)
             ctx.df_cache = await update_multi_tf_ohlcv_cache(
                 ctx.exchange,
                 ctx.df_cache,
                 batch,
-                ctx.config,
+                {**ctx.config, "timeframes": tfs},
                 limit=limit,
                 use_websocket=ctx.config.get("use_websocket", False),
                 force_websocket_history=ctx.config.get(
@@ -1342,11 +1352,13 @@ async def _update_caches_impl(ctx: BotContext) -> None:
             )
         except Exception as exc:
             logger.warning("WS OHLCV failed: %s - falling back to REST", exc)
+            for tf in tfs:
+                logger.info("Starting OHLCV update for timeframe %s", tf)
             ctx.df_cache = await update_multi_tf_ohlcv_cache(
                 ctx.exchange,
                 ctx.df_cache,
                 batch,
-                ctx.config,
+                {**ctx.config, "timeframes": tfs},
                 limit=limit,
                 start_since=start_since,
                 use_websocket=False,


### PR DESCRIPTION
## Summary
- Guarantee `1m` and `5m` timeframes are always requested during initial history load and per-cycle updates
- Add logging before OHLCV cache updates and REST fallback to show requested timeframes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet')*
- `python - <<'PY'
import logging, asyncio
import crypto_bot.main as m
async def dummy_update_multi_tf_ohlcv_cache(*a, **k):
    return {}
m.update_multi_tf_ohlcv_cache = dummy_update_multi_tf_ohlcv_cache
class DummyCtx:
    def __init__(self):
        self.exchange = object()
        self.df_cache = {}
        self.current_batch=['BTC/USD']
        self.config={'timeframes':['1h'], 'telegram':{}}
        self.notifier=None
        self.volatility_factor=1
async def run():
    await m._update_caches_impl(DummyCtx())
logging.basicConfig(level=logging.INFO)
asyncio.run(run())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a0cda0936c8330963e1060dceeea3a