### PR TITLE
Consolidate ML status logging into single message

### DIFF
--- a/crypto_bot/ml/selfcheck.py
+++ b/crypto_bot/ml/selfcheck.py
@@ -24,7 +24,6 @@ def log_ml_status_once() -> None:
         or os.getenv("SUPABASE_API_KEY")
         or os.getenv("SUPABASE_ANON_KEY")
     )
-    log.info("ML status: supabase_url=%s key_present=%s", url_ok, key_ok)
     log.info(
         "ML status: packages=%s supabase_url=%s key_present=%s",
         pkgs_ok,

--- a/tests/test_ml_selfcheck.py
+++ b/tests/test_ml_selfcheck.py
@@ -28,7 +28,10 @@ def test_log_ml_status_once_logs_supabase_status(monkeypatch, caplog):
     caplog.set_level(logging.INFO, logger="crypto_bot.ml")
 
     selfcheck.log_ml_status_once()
-    assert "ML status: supabase_url=False key_present=False" in caplog.text
+    assert (
+        "ML status: packages=True supabase_url=False key_present=False"
+        in caplog.text
+    )
 
     caplog.clear()
     selfcheck.log_ml_status_once()
@@ -43,4 +46,7 @@ def test_log_ml_status_once_detects_credentials(monkeypatch, caplog):
     caplog.set_level(logging.INFO, logger="crypto_bot.ml")
 
     selfcheck.log_ml_status_once()
-    assert "ML status: supabase_url=True key_present=True" in caplog.text
+    assert (
+        "ML status: packages=True supabase_url=True key_present=True"
+        in caplog.text
+    )


### PR DESCRIPTION
## Summary
- Condense ML environment logging into a single info message that reports required package availability and Supabase credential presence
- Adjust ML self-check tests to expect the combined log message

## Testing
- `pytest tests/test_ml_selfcheck.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0deea9adc8330a18dd5ed9e878aa8