### PR TITLE
refactor legacy strategies init

### DIFF
--- a/crypto_bot/strategies/__init__.py
+++ b/crypto_bot/strategies/__init__.py
@@ -1,46 +1,31 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Iterable, Tuple
 import inspect
 import logging
+from typing import Any, Callable, Dict, Iterable, Tuple
+
 import pandas as pd
 
 log = logging.getLogger(__name__)
 
 # Optional OHLCV DataFrame provider supplied by the application. Strategies can
 # request recent price data via :func:`get_ohlcv_df`.
-_OHLCV_PROVIDER: Callable[[str, str, int], Any] | None = None
+_OHLCV_PROVIDER: Callable[[str, str, int], pd.DataFrame] | None = None
 
 
-def set_ohlcv_provider(provider: Callable[[str, str, int], Any]) -> None:
-    """Register a callable used to fetch OHLCV dataframes.
-
-    Parameters
-    ----------
-    provider:
-        Callable accepting ``(symbol, timeframe, limit)`` and returning a
-        :class:`pandas.DataFrame` with columns ``timestamp``, ``open``, ``high``,
-        ``low``, ``close`` and ``volume``.
-    """
+def set_ohlcv_provider(provider: Callable[[str, str, int], pd.DataFrame]) -> None:
+    """Register a function used to fetch OHLCV dataframes."""
 
     global _OHLCV_PROVIDER
     _OHLCV_PROVIDER = provider
 
 
-def get_ohlcv_df(symbol: str, timeframe: str, limit: int = 500):
+def get_ohlcv_df(symbol: str, timeframe: str, limit: int = 500) -> pd.DataFrame:
     """Return OHLCV data for ``symbol`` using the registered provider."""
+
     if _OHLCV_PROVIDER is None:
         raise RuntimeError("OHLCV provider not configured")
     return _OHLCV_PROVIDER(symbol, timeframe, limit)
-
-# Will be set by main.py to return a pandas.DataFrame for (symbol, timeframe, limit)
-_OHLCV_PROVIDER: Callable[[str, str, int], "pd.DataFrame"] | None = None
-
-
-def set_ohlcv_provider(provider: Callable[[str, str, int], "pd.DataFrame"]) -> None:
-    """Register a function: provider(symbol, timeframe, limit)->pd.DataFrame."""
-    global _OHLCV_PROVIDER
-    _OHLCV_PROVIDER = provider
 
 
 def _df(symbol: str, timeframe: str, limit: int = 500) -> pd.DataFrame | None:
@@ -152,13 +137,6 @@ def _maybe_await(func: Callable[..., Any] | None, *args, **kwargs) -> Any:
         log.exception("Strategy call failed")
         return {}
 
-__all__ = [
-    "load_strategies",
-    "initialize",
-    "score",
-    "LOADED_STRATEGIES",
-    "set_ohlcv_provider",
-    "get_ohlcv_df",
-]
 
-__all__ = ["score", "set_ohlcv_provider"]
+__all__ = ["score", "set_ohlcv_provider", "get_ohlcv_df"]
+


### PR DESCRIPTION
## Summary
- streamline strategies package init to remove legacy code
- provide typed OHLCV provider and compatibility scoring helper
- limit public API to essential functions

## Testing
- `pytest tests/test_strategy_adapter.py tests/test_strategy_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_68a203c73b2c8330820b34338fc0820d