### PR TITLE
Avoid duplicate OHLCV update logs

### DIFF
--- a/crypto_bot/utils/market_loader.py
+++ b/crypto_bot/utils/market_loader.py
@@ -1489,8 +1489,6 @@ async def _update_ohlcv_cache_inner(
     now = time.time()
     snapshot_due = now - _last_snapshot_time >= snapshot_interval
 
-    logger.info("Starting OHLCV update for timeframe %s", timeframe)
-
     since_map: Dict[str, int | None] = {}
     if start_since is not None:
         tf_sec = timeframe_seconds(exchange, timeframe)
@@ -1688,7 +1686,6 @@ async def _update_ohlcv_cache_inner(
                     )
                 except Exception:
                     pass
-    logger.info("Completed OHLCV update for timeframe %s", timeframe)
     return cache
 
 


### PR DESCRIPTION
## Summary
- Remove start/end logging in `_update_ohlcv_cache_inner` to prevent duplicate OHLCV update lifecycle messages

## Testing
- `pytest tests/test_ohlcv_cache_manager.py`
- `pytest` *(fails: ImportError while importing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a105c8ebec8330ab37b798f404571c