### PR TITLE
Fix Telegram bot shutdown loop

### DIFF
--- a/crypto_bot/telegram_bot_ui.py
+++ b/crypto_bot/telegram_bot_ui.py
@@ -182,9 +182,11 @@ class TelegramBotUI:
                     try:
                         await self.app.start()
                         await self.app.updater.start_polling()
-                        await self.app.updater.wait_closed()
                         backoff = 1
                         last_log = 0
+                        await asyncio.Future()
+                    except asyncio.CancelledError:
+                        raise
                     except (NetworkError, OSError) as exc:
                         if backoff != last_log:
                             self.logger.error(


### PR DESCRIPTION
## Summary
- replace wait_closed with an indefinite wait and explicit cancellation handling
- ensure updater and application stop gracefully to avoid AttributeError

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68a104122e9c83309608c4cff911b32b