### PR TITLE
Limit OHLCV parallel requests to safe default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,7 +1280,7 @@ symbol_filter:
   http_timeout: 10               # seconds for fallback /Ticker requests
   ticker_retry_attempts: 3       # number of fetch_tickers retries
   log_ticker_exceptions: false   # include stack traces when true
-max_concurrent_ohlcv: 2          # simultaneous OHLCV requests during startup
+max_concurrent_ohlcv: 10         # simultaneous OHLCV requests during startup
   max_concurrent_tickers: 20       # simultaneous ticker requests
   ticker_rate_limit: 0             # ms delay after each ticker request
   ticker_backoff_initial: 2        # seconds after first failure
@@ -1303,7 +1303,8 @@ symbol_filter:
 ```
 
 `max_concurrent_ohlcv` controls how many OHLCV requests are made in parallel
-during the startup scan. It defaults to `2`, keeping API usage modest.
+during the startup scan. It defaults to `10` but can be overridden in
+`config.yaml` to stay within Kraken's connection pool capacity.
 `initial_timeframes` lists the intervals preloaded before trading begins. When
 omitted it falls back to the `timeframes` list (1m, 5m, 15m and 1h by
 default; Coinbase does not offer 4h candles). `initial_history_candles` sets how many bars to download for each of

--- a/crypto_bot/utils/market_loader.py
+++ b/crypto_bot/utils/market_loader.py
@@ -221,6 +221,8 @@ REST_OHLCV_TIMEOUT = 90
 MAX_OHLCV_FAILURES = 10
 MAX_WS_LIMIT = 500
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
+# Cap simultaneous OHLCV requests to stay within Kraken's connection pool.
+DEFAULT_MAX_CONCURRENT_OHLCV = 10
 STATUS_UPDATES = True
 # Per-timeframe locks are provided by crypto_bot.data.locks
 
@@ -1454,6 +1456,10 @@ async def load_ohlcv_parallel(
     ----------
     notifier : TelegramNotifier | None, optional
         If provided, failures will be sent using this notifier.
+    max_concurrent : int | None, optional
+        Maximum number of simultaneous OHLCV requests. If ``None``, the
+        ``max_concurrent_ohlcv`` value from ``config.yaml`` is used when
+        available, otherwise a default of ``10`` is applied.
     """
     if use_websocket or force_websocket_history:
         logger.debug(
@@ -1514,12 +1520,20 @@ async def load_ohlcv_parallel(
     if not symbols:
         return data
 
-    if max_concurrent is not None:
-        if not isinstance(max_concurrent, int) or max_concurrent < 1:
-            raise ValueError("max_concurrent must be a positive integer or None")
-        sem = asyncio.Semaphore(max_concurrent)
-    else:
-        sem = None
+    if max_concurrent is None:
+        try:
+            with open(CONFIG_PATH) as f:
+                cfg = yaml.safe_load(f) or {}
+            cfg_val = cfg.get("max_concurrent_ohlcv")
+            if cfg_val is not None:
+                max_concurrent = int(cfg_val)
+        except Exception:
+            pass
+        if max_concurrent is None:
+            max_concurrent = DEFAULT_MAX_CONCURRENT_OHLCV
+    if not isinstance(max_concurrent, int) or max_concurrent < 1:
+        raise ValueError("max_concurrent must be a positive integer or None")
+    sem = asyncio.Semaphore(max_concurrent)
 
     async def sem_fetch(sym: str):
         async def _fetch_and_sleep():


### PR DESCRIPTION
## Summary
- Limit `load_ohlcv_parallel` to 10 concurrent requests by default to avoid exceeding Kraken's pool
- Allow `max_concurrent_ohlcv` in `config.yaml` to override the default and document it

## Testing
- `pytest tests/test_market_loader.py::test_load_ohlcv_parallel tests/test_market_loader.py::test_load_ohlcv_parallel_skips_unsupported_symbol tests/test_market_loader.py::test_load_ohlcv_parallel_invalid_max_concurrent -q`
- `pytest tests/test_market_loader.py::test_load_ohlcv_parallel_respects_max_concurrent -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3d39b95e48330b437f999c10fee24