### PR TITLE
Add ML trainer hint coverage

### DIFF
--- a/tests/test_ml_trainer_hint.py
+++ b/tests/test_ml_trainer_hint.py
@@ -1,0 +1,20 @@
+import sys
+import logging
+
+from crypto_bot.utils import ml_utils
+
+
+def test_trainer_hint_logged_when_trainer_missing(monkeypatch, caplog):
+    caplog.set_level(logging.DEBUG)
+
+    monkeypatch.setattr(ml_utils, "_check_packages", lambda _pkgs: ["pkg"])
+    monkeypatch.delitem(sys.modules, "cointrader_trainer", raising=False)
+    ml_utils._ml_checked = False
+    ml_utils.ML_AVAILABLE = False
+
+    ml_utils.is_ml_available()
+
+    assert (
+        "cointrader-trainer not installed; proceeding with runtime model download"
+        in caplog.text
+    )


### PR DESCRIPTION
## Summary
- test hint logged when cointrader-trainer package missing

## Testing
- `pytest tests/test_ml_trainer_hint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0deed06908330bc19b41f20766bc2