### PR TITLE
chore: tidy requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,4 +45,3 @@ torch
 stable-baselines3
 lunarcrush
 keyring
-# cointrader-trainer>=0.1.0  # optional trainer integration


### PR DESCRIPTION
## Summary
- remove commented cointrader-trainer requirement
- ensure Supabase client dependency remains for model downloads

## Testing
- `pytest tests/test_logger.py` *(fails: AttributeError: 'module' object at crypto_bot.utils.telegram has no attribute 'telegram')*


------
https://chatgpt.com/codex/tasks/task_e_68a0cf4b2c2c8330963ff21097ff8579