### PR TITLE
Use Supabase registry for regime models

### DIFF
--- a/crypto_bot/regime/api.py
+++ b/crypto_bot/regime/api.py
@@ -1,23 +1,22 @@
 """Regime model API with resilient fallbacks.
 
 This module attempts to load the latest trained regime model from a
-`cointrainer` registry.  Should the registry be unavailable or the model
-fail to load/execute, a lightweight technical-analysis baseline is used
-instead.  The baseline relies solely on ``pandas``/``numpy`` and
+Supabase-backed registry.  Should the registry be unavailable or the
+model fail to load/execute, a lightweight technical-analysis baseline is
+used instead.  The baseline relies solely on ``pandas``/``numpy`` and
 therefore works in minimal environments.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from io import BytesIO
 from typing import Literal, Optional
 
 import numpy as np
 import pandas as pd
 
 try:  # Import lazily guarded; registry may be unavailable in some envs
-    from cointrainer import registry as _registry  # type: ignore
+    from crypto_bot.regime import registry as _registry
 except Exception:  # pragma: no cover - registry is optional
     _registry = None
 
@@ -80,25 +79,7 @@ def _rsi(series: pd.Series, window: int = 14) -> pd.Series:
     return 100 - (100 / (1 + rs))
 
 
-def _load_model_from_bytes(blob: bytes):
-    """Deserialize a model from bytes.
-
-    Joblib is attempted first (if available) and falls back to the standard
-    ``pickle`` module.  Importing ``joblib`` lazily avoids mandatory
-    dependencies for callers who only rely on the baseline prediction.
-    """
-
-    try:
-        import joblib  # type: ignore
-
-        return joblib.load(BytesIO(blob))
-    except Exception:  # pragma: no cover - joblib may be missing or fail
-        import pickle
-
-        return pickle.loads(blob)
-
-
-def predict(features: pd.DataFrame) -> Prediction:
+def predict(features: pd.DataFrame, symbol: str = "BTCUSDT") -> Prediction:
     """Predict the trading regime for the provided ``features``.
 
     Attempts to retrieve and execute the latest trained model from the
@@ -110,34 +91,25 @@ def predict(features: pd.DataFrame) -> Prediction:
     if _registry is None:  # Registry not imported or unavailable
         return _baseline_action(features)
 
-    prefix = "models/regime/"  # The registry uses this prefix for the model
-
     try:
-        meta = _registry.load_pointer(prefix)  # type: ignore[attr-defined]
+        model, meta = _registry.load_latest_regime(symbol)
         feat_list = meta.get("feature_list")
         if feat_list:
             available = [c for c in feat_list if c in features.columns]
             if available:
                 features = features[available]
 
-        blob = _registry.load_latest(prefix, allow_fallback=False)
-        model = _load_model_from_bytes(blob)
-
-        try:
-            proba = model.predict_proba(features.tail(1))  # type: ignore[attr-defined]
-            proba = getattr(proba, "ravel", lambda: proba)()
-            idx = int(np.argmax(proba))
-            label_order = meta.get("label_order", [-1, 0, 1])
-            mapping = {-1: "short", 0: "flat", 1: "long"}
-            class_id = label_order[idx] if idx < len(label_order) else 0
-            action = mapping.get(class_id, "flat")
-            score = (
-                float(proba[idx]) if hasattr(proba, "__len__") else float(proba)
-            )
-            return Prediction(action=action, score=score, meta={"source": "registry"})
-        except Exception:  # pragma: no cover - model inference failure
-            return _baseline_action(features)
-
-    except Exception:  # pragma: no cover - registry issues
+        proba = model.predict_proba(features.tail(1))  # type: ignore[attr-defined]
+        proba = getattr(proba, "ravel", lambda: proba)()
+        idx = int(np.argmax(proba))
+        label_order = meta.get("label_order", [-1, 0, 1])
+        mapping = {-1: "short", 0: "flat", 1: "long"}
+        class_id = label_order[idx] if idx < len(label_order) else 0
+        action = mapping.get(class_id, "flat")
+        score = (
+            float(proba[idx]) if hasattr(proba, "__len__") else float(proba)
+        )
+        return Prediction(action=action, score=score, meta=meta)
+    except Exception:  # pragma: no cover - registry or model issues
         return _baseline_action(features)
 


### PR DESCRIPTION
## Summary
- switch regime API to import registry from `crypto_bot` instead of `cointrainer`
- refresh regime models via Supabase helper functions and metadata hashes
- keep baseline fallbacks when Supabase is unavailable

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cf329ef88330990d181fddf838c0