### PR TITLE
Standardize generate_signal signatures

### DIFF
--- a/crypto_bot/strategy/bounce_scalper.py
+++ b/crypto_bot/strategy/bounce_scalper.py
@@ -190,21 +190,27 @@ def confirm_lower_highs(df: pd.DataFrame, bars: int) -> bool:
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[Union[dict, BounceScalperConfig]] = None,
-    *,
-    lower_df: Optional[pd.DataFrame] = None,
-    fetcher: Optional[Callable[[str], pd.DataFrame]] = None,
-    book: Optional[dict] = None,
-    force: bool = False,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Identify short-term bounces with volume confirmation.
 
     Setting ``force=True`` bypasses the cooldown and recent win-rate filters
     for a single invocation.
     """
+    if isinstance(symbol, (dict, BounceScalperConfig)) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+    lower_df = kwargs.get("lower_df")
+    fetcher = kwargs.get("fetcher")
+    book = kwargs.get("book")
+    force = kwargs.get("force", False)
+
     if df.empty:
         return 0.0, "none"
 

--- a/crypto_bot/strategy/breakout.py
+++ b/crypto_bot/strategy/breakout.py
@@ -15,10 +15,9 @@ logger = logging.getLogger(__name__)
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str, float]:
     """Selective breakout strategy with compression and volume filters.
 
