### PR TITLE
Fix ambiguous ATR comparisons in sniper bot

### DIFF
--- a/crypto_bot/strategy/sniper_bot.py
+++ b/crypto_bot/strategy/sniper_bot.py
@@ -154,9 +154,13 @@ def generate_signal(
     avg_vol = prev_vol.mean() if not prev_vol.empty else 0.0
     body = abs(df["close"].iloc[-1] - df["open"].iloc[-1])
     event = False
-    if (atr is not None and atr > 0) and avg_vol > 0:
-        if body >= 2 * atr and df["volume"].iloc[-1] >= 2 * avg_vol:
+    atr_val: float | None = None
+    if atr is not None:
+        atr_val = float(atr.iloc[-1]) if hasattr(atr, "iloc") else float(atr)
+    if (atr_val is not None and atr_val > 0) and avg_vol > 0:
+        if body >= 2 * atr_val and df["volume"].iloc[-1] >= 2 * avg_vol:
             event = True
+    atr = atr_val
 
     if df["volume"].iloc[-1] < min_volume:
         logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
@@ -191,6 +195,10 @@ def generate_signal(
 
     if price_fallback:
         atr_value = volatility.calc_atr(df, period=atr_window, as_series=False)
+        if atr_value is not None and hasattr(atr_value, "iloc"):
+            atr_value = float(atr_value.iloc[-1])
+        elif atr_value is not None:
+            atr_value = float(atr_value)
         if atr_value is None or atr_value <= 0:
             logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
             return 0.0, "none", 0.0, event


### PR DESCRIPTION
## Summary
- Cast ATR results to float before comparisons in `sniper_bot` to avoid ambiguous Series truth-value errors
- Ensure fallback ATR computation also returns a scalar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `pytest tests/test_sniper_bot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3bd988c648330acddfea65ed16185