### PR TITLE
Guard dip_hunter ADX against short slices

### DIFF
--- a/crypto_bot/strategy/dip_hunter.py
+++ b/crypto_bot/strategy/dip_hunter.py
@@ -85,8 +85,8 @@ def generate_signal(
         return 0.0, "none"
 
     rsi = ta.momentum.rsi(recent["close"], window=rsi_window)
-    # Guard: need at least window+1 rows to compute a stable ADX in ta
-    if len(recent) < adx_window + 1:
+    # Need > window bars to compute ADX safely
+    if len(recent) <= adx_window:
         return 0.0, "none"
     adx = ADXIndicator(
         recent["high"], recent["low"], recent["close"], window=adx_window


### PR DESCRIPTION
## Summary
- prevent ADX calculation in dip_hunter when recent window is too short

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis'; No module named 'cointrainer'; SyntaxError in tests/test_initial_scan.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bdbbcc308330b1887449262d218d