### PR TITLE
feat: support pair-specific regime models

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -611,6 +611,7 @@ twap_enabled: true
 twap_interval_seconds: 5
 twap_slices: 6
 use_ml_regime_classifier: true
+use_per_pair_models: true
 use_websocket: true
 volatility_filter:
   max_funding_rate: 0.1

--- a/crypto_bot/regime/regime_config.yaml
+++ b/crypto_bot/regime/regime_config.yaml
@@ -16,6 +16,7 @@ ma_window: 20
 higher_timeframe: "4h"
 confirm_trend_with_higher_tf: false
 use_ml_regime_classifier: true  # Enable Trainer's LightGBM
+use_per_pair_models: true
 ml_min_bars: 5
 log_level: INFO
 score_weights:

--- a/crypto_bot/utils/market_analyzer.py
+++ b/crypto_bot/utils/market_analyzer.py
@@ -248,7 +248,7 @@ async def analyze_symbol(
     if ML_AVAILABLE:
         try:
             regime, info = await classify_regime_async(
-                df, higher_df, notifier=notifier
+                df, higher_df, notifier=notifier, symbol=symbol
             )
         except Exception as exc:
             analysis_logger.error("classify_regime_async failed: %s", exc)
@@ -330,7 +330,7 @@ async def analyze_symbol(
         if ML_AVAILABLE:
             try:
                 labels = await classify_regime_async(
-                    df_map=vote_map, notifier=notifier
+                    df_map=vote_map, notifier=notifier, symbol=symbol
                 )
             except Exception as exc:
                 analysis_logger.error(


### PR DESCRIPTION
## Summary
- load pair-specific regime models with global fallback
- use per-pair models in market analyzer classification
- add `use_per_pair_models` config flag

## Testing
- `pytest tests/test_regime_classifier.py tests/test_market_analyzer_fallback.py tests/test_strategy_ensemble.py -q` *(fails: TypeError: calc_atr() got an unexpected keyword argument 'window', plus additional assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e2e0131c8330abed38df3a5cab29