### PR TITLE
Add Supabase regime model logging and global env config

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+CT_MODELS_BUCKET=models
+CT_REGIME_PREFIX=models/regime/global  # Add /global to avoid symbol segmentation
+SUPABASE_URL=your_supabase_url
+SUPABASE_SERVICE_ROLE_KEY=your_key

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -537,7 +537,8 @@ def _ensure_ml(cfg: dict) -> None:
     try:  # pragma: no cover - best effort
         from crypto_bot.regime.regime_classifier import load_regime_model
 
-        asyncio.run(load_regime_model("BTCUSDT"))
+        _, model_path = asyncio.run(load_regime_model("BTCUSDT"))
+        logger.info("Loaded global regime model from Supabase: %s", model_path)
     except Exception as exc:  # pragma: no cover - model load failure
         logger.error("Machine learning initialization failed: %s", exc)
         raise MLUnavailableError("model load failure", cfg) from exc

--- a/crypto_bot/regime/regime_classifier.py
+++ b/crypto_bot/regime/regime_classifier.py
@@ -224,7 +224,7 @@ def _ml_fallback(
 async def _download_supabase_model():
     """Download LightGBM model from Supabase and return a Booster."""
     async with _supabase_model_lock:
-        model = await load_regime_model(os.getenv("SYMBOL", "BTCUSDT"))
+        model, _ = await load_regime_model(os.getenv("SYMBOL", "BTCUSDT"))
         return model
 
 
@@ -237,33 +237,37 @@ async def _get_supabase_model() -> object | None:
         return _supabase_model
 
 
-async def load_regime_model(symbol: str) -> object | None:
+async def load_regime_model(symbol: str) -> tuple[object | None, str | None]:
     try:
         from supabase import create_client
     except Exception as exc:  # pragma: no cover - optional dependency
         logger.warning("Supabase client unavailable: %s", exc)
-        return None
+        return None, None
 
     url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_KEY")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
     bucket = os.getenv("CT_MODELS_BUCKET", "models")
     if not url or not key:
         logger.warning("No model in Supabase; using heuristic")
-        return None
+        return None, None
 
     client = create_client(url, key)
     latest_path = f"regime/{symbol}/LATEST.json"
+    model_path = None
     try:
         latest_bytes = client.storage.from_(bucket).download(latest_path)
         if latest_bytes:
             data = json.loads(latest_bytes.decode("utf-8"))
-            model_bytes = client.storage.from_(bucket).download(data["key"])
-            return pickle.loads(model_bytes)
+            model_path = data["key"]
+            model_bytes = client.storage.from_(bucket).download(model_path)
+            model = pickle.loads(model_bytes)
+            logger.info("Loaded global regime model from Supabase: %s", model_path)
+            return model, model_path
     except Exception as exc:
         logger.error("Failed to load regime model: %s", exc)
 
     logger.warning("No model in Supabase; using heuristic")
-    return None
+    return None, model_path
 
 
 async def _ml_recovery_loop(notifier: TelegramNotifier | None) -> None:


### PR DESCRIPTION
## Summary
- Add root `.env` with Supabase and regime model config for global loading
- Log Supabase regime model path during ML initialization
- Return model path from `load_regime_model` and accept service role key

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis', 'cointrainer', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e2ca50288330a322b8ebb97eca83