### PR TITLE
refactor: simplify ML initialization

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -132,13 +132,6 @@ REQUIRED_ENV_VARS = {
     "TELEGRAM_CHAT_ID",
 }
 
-
-def _parse_version(ver: str) -> tuple[int, ...]:
-    return tuple(int(p) for p in ver.split(".") if p.isdigit())
-
-trainer_version, MIN_CT2_INTEGRATION = "0.0.0", "0.1.0"
-_TRAINER_AVAILABLE = False
-
 CONFIG_DIR = Path(__file__).resolve().parent
 CONFIG_PATH = CONFIG_DIR / "config.yaml"
 ENV_PATH = CONFIG_DIR / ".env"
@@ -513,24 +506,17 @@ def _ensure_ml(cfg: dict) -> None:
     Raises
     ------
     MLUnavailableError
-        If the trainer package is installed but the model cannot be loaded.
+        If the Supabase model cannot be loaded.
     """
     if not cfg.get("ml_enabled", True):
         return
-    if not _TRAINER_AVAILABLE:
-        logger.info(
-            "cointrader-trainer not installed; install with 'pip install cointrader-trainer' to enable ML features"
-        )
-        return
     try:  # pragma: no cover - best effort
-        from coinTrader_Trainer.ml_trainer import load_model
+        from crypto_bot.regime.regime_classifier import load_regime_model
 
-        load_model("mean_bot")
-    except Exception as exc:  # pragma: no cover - missing trainer or model
+        asyncio.run(load_regime_model("BTCUSDT"))
+    except Exception as exc:  # pragma: no cover - model load failure
         logger.error("Machine learning initialization failed: %s", exc)
-        raise MLUnavailableError(
-            "coinTrader_Trainer model load failure", cfg
-        ) from exc
+        raise MLUnavailableError("model load failure", cfg) from exc
 
 
 def _ensure_ml_if_needed(cfg: dict) -> None:
@@ -3089,7 +3075,6 @@ async def main() -> None:
     global fetch_geckoterminal_ohlcv, fetch_solana_prices, cross_chain_trade, sniper_solana, sniper_trade
     global load_token_mints, set_token_mints, TelegramBotUI, start_runner, sniper_run
     global stream_evaluator
-    global _TRAINER_AVAILABLE, trainer_version, MIN_CT2_INTEGRATION
 
     from schema.scanner import (
         ScannerConfig,
@@ -3182,13 +3167,6 @@ async def main() -> None:
     from crypto_bot.volatility_filter import calc_atr
     from crypto_bot.solana.exit import monitor_price
     from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
-    try:  # pragma: no cover - optional dependency
-        from crypto_bot.version import __version__ as trainer_version, MIN_CT2_INTEGRATION
-        _TRAINER_AVAILABLE = True
-    except Exception:  # pragma: no cover - trainer not installed
-        trainer_version, MIN_CT2_INTEGRATION = "0.0.0", "0.1.0"
-        _TRAINER_AVAILABLE = False
-
 
     init_ml_components()
     _reload_modules()

--- a/crypto_bot/ml/selfcheck.py
+++ b/crypto_bot/ml/selfcheck.py
@@ -5,17 +5,12 @@ _logged = False
 
 
 def log_ml_status_once() -> None:
-    """Log ML package and Supabase environment status once."""
+    """Log Supabase ML environment status once."""
     global _logged
     if _logged:
         return
     _logged = True
     log = logging.getLogger("crypto_bot.ml")
-    try:  # pragma: no cover - optional dependency
-        import cointrader_trainer  # noqa: F401
-        pkg = True
-    except ImportError:  # pragma: no cover - package missing
-        pkg = False
     url_ok = bool(os.getenv("SUPABASE_URL"))
     key_ok = bool(
         os.getenv("SUPABASE_SERVICE_ROLE_KEY")
@@ -23,6 +18,4 @@ def log_ml_status_once() -> None:
         or os.getenv("SUPABASE_API_KEY")
         or os.getenv("SUPABASE_ANON_KEY")
     )
-    log.info(
-        "ML status: package=%s supabase_url=%s key_present=%s", pkg, url_ok, key_ok
-    )
+    log.info("ML status: supabase_url=%s key_present=%s", url_ok, key_ok)

--- a/crypto_bot/utils/ml_utils.py
+++ b/crypto_bot/utils/ml_utils.py
@@ -75,13 +75,6 @@ def is_ml_available() -> bool:
     _ml_checked = True
 
     try:
-        try:  # optional training utilities
-            import cointrader_trainer  # noqa: F401
-        except ImportError:
-            logger.info("ML disabled: cointrader-trainer not installed")
-            ML_AVAILABLE = False
-            return False
-
         if not _check_packages(_REQUIRED_PACKAGES):
             raise ImportError("Missing required ML packages")
 

--- a/tests/test_ml_selfcheck.py
+++ b/tests/test_ml_selfcheck.py
@@ -21,13 +21,10 @@ def test_log_ml_status_once_logs_once(monkeypatch, caplog):
         "SUPABASE_ANON_KEY",
     ]:
         monkeypatch.delenv(var, raising=False)
-    monkeypatch.setitem(sys.modules, "cointrader_trainer", None)
     caplog.set_level(logging.INFO, logger="crypto_bot.ml")
 
     selfcheck.log_ml_status_once()
-    assert (
-        "ML status: package=False supabase_url=False key_present=False" in caplog.text
-    )
+    assert "ML status: supabase_url=False key_present=False" in caplog.text
 
     caplog.clear()
     selfcheck.log_ml_status_once()

--- a/tests/test_ml_trainer_hint.py
+++ b/tests/test_ml_trainer_hint.py
@@ -1,16 +1,25 @@
 import importlib
 import logging
 
+import pytest
+
 import crypto_bot.main as main
+from crypto_bot.regime import regime_classifier
 
 
-def test_missing_trainer_logs_install_hint(caplog):
-    """When ML is enabled but cointrader-trainer is missing, log hint."""
+def test_ml_loader_logs_error(caplog, monkeypatch):
+    """When ML loader fails, log the error without trainer hints."""
     importlib.reload(main)
-    main._TRAINER_AVAILABLE = False
-    caplog.set_level(logging.INFO, logger="bot")
 
-    main._ensure_ml_if_needed({"ml_enabled": True})
+    async def boom(_symbol):
+        raise RuntimeError("boom")
 
-    assert "pip install cointrader-trainer" in caplog.text
+    monkeypatch.setattr(regime_classifier, "load_regime_model", boom)
+    caplog.set_level(logging.ERROR, logger="bot")
+
+    with pytest.raises(main.MLUnavailableError):
+        main._ensure_ml_if_needed({"ml_enabled": True})
+
+    assert "Machine learning initialization failed: boom" in caplog.text
+    assert "cointrader-trainer" not in caplog.text
 


### PR DESCRIPTION
## Summary
- remove trainer availability flag and legacy version checks
- load Supabase-based ML models directly in `_ensure_ml`
- streamline ML environment self-check and update related tests

## Testing
- `pytest tests/test_ml_trainer_hint.py tests/test_ml_selfcheck.py -q`
- `PYTHONPATH=$PWD pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*


------
https://chatgpt.com/codex/tasks/task_e_68a0cf445aa88330a2f714628cf85b28