### PR TITLE
Log meme sniper actions to dedicated file

### DIFF
--- a/crypto_bot/strategy/meme_sniper.py
+++ b/crypto_bot/strategy/meme_sniper.py
@@ -17,14 +17,14 @@ import websockets
 from solana.rpc.async_api import AsyncClient
 
 from crypto_bot.strategy.sniper_solana import generate_signal
-from crypto_bot.utils.logger import setup_logger
+from crypto_bot.utils.logger import LOG_DIR, setup_logger
 from crypto_bot.utils.token_registry import (
     PUMP_FUN_PROGRAM,
     extract_mint_from_logs,
     get_symbol_from_mint,
 )
 
-logger = setup_logger(__name__)
+logger = setup_logger(__name__, LOG_DIR / "meme_sniper.log")
 
 
 async def monitor_pump_websocket(


### PR DESCRIPTION
## Summary
- route `meme_sniper` logging through project-wide LOG_DIR using a dedicated `meme_sniper.log`

## Testing
- `pytest tests/test_strategy_loader.py::test_strategy_loader` *(fails: not found: tests/test_strategy_loader.py::test_strategy_loader)*
- `pytest tests/test_strategy_loader.py::test_load_strategies_fallback`


------
https://chatgpt.com/codex/tasks/task_e_68a2283ff010833083c04c44b68e4299