### PR TITLE
Trim HFT warmup to most liquid symbols

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -1221,7 +1221,22 @@ async def fetch_candidates(ctx: BotContext) -> None:
                 base_size = follow_size
         else:
             if not symbol_priority_queue:
-                symbol_priority_queue = build_priority_queue(symbols)
+                from crypto_bot.utils.symbol_pre_filter import liq_cache
+
+                selected_symbols = [s for s, _ in symbols]
+                volume_24h = {
+                    s: (liq_cache.get(s) or (0.0, 0.0, 0.0))[0]
+                    for s in selected_symbols
+                }
+                liquid = sorted(
+                    selected_symbols,
+                    key=lambda s: volume_24h.get(s, 0.0),
+                    reverse=True,
+                )[:150]
+                liquid_scores = [(s, sc) for s, sc in symbols if s in liquid]
+                rest_scores = [(s, sc) for s, sc in symbols if s not in liquid]
+                symbol_priority_queue = build_priority_queue(liquid_scores)
+                symbol_priority_queue.extend(build_priority_queue(rest_scores))
             base_size = base_size_cfg
 
         if onchain_syms and resolved_mode != "cex":


### PR DESCRIPTION
## Summary
- Prioritize up to 150 most liquid symbols on initial run using 24h volumes
- Defer remaining symbols until after liquid subset is processed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cointrainer')*


------
https://chatgpt.com/codex/tasks/task_e_68a105f50f608330bfe130bae6708829