### PR TITLE
Reduce ticker scan logging

### DIFF
--- a/crypto_bot/__main__.py
+++ b/crypto_bot/__main__.py
@@ -2,7 +2,7 @@ import logging
 
 from logging_setup import setup_logging
 
-setup_logging(level="INFO", logfile="bot.log")
+setup_logging(level="INFO", logfile="bot.log", console_level="WARNING")
 
 logger = logging.getLogger("crypto_bot.main")
 logger.info("Starting bot")

--- a/crypto_bot/utils/symbol_pre_filter.py
+++ b/crypto_bot/utils/symbol_pre_filter.py
@@ -340,7 +340,7 @@ async def _parse_metrics(
     liq_cache[symbol] = (volume_usd, spread_pct, 1.0)
 
     cached_vol, cached_spread, _ = liq_cache[symbol]
-    logger.info("%s: vol=%.2f chg=%.2f%% spr=%.2f%%", symbol, cached_vol, change_pct, cached_spread)
+    logger.debug("%s: vol=%.2f chg=%.2f%% spr=%.2f%%", symbol, cached_vol, change_pct, cached_spread)
     return cached_vol, change_pct, cached_spread
 
 
@@ -951,7 +951,7 @@ async def filter_symbols(
         seen.add(symbol)
         local_min_volume = min_volume * 0.5 if symbol.endswith("/USDC") else min_volume
         if vol_usd < local_min_volume:
-            logger.warning(
+            logger.debug(
                 "Skipping %s due to low ticker volume %.2f < %.2f",
                 symbol,
                 vol_usd,
@@ -961,7 +961,7 @@ async def filter_symbols(
             rejects[RejectReason.LOW_VOLUME] += 1
             continue
         if spread_pct > max_spread:
-            logger.warning(
+            logger.debug(
                 "Skipping %s due to high spread %.2f%% > %.2f%%",
                 symbol,
                 spread_pct,
@@ -1198,7 +1198,7 @@ async def filter_symbols(
         logger.info("Resolved %s to mint %s for onchain", sym, mint)
         vol = 0.0
         if vol < onchain_min_volume:
-            logger.info(
+            logger.debug(
                 "Skipping %s due to low volume %.2f USD (min %.2f)",
                 sym,
                 vol,

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -3,7 +3,7 @@ import logging.config
 import sys
 
 
-def setup_logging(level="INFO", logfile="bot.log"):
+def setup_logging(level="INFO", logfile="bot.log", console_level=None):
     LOGGING = {
         "version": 1,
         "disable_existing_loggers": False,
@@ -16,7 +16,7 @@ def setup_logging(level="INFO", logfile="bot.log"):
         "handlers": {
             "stdout": {
                 "class": "logging.StreamHandler",
-                "level": level,
+                "level": console_level or level,
                 "formatter": "console",
                 "stream": sys.stdout,
             },


### PR DESCRIPTION
## Summary
- quiet per-symbol ticker logs and volume/spread warnings
- allow different console log level to reduce routine scan chatter

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named '...' and further errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1041084ac8330a3a35a00bbbc452f