### PR TITLE
Ensure load_ohlcv passes keyword args to to_thread

### DIFF
--- a/crypto_bot/utils/market_loader.py
+++ b/crypto_bot/utils/market_loader.py
@@ -1413,7 +1413,9 @@ async def load_ohlcv(
             if asyncio.iscoroutinefunction(fetch_fn):
                 coro = fetch_fn(market_id, timeframe=timeframe, limit=limit, **kwargs)
             else:  # pragma: no cover - synchronous fallback
-                coro = asyncio.to_thread(fetch_fn, market_id, timeframe, limit, **kwargs)
+                coro = asyncio.to_thread(
+                    fetch_fn, market_id, timeframe=timeframe, limit=limit, **kwargs
+                )
             data = await asyncio.wait_for(coro, timeout)
             record_io()
             await asyncio.sleep(1)


### PR DESCRIPTION
## Summary
- avoid misinterpreting arguments when calling synchronous `fetch_ohlcv`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*


------
https://chatgpt.com/codex/tasks/task_e_68a3d397fb308330973a43c6f4819e76