### PR TITLE
Allow strategies to accept symbol and timeframe arguments

### DIFF
--- a/crypto_bot/strategies/__init__.py
+++ b/crypto_bot/strategies/__init__.py
@@ -31,7 +31,16 @@ async def _invoke_strategy(gen: Callable, **kwargs):
     except TypeError:
         # Some older strategies are df-only; try that before failing.
         if "df" in kwargs:
-            return await _maybe_await(gen(kwargs["df"]))
+            try:
+                return await _maybe_await(
+                    gen(
+                        kwargs["df"],
+                        kwargs.get("symbol"),
+                        kwargs.get("timeframe"),
+                    )
+                )
+            except TypeError:
+                return await _maybe_await(gen(kwargs["df"]))
         raise
 
 

--- a/crypto_bot/strategy/bounce_scalper.py
+++ b/crypto_bot/strategy/bounce_scalper.py
@@ -198,7 +198,7 @@ def generate_signal(
     force: bool = False,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Identify short-term bounces with volume confirmation.
 

--- a/crypto_bot/strategy/breakout.py
+++ b/crypto_bot/strategy/breakout.py
@@ -18,7 +18,7 @@ def generate_signal(
     config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str, float]:
     """Selective breakout strategy with compression and volume filters.
 
@@ -28,6 +28,12 @@ def generate_signal(
         Input OHLCV data on a 5m timeframe.
     config : dict, optional
         Configuration containing a ``breakout`` section with parameters.
+    symbol : str, optional
+        Asset symbol for the data. Unused but accepted for compatibility.
+    timeframe : str, optional
+        Candle timeframe for ``df``. Unused but accepted for compatibility.
+    **kwargs : dict
+        Additional keyword arguments for forward compatibility.
 
     Returns
     -------

--- a/crypto_bot/strategy/breakout_bot.py
+++ b/crypto_bot/strategy/breakout_bot.py
@@ -108,7 +108,7 @@ def generate_signal(
     higher_df: Optional[pd.DataFrame] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str] | Tuple[float, str, float]:
     """Breakout strategy using Bollinger/Keltner squeeze confirmation.
 

--- a/crypto_bot/strategy/cross_chain_arb_bot.py
+++ b/crypto_bot/strategy/cross_chain_arb_bot.py
@@ -31,7 +31,7 @@ def generate_signal(
     mempool_cfg: Optional[Mapping[str, object]] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return arbitrage signal comparing CEX OHLCV data to Solana prices."""
     if df is None or df.empty:

--- a/crypto_bot/strategy/dca_bot.py
+++ b/crypto_bot/strategy/dca_bot.py
@@ -9,7 +9,7 @@ def generate_signal(
     config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Simple dollar-cost averaging signal supporting long and short."""
     if df is None or df.empty or "close" not in df:

--- a/crypto_bot/strategy/dex_scalper.py
+++ b/crypto_bot/strategy/dex_scalper.py
@@ -19,7 +19,7 @@ def generate_signal(
     mempool_monitor: Optional[SolanaMempoolMonitor] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Short-term momentum strategy using EMA divergence on DEX pairs.
 

--- a/crypto_bot/strategy/flash_crash_bot.py
+++ b/crypto_bot/strategy/flash_crash_bot.py
@@ -11,7 +11,7 @@ def generate_signal(
     config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return long signal on sudden drops with high volume."""
     if df is None or len(df) < 2:

--- a/crypto_bot/strategy/grid_bot.py
+++ b/crypto_bot/strategy/grid_bot.py
@@ -186,7 +186,7 @@ def generate_signal(
     timeframe: str | None = None,
     mempool_monitor: SolanaMempoolMonitor | None = None,
     mempool_cfg: dict | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Generate a grid based trading signal."""
     cfg = GridConfig.from_dict(_as_dict(config))

--- a/crypto_bot/strategy/lstm_bot.py
+++ b/crypto_bot/strategy/lstm_bot.py
@@ -25,7 +25,7 @@ def generate_signal(
     config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return LSTM-based momentum signal."""
     if df is None or df.empty:

--- a/crypto_bot/strategy/mean_bot.py
+++ b/crypto_bot/strategy/mean_bot.py
@@ -50,7 +50,7 @@ async def generate_signal(
     config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Score mean reversion opportunities using multiple indicators."""
 

--- a/crypto_bot/strategy/mean_revert.py
+++ b/crypto_bot/strategy/mean_revert.py
@@ -46,7 +46,7 @@ def generate_signal(
     spread_bp: float = 0.0,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str, Optional[float], Optional[Position]]:
     """Mean-reversion strategy with ATR stop and time/z exits.
 

--- a/crypto_bot/strategy/meme_wave_bot.py
+++ b/crypto_bot/strategy/meme_wave_bot.py
@@ -49,7 +49,7 @@ async def generate_signal(
     mempool_cfg: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return a meme wave score and direction using volume and sentiment."""
 

--- a/crypto_bot/strategy/micro_scalp_bot.py
+++ b/crypto_bot/strategy/micro_scalp_bot.py
@@ -60,7 +60,7 @@ def generate_signal(
     tick_data: pd.DataFrame | None = None,
     book: Optional[dict] = None,
     ticks: Optional[pd.DataFrame] = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return short-term signal using EMA crossover on 1m data.
 
@@ -77,14 +77,20 @@ def generate_signal(
         Higher timeframe OHLCV data used to confirm the trend. When provided
         the function only returns a signal if ``trend_fast`` is above
         ``trend_slow`` for longs (and vice versa for shorts).
-    book : dict, optional
-        Order book data with ``bids`` and ``asks`` arrays.
-    ticks : pd.DataFrame, optional
-        Optional tick-level data with ``price`` and optional ``volume`` columns.
+    symbol : str, optional
+        Asset symbol for the data. Unused but accepted for compatibility.
+    timeframe : str, optional
+        Candle timeframe of ``df``. Unused but accepted for compatibility.
     mempool_monitor : SolanaMempoolMonitor, optional
         Instance used to monitor the Solana priority fee.
     mempool_cfg : dict, optional
         Configuration controlling the mempool fee check.
+    tick_data : pd.DataFrame, optional
+        Additional tick data to append before generating the signal.
+    book : dict, optional
+        Order book data with ``bids`` and ``asks`` arrays.
+    ticks : pd.DataFrame, optional
+        Optional tick-level data with ``price`` and optional ``volume`` columns.
     
     Additional config options
     -------------------------

--- a/crypto_bot/strategy/momentum_bot.py
+++ b/crypto_bot/strategy/momentum_bot.py
@@ -30,7 +30,7 @@ def generate_signal(
     config: dict | None = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Donchian breakout with volume confirmation."""
     if df is None or df.empty:

--- a/crypto_bot/strategy/range_arb_bot.py
+++ b/crypto_bot/strategy/range_arb_bot.py
@@ -64,7 +64,7 @@ def generate_signal(
     config: dict | None = None,
     symbol: Optional[str] = None,
     timeframe: Optional[str] = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Generate arb signal using kernel prediction.
 

--- a/crypto_bot/strategy/sniper_bot.py
+++ b/crypto_bot/strategy/sniper_bot.py
@@ -43,7 +43,7 @@ def generate_signal(
     price_fallback: bool = True,
     fallback_atr_mult: float = 1.5,
     fallback_volume_mult: float = 1.2,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str, float, bool]:
     """Detect pumps for newly listed tokens using early price and volume action.
 
@@ -53,6 +53,10 @@ def generate_signal(
         OHLCV data ordered oldest -> newest.
     config : dict, optional
         Configuration values overriding the keyword defaults.
+    symbol : str, optional
+        Asset symbol for the provided data.
+    timeframe : str, optional
+        Candle timeframe for ``df``.
     breakout_pct : float, optional
         Minimum percent change from the first close considered a breakout.
     volume_multiple : float, optional

--- a/crypto_bot/strategy/stat_arb_bot.py
+++ b/crypto_bot/strategy/stat_arb_bot.py
@@ -36,7 +36,7 @@ def generate_signal(
     config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return (score, direction) based on the price spread z-score."""
     if df_a is None or df_b is None or df_a.empty or df_b.empty:

--- a/crypto_bot/strategy/trend_bot.py
+++ b/crypto_bot/strategy/trend_bot.py
@@ -50,7 +50,7 @@ def generate_signal(
     config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Trend following signal with ADX, volume and optional Donchian filters."""
     config = config or {}


### PR DESCRIPTION
## Summary
- add optional `symbol` and `timeframe` parameters with `**kwargs` to strategy `generate_signal`
- forward symbol and timeframe through `_invoke_strategy`
- document new parameters where signatures are shown

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager')*


------
https://chatgpt.com/codex/tasks/task_e_68a3e155061483308ff2c2fa91611f41