### PR TITLE
Handle missing regime models gracefully

### DIFF
--- a/crypto_bot/regime/registry.py
+++ b/crypto_bot/regime/registry.py
@@ -1,10 +1,18 @@
+"""Regime model loading utilities.
+
+This module provides a small helper to fetch the latest regime model from
+Supabase storage.  The function is resilient: if the Supabase dependency is not
+available or the expected files cannot be retrieved the code gracefully falls
+back to a built-in heuristic model.
+"""
+
 from __future__ import annotations
 
 import hashlib
 import json
-import os
 import logging
-from typing import Any, Tuple, Dict
+import os
+from typing import Any, Dict, Tuple
 
 from .ml_fallback import load_model as _load_fallback
 
@@ -16,15 +24,10 @@ _no_model_logged = False
 def load_latest_regime(symbol: str) -> Tuple[Any, Dict]:
     """Load the most recent regime model for ``symbol``.
 
-    The function attempts to fetch model metadata from Supabase storage.  The
-    metadata file (``LATEST.json``) is expected to contain a pointer to the
-    model binary and optionally its SHA256 hash.  When the metadata file is not
-    found the function looks for a direct model file named
-    ``<symbol_lower>_regime_lgbm.pkl`` (customisable via the
-    ``CT_REGIME_MODEL_TEMPLATE`` environment variable).  If neither the
-    metadata nor the direct file can be retrieved the embedded fallback model
-    is returned and a single info message is logged.  Other failures are raised
-    so callers can handle them separately.
+    The function first attempts to download ``LATEST.json`` from the Supabase
+    bucket which points to the actual model file and optionally contains a
+    SHA256 checksum.  When the metadata or model file is missing the code tries a
+    direct path and finally falls back to the embedded heuristic model.
     """
 
     bucket = os.environ.get("CT_MODELS_BUCKET", "models")
@@ -34,7 +37,8 @@ def load_latest_regime(symbol: str) -> Tuple[Any, Dict]:
         "{prefix}/{symbol}/{symbol_lower}_regime_lgbm.pkl",
     )
 
-    try:  # pragma: no cover - network and optional dependency
+    client = None
+    try:  # pragma: no cover - optional dependency and network access
         from supabase import create_client  # type: ignore
 
         url = os.environ["SUPABASE_URL"]
@@ -43,8 +47,8 @@ def load_latest_regime(symbol: str) -> Tuple[Any, Dict]:
             or os.environ.get("SUPABASE_SERVICE_KEY")
             or os.environ["SUPABASE_KEY"]
         )
-
         client = create_client(url, key)
+
         latest_key = f"{prefix}/{symbol}/LATEST.json"
         meta_bytes = client.storage.from_(bucket).download(latest_key)
         meta = json.loads(meta_bytes.decode("utf-8"))
@@ -58,30 +62,34 @@ def load_latest_regime(symbol: str) -> Tuple[Any, Dict]:
     except Exception as exc:
         status = getattr(getattr(exc, "response", None), "status_code", None)
         msg = str(getattr(exc, "message", exc))
-        if status == 404 or "404" in str(exc) or "not_found" in msg:
-            try:
-                direct_key = f"{prefix}/{symbol}/{symbol.lower()}_regime_lgbm.pkl"
-                blob = client.storage.from_(bucket).download(direct_key)
-                return blob, {}
-            except Exception:
-        if status == 404 or "404" in str(exc):
-            try:
-                direct_key = template.format(
+        not_found = status == 404 or "404" in str(exc) or "not_found" in msg
+
+        if client and not_found:
+            for direct_key in (
+                f"{prefix}/{symbol}/{symbol.lower()}_regime_lgbm.pkl",
+                template.format(
                     prefix=prefix, symbol=symbol, symbol_lower=symbol.lower()
-                )
-                blob = client.storage.from_(bucket).download(direct_key)
-                return blob, {}
-            except Exception as exc2:  # pragma: no cover - network
-                status2 = getattr(getattr(exc2, "response", None), "status_code", None)
-                if status2 != 404 and "404" not in str(exc2):
-                    raise
-                global _no_model_logged
-                if not _no_model_logged:
-                    logger.info(
-                        "No regime model found in bucket '%s/%s' — falling back to heuristics (this is OK for live trading)",
-                        bucket,
-                        prefix,
+                ),
+            ):
+                try:
+                    blob = client.storage.from_(bucket).download(direct_key)
+                    return blob, {}
+                except Exception as exc2:  # pragma: no cover - network
+                    status2 = getattr(
+                        getattr(exc2, "response", None), "status_code", None
                     )
-                    _no_model_logged = True
-                return _load_fallback(), {}
+                    if status2 != 404 and "404" not in str(exc2):
+                        raise
+
+        if not_found or client is None:
+            global _no_model_logged
+            if not _no_model_logged:
+                logger.info(
+                    "No regime model found in bucket '%s/%s' — falling back to heuristics (this is OK for live trading)",
+                    bucket,
+                    prefix,
+                )
+                _no_model_logged = True
+            return _load_fallback(), {}
         raise
+


### PR DESCRIPTION
## Summary
- simplify regime model registry and avoid undefined `client`
- fall back to heuristic model when Supabase model files are missing

## Testing
- `pytest tests/test_regime_registry.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68a3c3743c288330bf1bace06129201e