### PR TITLE
Add early token assessment filter

### DIFF
--- a/crypto_bot/early_token_filter.py
+++ b/crypto_bot/early_token_filter.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""Utility to score newly issued tokens for early pump potential.
+
+The :func:`assess_early_token` coroutine aggregates lightweight on‑chain
+metrics, social sentiment, basic volume checks and an optional machine
+learning model from the optional ``coinTrader_Trainer`` package.  The
+resulting score ranges from ``0.0`` to ``1.0`` where higher values
+indicate a more attractive candidate for early trading.
+"""
+
+from typing import Any, Dict
+import asyncio
+
+import pandas as pd
+import requests
+
+from crypto_bot.sentiment_filter import fetch_twitter_sentiment_async
+from crypto_bot.utils.market_loader import fetch_geckoterminal_ohlcv
+from crypto_bot.utils.logger import LOG_DIR, setup_logger
+
+try:  # optional dependency
+    from coinTrader_Trainer.ml_trainer import load_model, predict_regime  # type: ignore
+except Exception:  # pragma: no cover - optional package missing
+    load_model = None  # type: ignore
+    predict_regime = None  # type: ignore
+
+logger = setup_logger(__name__, LOG_DIR / "early_assessment.log")
+
+
+async def assess_early_token(symbol: str, mint: str, cfg: Dict[str, Any]) -> float:
+    """Return an early pump score for ``symbol``.
+
+    The score combines:
+
+    * **On-chain checks** using Helius metadata (developer holdings,
+      initial liquidity).
+    * **Sentiment** from Twitter via :func:`fetch_twitter_sentiment_async`.
+    * **Recent volume** from GeckoTerminal OHLCV data.
+    * **Machine learning** prediction from ``coinTrader_Trainer`` when
+      available.
+
+    The final score ranges from ``0`` to ``1``.  Scores above ``0.6``
+    are considered promising candidates for further evaluation.
+    """
+
+    score = 0.0
+
+    # --- On-chain filters -------------------------------------------------
+    helius_api = cfg.get("helius_api_key")
+    if helius_api:
+        url = f"https://api.helius.xyz/v0/token-metadata?api-key={helius_api}&mints={mint}"
+        try:
+            resp = await asyncio.to_thread(requests.get, url, timeout=10)
+            data = resp.json().get(mint, {}) if resp.ok else {}
+        except Exception as exc:  # pragma: no cover - network best effort
+            logger.error("Helius token lookup failed for %s: %s", mint, exc)
+            data = {}
+
+        try:
+            dev_hold_pct = (
+                float(data.get("dev_holding", 0))
+                / float(data.get("total_supply", 1))
+                * 100.0
+            )
+        except Exception:
+            dev_hold_pct = 0.0
+
+        if dev_hold_pct > 20:  # Rug risk
+            return 0.0
+
+        try:
+            liquidity_usd = float(data.get("initial_liquidity_usd", 0) or 0.0)
+        except Exception:
+            liquidity_usd = 0.0
+
+        if liquidity_usd < 5_000:
+            return 0.0
+        score += 0.3 if liquidity_usd > 10_000 else 0.1
+
+    # --- Sentiment -------------------------------------------------------
+    try:
+        sentiment = await fetch_twitter_sentiment_async(query=symbol)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.error("Sentiment fetch failed for %s: %s", symbol, exc)
+        sentiment = 50
+    score += (sentiment / 100.0) * 0.3
+
+    # --- Volume via GeckoTerminal ---------------------------------------
+    vol_usd = 0.0
+    try:
+        ohlcv = await fetch_geckoterminal_ohlcv(f"{symbol}/USDC", limit=5)
+        if ohlcv:
+            vol_usd = float(ohlcv[-1][5])
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.error("GeckoTerminal fetch failed for %s: %s", symbol, exc)
+    if vol_usd > 10_000:
+        score += 0.2
+
+    # --- ML prediction ---------------------------------------------------
+    if load_model and predict_regime:
+        try:
+            model = load_model("regime_lgbm")
+            # Minimal feature set; additional features can be added as needed.
+            early_df = pd.DataFrame(
+                [{"volume": vol_usd, "sentiment": sentiment}]
+            )
+            regime_prob = predict_regime(early_df, model).get("volatile_pump", 0.0)
+            score += float(regime_prob) * 0.4
+        except Exception as exc:  # pragma: no cover - optional
+            logger.error("ML regime prediction failed for %s: %s", symbol, exc)
+
+    logger.info("Early score for %s: %.2f", symbol, score)
+    return float(score)
+
+
+__all__ = ["assess_early_token"]

--- a/tests/test_early_token_filter.py
+++ b/tests/test_early_token_filter.py
@@ -1,0 +1,74 @@
+import asyncio
+
+import pytest
+
+from crypto_bot.early_token_filter import assess_early_token
+
+
+async def _run(symbol, mint, cfg):
+    return await assess_early_token(symbol, mint, cfg)
+
+
+def test_assess_early_token_scoring(monkeypatch):
+    async def fake_sentiment(query: str):
+        assert query == "AAA"
+        return 80
+
+    async def fake_gecko(pair: str, limit: int = 5):
+        assert pair == "AAA/USDC"
+        return [[0, 1, 1, 1, 1, 20_000]]
+
+    def fake_load_model(name: str):
+        assert name == "regime_lgbm"
+        return object()
+
+    def fake_predict_regime(df, model):
+        return {"volatile_pump": 0.5}
+
+    monkeypatch.setattr(
+        "crypto_bot.early_token_filter.fetch_twitter_sentiment_async", fake_sentiment
+    )
+    monkeypatch.setattr(
+        "crypto_bot.early_token_filter.fetch_geckoterminal_ohlcv", fake_gecko
+    )
+    monkeypatch.setattr("crypto_bot.early_token_filter.load_model", fake_load_model)
+    monkeypatch.setattr("crypto_bot.early_token_filter.predict_regime", fake_predict_regime)
+
+    score = asyncio.run(_run("AAA", "mint", {}))
+
+    expected = (80 / 100) * 0.3 + 0.2 + 0.5 * 0.4
+    assert score == pytest.approx(expected)
+
+
+def test_assess_early_token_rejects_onchain(monkeypatch):
+    class DummyResp:
+        ok = True
+
+        def json(self):
+            return {
+                "mint": {
+                    "dev_holding": 30,
+                    "total_supply": 100,
+                    "initial_liquidity_usd": 10_000,
+                }
+            }
+
+    def fake_get(url, timeout=10):
+        return DummyResp()
+
+    monkeypatch.setattr("requests.get", fake_get)
+    monkeypatch.setattr(
+        "crypto_bot.early_token_filter.fetch_twitter_sentiment_async",
+        lambda *a, **k: 50,
+    )
+    monkeypatch.setattr(
+        "crypto_bot.early_token_filter.fetch_geckoterminal_ohlcv",
+        lambda *a, **k: [[0, 1, 1, 1, 1, 0]],
+    )
+    monkeypatch.setattr("crypto_bot.early_token_filter.load_model", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "crypto_bot.early_token_filter.predict_regime", lambda df, model: {"volatile_pump": 0}
+    )
+
+    score = asyncio.run(_run("AAA", "mint", {"helius_api_key": "k"}))
+    assert score == 0.0


### PR DESCRIPTION
## Summary
- add `assess_early_token` helper that scores new tokens using on-chain metrics, sentiment, volume and optional ML prediction
- cover scoring and rejection logic with unit tests

## Testing
- `pytest tests/test_early_token_filter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2097cc8648330bb332f75c600f48b