### PR TITLE
Log trade outcomes to bandit and persist state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ __pycache__/
 
 crypto_bot/logs/
 crypto_bot/user_config.yaml
+crypto_bot/state/
 *.log
 cache/

--- a/crypto_bot/selector/bandit.py
+++ b/crypto_bot/selector/bandit.py
@@ -53,8 +53,9 @@ class Bandit:
             stats["beta"] += 1
         stats["trades"] = stats.get("trades", 0) + 1
         self.update_count += 1
-        if self.update_count % 50 == 0:
-            self._save_state()
+        # Persist state on every update so historical performance carries
+        # across application restarts.
+        self._save_state()
 
     def select(self, context: Any, arms: Iterable[str], symbol: str) -> str:
         """Return a strategy name chosen via Thompson sampling."""

--- a/crypto_bot/utils/pnl_logger.py
+++ b/crypto_bot/utils/pnl_logger.py
@@ -1,8 +1,8 @@
 import pandas as pd
-from pathlib import Path
 from datetime import datetime
 
 from .logger import LOG_DIR
+from crypto_bot.selector import bandit
 
 
 LOG_FILE = LOG_DIR / "strategy_pnl.csv"
@@ -32,3 +32,10 @@ def log_pnl(
     df = pd.DataFrame([record])
     header = not LOG_FILE.exists()
     df.to_csv(LOG_FILE, mode="a", header=header, index=False)
+
+    # Update bandit with trade outcome so strategy selection learns
+    # across runs.  A positive PnL is treated as a win.
+    try:  # pragma: no cover - defensive in case bandit is disabled
+        bandit.update(symbol, strategy, pnl > 0)
+    except Exception:  # noqa: BLE001
+        pass

--- a/tests/test_pnl_logger.py
+++ b/tests/test_pnl_logger.py
@@ -1,10 +1,18 @@
 import pandas as pd
 from crypto_bot.utils import pnl_logger
+from crypto_bot.selector import bandit
 
 
 def test_log_pnl_creates_csv(tmp_path, monkeypatch):
     log_file = tmp_path / "pnl.csv"
     monkeypatch.setattr(pnl_logger, "LOG_FILE", log_file)
+
+    calls = {}
+
+    def fake_update(symbol, strategy, win):
+        calls["args"] = (symbol, strategy, win)
+
+    monkeypatch.setattr(bandit, "update", fake_update)
 
     pnl_logger.log_pnl("trend_bot", "XBT/USDT", 100.0, 110.0, 10.0, 0.8, "buy")
 
@@ -21,3 +29,4 @@ def test_log_pnl_creates_csv(tmp_path, monkeypatch):
         "direction",
     }
     assert expected_cols.issubset(df.columns)
+    assert calls["args"] == ("XBT/USDT", "trend_bot", True)


### PR DESCRIPTION
## Summary
- update bandit with trade outcome each time PnL is logged
- persist bandit priors on every update so selections learn across runs
- cover PnL logging with a test and ignore generated state files

## Testing
- `pytest tests/test_pnl_logger.py tests/test_bandit.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68a105fe304c8330bf064665975460f4