### PR TITLE
Refactor regime loader to use Supabase metadata with fallback

### DIFF
--- a/crypto_bot/regime/facade.py
+++ b/crypto_bot/regime/facade.py
@@ -4,18 +4,17 @@ from typing import Any
 
 from .registry import load_latest_regime
 
-# Cache loaded models keyed by trading symbol. This avoids repeated downloads
-# or deserialisation work for callers that invoke ``predict`` multiple times
-# for the same asset.
-_cache: dict[str, tuple[Any, dict]] = {}
+# Cache loaded models keyed by trading symbol to avoid repeated downloads or
+# deserialisation work for callers that invoke ``predict`` multiple times for
+# the same asset.
+_cache: dict[str, Any] = {}
 
 
-def _get_model(symbol: str):
+def _get_model(symbol: str) -> Any:
     """Return a cached model for ``symbol`` or load it if missing."""
     if symbol not in _cache:
-        model, meta = load_latest_regime(symbol)
-        _cache[symbol] = (model, meta)
-    return _cache[symbol][0]
+        _cache[symbol] = load_latest_regime(symbol)
+    return _cache[symbol]
 
 
 def predict(features_df, symbol: str = "BTCUSDT"):

--- a/crypto_bot/regime/registry.py
+++ b/crypto_bot/regime/registry.py
@@ -1,95 +1,53 @@
-import io, os, json, pickle, hashlib
-from supabase import create_client
-
-
-def _client():
-    url = os.environ["SUPABASE_URL"]
-    key = (
-        os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
-        or os.environ.get("SUPABASE_SERVICE_KEY")
-        or os.environ["SUPABASE_KEY"]
-    )
-    return create_client(url, key)
-
-
-def resolve_latest(symbol: str, bucket=None, prefix=None) -> dict:
-    bucket = bucket or os.environ.get("CT_MODELS_BUCKET", "models")
-    prefix = prefix or os.environ.get("CT_REGIME_PREFIX", "models/regime")
-    latest_key = f"{prefix}/{symbol}/LATEST.json"
-    sb = _client()
-    b = sb.storage.from_(bucket).download(latest_key)
-    meta = json.loads(b.decode("utf-8"))
-    assert meta.get("key"), "LATEST.json missing 'key'"
-    return meta | {"latest_key": latest_key, "bucket": bucket}
-
-
-def _sha256_bytes(b: bytes) -> str:
-    return "sha256:" + hashlib.sha256(b).hexdigest()
-
-
-def load_latest_regime(symbol: str):
-    try:
-        meta = resolve_latest(symbol)
-        sb = _client()
-        blob = sb.storage.from_(meta["bucket"]).download(meta["key"])
-        if "hash" in meta:
-            assert _sha256_bytes(blob) == meta["hash"], "Model hash mismatch"
-        model = pickle.loads(blob)
-        return model, meta
-    except Exception as e:
-        # Fallback to embedded base64 model
-        from crypto_bot.regime import model_data
-        model = model_data.load_default()
-        return model, {"source": "embedded", "error": str(e)}
 from __future__ import annotations
 
+import hashlib
 import io
+import json
 import os
-from typing import Tuple, Any
+from typing import Any
 
 from .ml_fallback import load_model as _load_fallback
 
 
-def _load_bytes(blob: bytes) -> Any:
-    """Deserialize a model from raw bytes.
+def load_latest_regime(symbol: str) -> Any:
+    """Load the most recent regime model for ``symbol``.
 
-    Joblib is attempted first and we fall back to pickle. This mirrors the
-    logic used elsewhere in the code base and keeps the dependency optional.
+    The function attempts to fetch model metadata from Supabase storage.
+    The metadata file (``LATEST.json``) is expected to contain a pointer to
+    the model binary and optionally its SHA256 hash.  When the download or
+    validation fails for any reason, an embedded fallback model is returned
+    instead.
     """
-    try:
-        import joblib  # type: ignore
+    try:  # pragma: no cover - network and optional dependency
+        from supabase import create_client  # type: ignore
 
-        return joblib.load(io.BytesIO(blob))
-    except Exception:  # pragma: no cover - joblib may be missing or fail
-        import pickle
+        url = os.environ["SUPABASE_URL"]
+        key = (
+            os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+            or os.environ.get("SUPABASE_SERVICE_KEY")
+            or os.environ["SUPABASE_KEY"]
+        )
+        bucket = os.environ.get("CT_MODELS_BUCKET", "models")
+        prefix = os.environ.get("CT_REGIME_PREFIX", "models/regime")
 
-        return pickle.loads(blob)
+        client = create_client(url, key)
+        latest_key = f"{prefix}/{symbol}/LATEST.json"
+        meta_bytes = client.storage.from_(bucket).download(latest_key)
+        meta = json.loads(meta_bytes.decode("utf-8"))
+        assert meta.get("key"), "LATEST.json missing 'key'"
 
+        blob = client.storage.from_(bucket).download(meta["key"])
+        if "hash" in meta:
+            digest = "sha256:" + hashlib.sha256(blob).hexdigest()
+            assert digest == meta["hash"], "Model hash mismatch"
 
-def load_latest_regime(symbol: str = "BTCUSDT") -> Tuple[Any, dict]:
-    """Load the most recent regime model.
+        try:
+            import joblib  # type: ignore
 
-    The loader prefers a model stored on Supabase when the required
-    credentials are present.  If that retrieval fails for any reason, the
-    embedded base64 fallback model is used instead.  The returned tuple
-    contains the model object and a metadata dictionary describing the
-    source.
-    """
-    url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
-    file_name = os.getenv("SUPABASE_MODEL_FILE", "regime_lgbm.pkl")
+            return joblib.load(io.BytesIO(blob))
+        except Exception:  # pragma: no cover - joblib may be missing or fail
+            import pickle
 
-    if url and key:
-        try:  # pragma: no cover - optional dependency and network access
-            from supabase import create_client  # type: ignore
-
-            client = create_client(url, key)
-            data = client.storage.from_("models").download(file_name)
-            model = _load_bytes(data)
-            return model, {"source": "supabase", "symbol": symbol}
-        except Exception:
-            pass
-
-    # Fallback to the embedded model when Supabase is unavailable.
-    model = _load_fallback()
-    return model, {"source": "fallback", "symbol": symbol}
+            return pickle.loads(blob)
+    except Exception:
+        return _load_fallback()


### PR DESCRIPTION
## Summary
- simplify regime registry to a single `load_latest_regime` that downloads metadata, verifies hashes and falls back to embedded model
- adjust regime facade to use simplified loader and cache models per symbol

## Testing
- `pip install fakeredis`
- `pip install cointrainer` *(fails: No matching distribution found for cointrainer)*
- `pytest -q` *(fails: No module named 'cointrainer')*


------
https://chatgpt.com/codex/tasks/task_e_68a0cf496a24833085f9f76f57561f1e