### PR TITLE
Add strategy orchestration and scoring helpers

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -2958,11 +2958,20 @@ async def _main_impl() -> MainResult:
         selected_symbols = list(dict.fromkeys(config.get("symbols", [])))
 
         async def strategy_loop() -> None:
-            await strategies.initialize(selected_symbols)
+            try:
+                await strategies.initialize(
+                    selected_symbols,
+                    mode=config.get("mode", "cex"),
+                )
+            except Exception:
+                logger.exception("Strategy engine initialization failed")
+                return
+
             logger.info(
                 "Strategy engine initialized for %d symbols; starting scoring loop...",
                 len(selected_symbols),
             )
+
             scan_secs = int(config.get("scan_interval_seconds", 10))
             while not shutdown_event.is_set():
                 try:

--- a/crypto_bot/strategies/__init__.py
+++ b/crypto_bot/strategies/__init__.py
@@ -1,3 +1,125 @@
-from .loader import load_strategies
+"""Strategy orchestration helpers.
 
-__all__ = ["load_strategies"]
+This module provides a thin wrapper around :mod:`crypto_bot.strategies.loader`
+that keeps track of instantiated strategies and exposes convenience helpers for
+initialization and scoring.  The goal is to offer a simple interface for the
+rest of the project while remaining backward compatible with the previous
+``load_strategies`` export.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import inspect
+import logging
+
+from . import loader
+
+logger = logging.getLogger(__name__)
+
+# Module-level store for strategies that have been loaded/initialised.  The
+# mapping keys are strategy names while the values are the instantiated objects.
+LOADED_STRATEGIES: dict[str, Any] = {}
+
+
+def _supports_mode(strategy: Any, mode: str) -> bool:
+    """Return ``True`` if ``strategy`` declares compatibility with ``mode``.
+
+    Strategies may optionally expose a ``mode`` attribute (single value) or a
+    ``modes`` attribute (an iterable).  When neither is present, the strategy is
+    assumed to support all modes.
+    """
+
+    modes = getattr(strategy, "modes", None)
+    if modes is not None:
+        if isinstance(modes, str):
+            return modes == mode
+        return mode in set(modes)
+    s_mode = getattr(strategy, "mode", None)
+    if s_mode is None:
+        return True
+    if isinstance(s_mode, str):
+        return s_mode == mode
+    return mode in set(s_mode)
+
+
+async def _maybe_await(func: Callable[..., Any], *args, **kwargs) -> Any:
+    """Invoke ``func`` and await the result if it returns an awaitable."""
+
+    result = func(*args, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+async def initialize(symbols: list[str], mode: str = "cex") -> None:
+    """Load strategies and run their ``initialize`` hooks if present.
+
+    Parameters
+    ----------
+    symbols:
+        Symbols that strategies should operate on.
+    mode:
+        Execution mode, e.g. ``"cex"`` or ``"onchain"``.
+    """
+
+    global LOADED_STRATEGIES
+    LOADED_STRATEGIES = {}
+
+    try:
+        loaded = loader.load_strategies(mode)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Strategy loading failed")
+        loaded = []
+
+    for strategy in loaded:
+        if not _supports_mode(strategy, mode):
+            continue
+        name = getattr(strategy, "name", strategy.__class__.__name__)
+        init_hook = getattr(strategy, "initialize", None)
+        if callable(init_hook):
+            try:
+                sig = inspect.signature(init_hook)
+                if sig.parameters:
+                    await _maybe_await(init_hook, symbols)
+                else:  # pragma: no cover - rare case
+                    await _maybe_await(init_hook)
+            except Exception:
+                logger.exception("Strategy %s failed to initialise", name)
+                continue
+        LOADED_STRATEGIES[name] = strategy
+
+
+async def score(*, symbols: list[str], timeframes: list[str]) -> dict[str, float]:
+    """Return a mapping of strategy name to score.
+
+    Each loaded strategy is queried for a scoring function.  Supported attribute
+    names are ``score`` and ``generate_signal``.  The first numerical component
+    of the returned value is used as the score.
+    """
+
+    results: dict[str, float] = {}
+    for name, strategy in LOADED_STRATEGIES.items():
+        func: Callable[..., Any] | None = None
+        for attr in ("score", "generate_signal"):
+            func = getattr(strategy, attr, None)
+            if callable(func):
+                break
+        if not func:
+            continue
+        try:
+            res = await _maybe_await(func, symbols=symbols, timeframes=timeframes)
+            if isinstance(res, tuple):
+                res = res[0]
+            results[name] = float(res)
+        except Exception:
+            logger.exception("Strategy %s scoring failed", name)
+    return results
+
+
+# Re-export for backwards compatibility
+load_strategies = loader.load_strategies
+
+__all__ = ["load_strategies", "initialize", "score", "LOADED_STRATEGIES"]
+

--- a/tests/test_strategy_orchestration.py
+++ b/tests/test_strategy_orchestration.py
@@ -1,0 +1,63 @@
+import pytest
+
+from crypto_bot import strategies
+
+
+class SyncStrategy:
+    def __init__(self):
+        self.name = "sync"
+        self.initialized = False
+
+    def initialize(self, symbols):
+        self.initialized = True
+        self.symbols = symbols
+
+    def score(self, *, symbols, timeframes):
+        return 0.5
+
+
+class AsyncStrategy:
+    def __init__(self):
+        self.name = "async"
+        self.initialized = False
+
+    async def initialize(self, symbols):
+        self.initialized = True
+        self.symbols = symbols
+
+    async def generate_signal(self, *, symbols, timeframes):
+        return 0.9, "long"
+
+
+@pytest.mark.asyncio
+async def test_initialize_loads_strategies(monkeypatch):
+    sync = SyncStrategy()
+    async_strat = AsyncStrategy()
+    monkeypatch.setattr(
+        strategies.loader,
+        "load_strategies",
+        lambda *a, **k: [sync, async_strat],
+    )
+
+    strategies.LOADED_STRATEGIES.clear()
+    await strategies.initialize(["BTC/USD"], mode="cex")
+
+    assert set(strategies.LOADED_STRATEGIES) == {"sync", "async"}
+    assert sync.initialized and async_strat.initialized
+
+
+@pytest.mark.asyncio
+async def test_score_returns_mapping(monkeypatch):
+    sync = SyncStrategy()
+    async_strat = AsyncStrategy()
+    monkeypatch.setattr(
+        strategies.loader,
+        "load_strategies",
+        lambda *a, **k: [sync, async_strat],
+    )
+
+    strategies.LOADED_STRATEGIES.clear()
+    await strategies.initialize(["ETH/USD"], mode="cex")
+    scores = await strategies.score(symbols=["ETH/USD"], timeframes=["1m"])
+
+    assert scores and scores["sync"] == pytest.approx(0.5) and scores["async"] == pytest.approx(0.9)


### PR DESCRIPTION
## Summary
- manage loaded strategies in a central store with async initialize and score helpers
- call new strategy helpers from HFT loop with error handling
- regression tests for strategy initialization and scoring

## Testing
- `pytest tests/test_strategy_loader.py tests/test_strategy_orchestration.py tests/test_main_symbols.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a146feb3108330b3cc2285d71c7e3f