### PR TITLE
Simplify momentum bot long logic and tests

### DIFF
--- a/tests/test_momentum_bot.py
+++ b/tests/test_momentum_bot.py
@@ -16,46 +16,52 @@ assert spec.loader is not None
 spec.loader.exec_module(momentum_bot)
 
 
-def _make_df(prices, volumes):
+def _make_df(length: int = 30) -> pd.DataFrame:
+    prices = list(range(length))
     return pd.DataFrame(
         {
             "open": prices,
             "high": [p + 1 for p in prices],
             "low": [p - 1 for p in prices],
             "close": prices,
-            "volume": volumes,
+            "volume": [100] * length,
         }
     )
 
 
-@pytest.fixture
-def breakout_df():
-    """Factory producing a Donchian breakout with optional volume spike."""
-
-    def _factory(volume_spike=True, breakout=True):
-        base = 100
-        prices = [base] * 25
-        prices.append(base + 2 if breakout else base)
-        volumes = [100] * 25 + ([300] if volume_spike else [100])
-        return _make_df(prices, volumes)
-
-    return _factory
-
-
-def test_breakout_with_volume_spike(breakout_df):
-    df = breakout_df()
-    score, direction = momentum_bot.generate_signal(df)
+def test_long_signal_macd(monkeypatch):
+    df = _make_df()
+    monkeypatch.setattr(
+        momentum_bot.ta.trend,
+        "macd",
+        lambda *args, **kwargs: pd.Series([1] * len(df)),
+    )
+    monkeypatch.setattr(
+        momentum_bot.ta.momentum,
+        "rsi",
+        lambda *args, **kwargs: pd.Series([30] * len(df)),
+    )
+    score, direction = momentum_bot.generate_signal(
+        df, config={"atr_normalization": False}
+    )
     assert direction == "long"
-    assert score > 0
+    assert score == pytest.approx(0.8)
 
 
-def test_no_signal_missing_conditions(breakout_df):
-    df_no_breakout = breakout_df(breakout=False)
-    score, direction = momentum_bot.generate_signal(df_no_breakout)
+def test_long_signal_rsi(monkeypatch):
+    df = _make_df()
+    monkeypatch.setattr(
+        momentum_bot.ta.trend,
+        "macd",
+        lambda *args, **kwargs: pd.Series([-1] * len(df)),
+    )
+    monkeypatch.setattr(
+        momentum_bot.ta.momentum,
+        "rsi",
+        lambda *args, **kwargs: pd.Series([60] * len(df)),
+    )
+    score, direction = momentum_bot.generate_signal(
+        df, config={"atr_normalization": False}
+    )
     assert direction == "long"
-    assert score > 0
-
-    df_no_volume = breakout_df(volume_spike=False)
-    score, direction = momentum_bot.generate_signal(df_no_volume)
-    assert direction == "long"
-    assert score > 0
+    assert score == pytest.approx(0.8)


### PR DESCRIPTION
## Summary
- Simplify momentum bot long signal to trigger when MACD > 0 or RSI > 50
- Remove breakout-based long checks and add logging
- Update momentum bot tests for MACD- or RSI-driven long signals

## Testing
- `pytest tests/test_momentum_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3bd7fe0988330a4cf4a7e65fd4b26