### PR TITLE
Add debug logging for skipped trades

### DIFF
--- a/crypto_bot/utils/logging_config.py
+++ b/crypto_bot/utils/logging_config.py
@@ -19,7 +19,7 @@ def setup_logging(log_path="logs/bot.log", level=logging.INFO):
     os.makedirs(os.path.dirname(log_path), exist_ok=True)
     root = logging.getLogger()
     root.handlers.clear()
-    root.setLevel(level)
+    root.setLevel(logging.DEBUG)
 
     # File handler for everything
     fh = RotatingFileHandler(log_path, maxBytes=5_000_000, backupCount=3)


### PR DESCRIPTION
## Summary
- Add detailed debug and warning logs in trade execution path to show why signals are skipped or executed
- Raise root logger level to DEBUG in logging configuration to surface debug messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tenacity'; 134 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a478c9ec7c8330b7f77949b5f4422c