### PR TITLE
Handle 1m/5m warmup fallback and extend history limits

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,6 @@ CT_MODELS_BUCKET=models
 CT_REGIME_PREFIX=models/regime/global  # Add /global to avoid symbol segmentation
 SUPABASE_URL=your_supabase_url
 SUPABASE_SERVICE_ROLE_KEY=your_key
+CT_MAX_WARMUP_CANDLES=3000
+CT_MAX_BACKFILL_DAYS=7
+CT_EXIT_WHEN_IDLE=false


### PR DESCRIPTION
## Summary
- Allow strategies to load 3000 1m candles and 7 days of history via new env vars
- Split symbol warmup by timeframe support and fall back to 5m when 1m is unavailable
- Add regression test for the 1m fallback logic

## Testing
- `pytest tests/test_market_loader.py::test_update_multi_tf_ohlcv_cache_falls_back_to_5m -q` *(Interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a105e8701883309d991547ec5b0239