### PR TITLE
chore: clean inline comments in env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,12 +1,12 @@
-SUPABASE_URL=https://your-project-ref.supabase.co  # e.g., https://xyzcompany.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here  # Preferred for full access; from Supabase > Authentication > Service Role
-SUPABASE_KEY=your_service_role_key_here  # Legacy alias for service key
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
+SUPABASE_KEY=your_service_role_key_here
 # SUPABASE_API_KEY=your_api_key_here  # Legacy API key name
 
 # ML-specific (defaults from repo; customize for your models)
-CT_MODELS_BUCKET=models  # Bucket for stored models
-CT_REGIME_PREFIX=models/regime  # Prefix for regime models
-CT_SYMBOL=XRPUSD  # Ensure this is the default symbol
+CT_MODELS_BUCKET=models
+CT_REGIME_PREFIX=models/regime
+CT_SYMBOL=XRPUSD
 
 CT_MAX_WARMUP_CANDLES=3000
 CT_MAX_BACKFILL_DAYS=7


### PR DESCRIPTION
## Summary
- remove inline comments from `.env` to avoid comments being loaded into environment variable values

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*


------
https://chatgpt.com/codex/tasks/task_e_68a4792e6a008330885803fb753047b1