### PR TITLE
Fix unawaited coroutine warning during startup

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -2468,7 +2468,7 @@ async def _main_impl() -> MainResult:
 
     logger.info("Starting bot")
     global UNKNOWN_COUNT, TOTAL_ANALYSES
-    config = load_config()
+    config, _ = await load_config_async()
     stop_reason = "completed"
 
     mapping = await load_token_mints()


### PR DESCRIPTION
## Summary
- load bot configuration asynchronously to avoid calling `asyncio.run` within an active event loop

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cointrainer')*
- `pytest tests/test_commit_lock.py tests/test_strategy_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e5bc1a4483308ca1a4d878b877fe