### PR TITLE
Make OHLC provider async and cache results

### DIFF
--- a/tests/test_strategy_adapter.py
+++ b/tests/test_strategy_adapter.py
@@ -6,7 +6,7 @@ from crypto_bot import strategies
 
 @pytest.fixture(autouse=True)
 def _provider():
-    def provider(symbol: str, timeframe: str, limit: int = 500) -> pd.DataFrame:
+    async def provider(symbol: str, timeframe: str, limit: int = 500) -> pd.DataFrame:
         return pd.DataFrame({"close": [1, 2, 3]})
 
     strategies.set_ohlcv_provider(provider)


### PR DESCRIPTION
## Summary
- wrap blocking `exchange.fetch_ohlcv` in `asyncio.to_thread` and cache downloaded data
- let strategies await an async OHLC provider and use cached DataFrames
- update strategy adapter test for async provider

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*
- `pytest tests/test_strategy_adapter.py`
- manual dummy run logs "Top strategy scores"

------
https://chatgpt.com/codex/tasks/task_e_68a240f64d6483309d4bab0df7b69eea