### PR TITLE
refactor: streamline ML dependency checks

### DIFF
--- a/crypto_bot/ml/selfcheck.py
+++ b/crypto_bot/ml/selfcheck.py
@@ -1,7 +1,10 @@
+import importlib
 import logging
 import os
 
 _logged = False
+
+_REQUIRED_PACKAGES = ("sklearn", "joblib", "ta")
 
 
 def log_ml_status_once() -> None:
@@ -11,11 +14,9 @@ def log_ml_status_once() -> None:
         return
     _logged = True
     log = logging.getLogger("crypto_bot.ml")
-    try:  # pragma: no cover - optional dependency
-        import cointrader_trainer  # noqa: F401
-        pkg = True
-    except ImportError:  # pragma: no cover - package missing
-        pkg = False
+    pkgs_ok = all(
+        importlib.util.find_spec(name) is not None for name in _REQUIRED_PACKAGES
+    )
     url_ok = bool(os.getenv("SUPABASE_URL"))
     key_ok = bool(
         os.getenv("SUPABASE_SERVICE_ROLE_KEY")
@@ -24,5 +25,8 @@ def log_ml_status_once() -> None:
         or os.getenv("SUPABASE_ANON_KEY")
     )
     log.info(
-        "ML status: package=%s supabase_url=%s key_present=%s", pkg, url_ok, key_ok
+        "ML status: packages=%s supabase_url=%s key_present=%s",
+        pkgs_ok,
+        url_ok,
+        key_ok,
     )

--- a/crypto_bot/utils/ml_utils.py
+++ b/crypto_bot/utils/ml_utils.py
@@ -75,15 +75,10 @@ def is_ml_available() -> bool:
     _ml_checked = True
 
     try:
-        try:  # optional training utilities
-            import cointrader_trainer  # noqa: F401
-        except ImportError:
-            logger.info("ML disabled: cointrader-trainer not installed")
+        if not _check_packages(_REQUIRED_PACKAGES):
+            logger.info("ML unavailable: missing required packages")
             ML_AVAILABLE = False
             return False
-
-        if not _check_packages(_REQUIRED_PACKAGES):
-            raise ImportError("Missing required ML packages")
 
         url, key = _get_supabase_creds()
         if not url or not key:

--- a/tests/test_ml_selfcheck.py
+++ b/tests/test_ml_selfcheck.py
@@ -1,5 +1,4 @@
 import importlib
-import sys
 import logging
 
 import pytest
@@ -21,12 +20,12 @@ def test_log_ml_status_once_logs_once(monkeypatch, caplog):
         "SUPABASE_ANON_KEY",
     ]:
         monkeypatch.delenv(var, raising=False)
-    monkeypatch.setitem(sys.modules, "cointrader_trainer", None)
+    monkeypatch.setattr(selfcheck.importlib.util, "find_spec", lambda name: None)
     caplog.set_level(logging.INFO, logger="crypto_bot.ml")
 
     selfcheck.log_ml_status_once()
     assert (
-        "ML status: package=False supabase_url=False key_present=False" in caplog.text
+        "ML status: packages=False supabase_url=False key_present=False" in caplog.text
     )
 
     caplog.clear()


### PR DESCRIPTION
## Summary
- remove cointrader_trainer import checks
- log Supabase credential presence and ML package availability once
- adjust ML availability checks and tests

## Testing
- `pytest`
- `pytest tests/test_ml_selfcheck.py -q`
- `pytest tests/test_ml_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0cf3c6d9c83308030cbb284189abf