### PR TITLE
Reduce redundant console output in status loop

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -2904,6 +2904,7 @@ async def _main_impl() -> MainResult:
         )
 
     async def status_loop() -> None:
+        last_line = ""
         while True:
             try:
                 balance = await fetch_balance(exchange, wallet, config)
@@ -2914,7 +2915,11 @@ async def _main_impl() -> MainResult:
             line = (
                 f"[Monitor] balance=${balance:,.2f} open={len(positions)} ({tickers})  last='{lastlog.last}'"
             )
-            print("\r" + line[:180].ljust(180), end="", flush=True)
+            out_line = line[:180]
+            if out_line != last_line:
+                sys.stdout.write("\r" + out_line.ljust(180))
+                sys.stdout.flush()
+                last_line = out_line
             await asyncio.sleep(5)
 
     register_task(asyncio.create_task(status_loop()))


### PR DESCRIPTION
## Summary
- avoid printing unchanged status lines by tracking the last line
- update display using `sys.stdout.write` with carriage return

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet'; 'crypto_bot' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68a254fa1e588330b1f2a68c90fad71f