@@ -34,6 +33,14 @@ def generate_signal(
     Tuple[float, str, float]
         ``(score, direction, atr)`` where ``score`` is 1 on signal, 0 otherwise.
     """
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+
     if df is None or df.empty:
         logger.info(
             "signal=breakout side=none reason=insufficient_data vol_z=nan bbw_pct=nan"

--- a/crypto_bot/strategy/breakout_bot.py
+++ b/crypto_bot/strategy/breakout_bot.py
@@ -104,11 +104,9 @@ def _squeeze(
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
-    higher_df: Optional[pd.DataFrame] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str] | Tuple[float, str, float]:
     """Breakout strategy using Bollinger/Keltner squeeze confirmation.
 
@@ -126,6 +124,15 @@ def generate_signal(
         Otherwise it returns ``(score, direction, atr)`` where ``atr`` is the
         most recent Average True Range value.
     """
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+    higher_df: Optional[pd.DataFrame] = kwargs.get("higher_df")
+
     if df is None or df.empty:
         return (0.0, "none") if higher_df is not None else (0.0, "none", 0.0)
 

--- a/crypto_bot/strategy/cross_chain_arb_bot.py
+++ b/crypto_bot/strategy/cross_chain_arb_bot.py
@@ -25,19 +25,24 @@ def _fetch_prices(symbols: List[str]) -> Dict[str, float]:
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[Mapping[str, object]] = None,
-    *,
-    mempool_monitor: Optional[SolanaMempoolMonitor] = None,
-    mempool_cfg: Optional[Mapping[str, object]] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return arbitrage signal comparing CEX OHLCV data to Solana prices."""
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config") or {}
+    mempool_monitor: Optional[SolanaMempoolMonitor] = kwargs.get("mempool_monitor")
+    mempool_cfg: Optional[Mapping[str, object]] = kwargs.get("mempool_cfg")
+
     if df is None or df.empty:
         return 0.0, "none"
 
-    config = config or {}
     params = config.get("cross_chain_arb_bot", {})
     pair = str(params.get("pair", ""))
     try:

--- a/crypto_bot/strategy/dca_bot.py
+++ b/crypto_bot/strategy/dca_bot.py
@@ -6,12 +6,17 @@ NAME = "dca_bot"
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Simple dollar-cost averaging signal supporting long and short."""
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
     if df is None or df.empty or "close" not in df:
         return 0.0, "none"
 

--- a/crypto_bot/strategy/dex_scalper.py
+++ b/crypto_bot/strategy/dex_scalper.py
@@ -14,12 +14,9 @@ ALLOWED_PAIRS = load_liquid_pairs() or []
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
-    *,
-    mempool_monitor: Optional[SolanaMempoolMonitor] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Short-term momentum strategy using EMA divergence on DEX pairs.
 
@@ -27,6 +24,15 @@ def generate_signal(
     used. If not provided, the ``MOCK_PRIORITY_FEE`` environment variable can
     define the fee for testing.
     """
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+    mempool_monitor: Optional[SolanaMempoolMonitor] = kwargs.get("mempool_monitor")
+
     if df.empty:
         return 0.0, "none"
 

--- a/crypto_bot/strategy/dip_hunter.py
+++ b/crypto_bot/strategy/dip_hunter.py
@@ -28,8 +28,6 @@ else:  # pragma: no cover - fallback
 
 def generate_signal(
     df: pd.DataFrame,
-    higher_df: pd.DataFrame | None = None,
-    config: dict | None = None,
     symbol: str | None = None,
     timeframe: str | None = None,
     **kwargs,
@@ -48,10 +46,14 @@ def generate_signal(
         May contain ``higher_df`` and ``config`` for advanced behaviour.
     """
 
-    if higher_df is None:
-        higher_df = kwargs.get("higher_df")
-    if config is None:
-        config = kwargs.get("config")
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    higher_df = kwargs.get("higher_df")
+    config = kwargs.get("config")
 
     symbol = symbol or (config.get("symbol", "") if config else "")
     params = config.get("dip_hunter", {}) if config else {}

--- a/crypto_bot/strategy/flash_crash_bot.py
+++ b/crypto_bot/strategy/flash_crash_bot.py
@@ -8,12 +8,18 @@ NAME = "flash_crash_bot"
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return long signal on sudden drops with high volume."""
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
     if df is None or len(df) < 2:
         return 0.0, "none"
 

--- a/crypto_bot/strategy/grid_bot.py
+++ b/crypto_bot/strategy/grid_bot.py
@@ -178,17 +178,23 @@ def is_in_trend(df: pd.DataFrame, fast: int, slow: int, side: str) -> bool:
 
 def generate_signal(
     df: pd.DataFrame,
-    num_levels: int | None = None,
-    config: ConfigType = None,
-    higher_df: pd.DataFrame | None = None,
-    *,
     symbol: str | None = None,
     timeframe: str | None = None,
-    mempool_monitor: SolanaMempoolMonitor | None = None,
-    mempool_cfg: dict | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Generate a grid based trading signal."""
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+    num_levels: int | None = kwargs.get("num_levels")
+    higher_df: pd.DataFrame | None = kwargs.get("higher_df")
+    mempool_monitor: SolanaMempoolMonitor | None = kwargs.get("mempool_monitor")
+    mempool_cfg: dict | None = kwargs.get("mempool_cfg")
+
     cfg = GridConfig.from_dict(_as_dict(config))
 
     if num_levels is None:

--- a/crypto_bot/strategy/lstm_bot.py
+++ b/crypto_bot/strategy/lstm_bot.py
@@ -22,12 +22,19 @@ else:  # pragma: no cover - fallback
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return LSTM-based momentum signal."""
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+
     if df is None or df.empty:
         return 0.0, "none"
 

--- a/crypto_bot/strategy/mean_bot.py
+++ b/crypto_bot/strategy/mean_bot.py
@@ -47,14 +47,19 @@ else:  # pragma: no cover - fallback
 
 async def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Score mean reversion opportunities using multiple indicators."""
 
-    config = config or {}
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config") or {}
     symbol = config.get("symbol", "")
     adx_window = 14
     min_bars = max(50, adx_window + 1)

--- a/crypto_bot/strategy/mean_revert.py
+++ b/crypto_bot/strategy/mean_revert.py
@@ -40,13 +40,9 @@ class Config:
 
 def generate_signal(
     df: pd.DataFrame,
-    position: Optional[Position] = None,
-    config: Optional[dict] = None,
-    *,
-    spread_bp: float = 0.0,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str, Optional[float], Optional[Position]]:
     """Mean-reversion strategy with ATR stop and time/z exits.
 
@@ -55,6 +51,19 @@ def generate_signal(
     suggested stop loss for new entries.  ``new_position`` describes the
     position after taking the action and should be persisted by the caller.
     """
+
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    elif symbol is not None and not isinstance(symbol, str):
+        kwargs.setdefault("position", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    position: Optional[Position] = kwargs.get("position")
+    config = kwargs.get("config")
+    spread_bp: float = kwargs.get("spread_bp", 0.0)
 
     if df is None or df.empty:
         return 0.0, "none", None, position

--- a/crypto_bot/strategy/meme_wave_bot.py
+++ b/crypto_bot/strategy/meme_wave_bot.py
@@ -43,15 +43,21 @@ async def exit_trade(price_feed, entry_price: float, cfg: Mapping[str, float]) -
 
 async def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
-    *,
-    mempool_monitor: Optional[SolanaMempoolMonitor] = None,
-    mempool_cfg: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return a meme wave score and direction using volume and sentiment."""
+
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+    mempool_monitor: Optional[SolanaMempoolMonitor] = kwargs.get("mempool_monitor")
+    mempool_cfg: Optional[dict] = kwargs.get("mempool_cfg")
 
     if mempool_monitor is None:
         return 0.0, "none"

--- a/crypto_bot/strategy/micro_scalp_bot.py
+++ b/crypto_bot/strategy/micro_scalp_bot.py
@@ -50,17 +50,9 @@ def _wick_ratios(row: pd.Series) -> Tuple[float, float]:
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
-    higher_df: pd.DataFrame | None = None,
-    *,
     symbol: str | None = None,
     timeframe: str | None = None,
-    mempool_monitor: Optional[SolanaMempoolMonitor] = None,
-    mempool_cfg: Optional[dict] = None,
-    tick_data: pd.DataFrame | None = None,
-    book: Optional[dict] = None,
-    ticks: Optional[pd.DataFrame] = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return short-term signal using EMA crossover on 1m data.
 
@@ -97,6 +89,20 @@ def generate_signal(
     ``trend_filter``
         When ``false`` the higher timeframe EMA confirmation is ignored.
     """
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+    higher_df = kwargs.get("higher_df")
+    mempool_monitor: Optional[SolanaMempoolMonitor] = kwargs.get("mempool_monitor")
+    mempool_cfg: Optional[dict] = kwargs.get("mempool_cfg")
+    tick_data: pd.DataFrame | None = kwargs.get("tick_data")
+    book: Optional[dict] = kwargs.get("book")
+    ticks: Optional[pd.DataFrame] = kwargs.get("ticks")
+
     if tick_data is not None and not tick_data.empty:
         df = pd.concat(
             [df.reset_index(drop=True), tick_data.reset_index(drop=True)],

--- a/crypto_bot/strategy/momentum_bot.py
+++ b/crypto_bot/strategy/momentum_bot.py
@@ -27,12 +27,19 @@ else:  # pragma: no cover - fallback
 
 def generate_signal(
     df: pd.DataFrame,
-    config: dict | None = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Donchian breakout with volume confirmation."""
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+
     if df is None or df.empty:
         return 0.0, "none"
 

--- a/crypto_bot/strategy/range_arb_bot.py
+++ b/crypto_bot/strategy/range_arb_bot.py
@@ -61,16 +61,23 @@ def kernel_regression(df: pd.DataFrame, window: int) -> float:
 
 def generate_signal(
     df: pd.DataFrame,
-    config: dict | None = None,
     symbol: Optional[str] = None,
     timeframe: Optional[str] = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Generate arb signal using kernel prediction.
 
     The strategy can run in any market regime, but trades are only taken
     when low volatility conditions are detected.
     """
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+
     if df.empty:
         return 0.0, "none"
 

--- a/crypto_bot/strategy/sniper_bot.py
+++ b/crypto_bot/strategy/sniper_bot.py
@@ -27,23 +27,9 @@ else:  # pragma: no cover - fallback
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[Dict[str, float | int | str]] = None,
-    *,
     symbol: str | None = None,
     timeframe: str | None = None,
-    breakout_pct: float = 0.01,
-    volume_multiple: float = 1.2,
-    max_history: int = 30,
-    initial_window: int = 3,
-    min_volume: float = 100.0,
-    direction: str = "auto",
-    high_freq: bool = False,
-    atr_window: int = 14,
-    volume_window: int = 5,
-    price_fallback: bool = True,
-    fallback_atr_mult: float = 1.5,
-    fallback_volume_mult: float = 1.2,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str, float, bool]:
     """Detect pumps for newly listed tokens using early price and volume action.
 
@@ -89,6 +75,27 @@ def generate_signal(
     Tuple[float, str, float, bool]
         Score between 0 and 1, trade direction, ATR value and event flag.
     """
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+
+    breakout_pct = kwargs.get("breakout_pct", 0.01)
+    volume_multiple = kwargs.get("volume_multiple", 1.2)
+    max_history = kwargs.get("max_history", 30)
+    initial_window = kwargs.get("initial_window", 3)
+    min_volume = kwargs.get("min_volume", 100.0)
+    direction = kwargs.get("direction", "auto")
+    high_freq = kwargs.get("high_freq", False)
+    atr_window = kwargs.get("atr_window", 14)
+    volume_window = kwargs.get("volume_window", 5)
+    price_fallback = kwargs.get("price_fallback", True)
+    fallback_atr_mult = kwargs.get("fallback_atr_mult", 1.5)
+    fallback_volume_mult = kwargs.get("fallback_volume_mult", 1.2)
+
     symbol = symbol or (config.get("symbol", "unknown") if config else "unknown")
     timeframe = timeframe or (config.get("timeframe") if config else None)
     if (

--- a/crypto_bot/strategy/stat_arb_bot.py
+++ b/crypto_bot/strategy/stat_arb_bot.py
@@ -33,17 +33,30 @@ _CORRELATION_THRESHOLD = 0.8
 def generate_signal(
     df_a: pd.DataFrame,
     df_b: pd.DataFrame,
-    config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return (score, direction) based on the price spread z-score."""
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+
     if df_a is None or df_b is None or df_a.empty or df_b.empty:
         return 0.0, "none"
 
-    threshold = float(config.get("zscore_threshold", _ZSCORE_THRESHOLD_DEFAULT)) if config else _ZSCORE_THRESHOLD_DEFAULT
-    lookback = int(config.get("lookback", _LOOKBACK_DEFAULT)) if config else _LOOKBACK_DEFAULT
+    threshold = (
+        float(config.get("zscore_threshold", _ZSCORE_THRESHOLD_DEFAULT))
+        if config
+        else _ZSCORE_THRESHOLD_DEFAULT
+    )
+    lookback = (
+        int(config.get("lookback", _LOOKBACK_DEFAULT)) if config else _LOOKBACK_DEFAULT
+    )
 
     if len(df_a) < lookback or len(df_b) < lookback:
         return 0.0, "none"

--- a/crypto_bot/strategy/trend_bot.py
+++ b/crypto_bot/strategy/trend_bot.py
@@ -47,13 +47,18 @@ else:  # pragma: no cover - fallback
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Trend following signal with ADX, volume and optional Donchian filters."""
-    config = config or {}
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config") or {}
     symbol = config.get("symbol", "")
     adx_window = 7
     min_bars = max(50, adx_window + 1)


### PR DESCRIPTION
## Summary
- Normalize strategy interfaces to `generate_signal(df, symbol=None, timeframe=None, **kwargs)`
- Ensure pair strategies accept `symbol`, `timeframe`, and additional kwargs

## Testing
- `pytest tests/test_dca_bot.py tests/test_dex_scalper.py tests/test_sniper_bot.py -q` *(fails: KeyError/AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e14b859c83309c6c0acdd37f46f1