### PR TITLE
Fix Supabase model lookup and unify Supabase env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,9 @@
 SUPABASE_URL=https://your-project-ref.supabase.co  # e.g., https://xyzcompany.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here  # Preferred for full access; from Supabase > Authentication > Service Role
-SUPABASE_KEY=your_service_role_key_here  # Legacy alias for service key
-# SUPABASE_API_KEY=your_api_key_here  # Legacy API key name
+SUPABASE_SERVICE_KEY=your_service_role_key_here  # Use service key for private buckets
 
 # ML-specific (defaults from repo; customize for your models)
 CT_MODELS_BUCKET=models  # Bucket for stored models
-CT_REGIME_PREFIX=models/regime  # Prefix for regime models
+CT_REGIME_PREFIX=regime  # Prefix for regime models
 CT_SYMBOL=XRPUSD  # Ensure this is the default symbol
 
 CT_MAX_WARMUP_CANDLES=3000

--- a/.env.example
+++ b/.env.example
@@ -2,14 +2,11 @@
 
 # Supabase credentials required to download ML regime models
 SUPABASE_URL=https://your-project.supabase.co
-# One of the following keys must be provided
-SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
-# SUPABASE_KEY=your_supabase_key  # legacy alias
-# SUPABASE_API_KEY=your_api_key   # legacy name
+SUPABASE_SERVICE_KEY=your_service_or_anon_key  # use service key for private buckets
 
 # Default model and regime locations
 CT_MODELS_BUCKET=models
-CT_REGIME_PREFIX=models/regime
+CT_REGIME_PREFIX=regime
 CT_SYMBOL=XRPUSD
 CT_MAX_WARMUP_CANDLES=3000
 CT_MAX_BACKFILL_DAYS=7

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Trained LightGBM models may be stored in Supabase using a stable layout:
 
 ```
 bucket: models
-prefix: models/regime/{SYMBOL}/…
+prefix: regime/{SYMBOL}/…
 ```
 
 The loader searches this path for a `LATEST.json` manifest to resolve the
@@ -156,15 +156,16 @@ Configure the loader with the following environment variables:
 
 ```ini
 SUPABASE_URL=
-# Required: service role key with access to the storage bucket
-SUPABASE_SERVICE_ROLE_KEY=
-# Optional alternative keys for download-only setups
+# Required: service or anon key with access to the storage bucket
+SUPABASE_SERVICE_KEY=
+# Legacy alternative keys
+# SUPABASE_SERVICE_ROLE_KEY=
 # SUPABASE_KEY=
 # SUPABASE_API_KEY=
 # Storage bucket holding uploaded models
 CT_MODELS_BUCKET=models
 # Prefix within the bucket for regime models
-CT_REGIME_PREFIX=models/regime
+CT_REGIME_PREFIX=regime
 CT_SYMBOL=XRPUSD
 # Optional override URL used if Supabase is unavailable
 # CT_MODEL_FALLBACK_URL=https://example.com/xrpusd_regime_lgbm.pkl
@@ -172,7 +173,7 @@ CT_SYMBOL=XRPUSD
 
 `CT_SYMBOL` controls which Supabase regime model is loaded. For instance,
 setting `CT_SYMBOL=XRPUSD` downloads the `xrpusd_regime_lgmb.pkl` model from the
-`models/regime/XRPUSD/` path in the configured bucket. When the Supabase
+`regime/XRPUSD/` path in the configured bucket. When the Supabase
 download fails the loader uses `CT_MODEL_FALLBACK_URL` (or the corresponding
 `model_fallback_url` configuration) and logs when this fallback is used, allowing
 ML scoring to continue.
@@ -186,7 +187,7 @@ CT_REGIME_MODEL_TEMPLATE={symbol}_regime_lgbm.pkl
 `CT_SYMBOL` controls which Supabase regime model is loaded. With
 `CT_REGIME_MODEL_TEMPLATE={symbol}_regime_lgbm.pkl` and `CT_SYMBOL=XRPUSD`, the
 loader resolves the filename `xrpusd_regime_lgbm.pkl` inside
-`models/regime/XRPUSD/`. Models can also be served from a public URL such as
+`regime/XRPUSD/`. Models can also be served from a public URL such as
 `https://prmhankbfjanqffwjcba.supabase.co/storage/v1/object/public/models/xrpusd_regime_lgbm.pkl`
 when credentials are provided or the bucket is public. When the Supabase
 download fails the loader tries `CT_MODEL_LOCAL_PATH` (or the corresponding

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -88,7 +88,7 @@ fees:
 
 # === features ===
 features:
-  ml: false  # set true to use ML regime models (requires SUPABASE_URL and one of SUPABASE_SERVICE_ROLE_KEY/SUPABASE_KEY/SUPABASE_API_KEY)
+  ml: false  # set true to use ML regime models (requires SUPABASE_URL and SUPABASE_SERVICE_KEY)
   helius: false
   pump_monitor: false
   telegram: true

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -740,7 +740,7 @@ def _ensure_ml_if_needed(cfg: dict) -> None:
         if not ML_AVAILABLE:
             symbol = cfg.get("symbol") or os.getenv("CT_SYMBOL", "XRPUSD")
             logger.info(
-                "ML model for %s unavailable; ensure SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY or SUPABASE_KEY are set. "
+                "ML model for %s unavailable; ensure SUPABASE_URL and SUPABASE_SERVICE_KEY (or legacy SUPABASE_SERVICE_ROLE_KEY/SUPABASE_KEY) are set. "
                 "Install cointrader-trainer only when training new models.",
                 symbol,
             )

--- a/crypto_bot/ml/model_loader.py
+++ b/crypto_bot/ml/model_loader.py
@@ -1,0 +1,58 @@
+import os, json, logging, requests
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+log = logging.getLogger(__name__)
+
+def _supabase_key() -> Optional[str]:
+    # Prefer canonical service key, then legacy names
+    return (
+        os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        or os.getenv("SUPABASE_KEY")
+        or os.getenv("SUPABASE_API_KEY")
+    )
+
+def _norm_symbol(symbol: str) -> str:
+    # normalize to the naming convention used in storage
+    return symbol.replace("/", "_").replace(":", "_")
+
+def load_regime_model(symbol: str) -> Dict[str, Any]:
+    bucket = os.getenv("CT_MODELS_BUCKET", "models")
+    prefix = os.getenv("CT_REGIME_PREFIX", "regime").strip("/")
+
+    key = f"{prefix}/{_norm_symbol(symbol)}.json"
+    url = os.getenv("SUPABASE_URL")
+    sb_key = _supabase_key()
+
+    # 1) Supabase storage client path (if you use supabase-py)
+    try:
+        from supabase import create_client  # type: ignore
+        if url and sb_key:
+            supa = create_client(url, sb_key)
+            data = supa.storage.from_(bucket).download(key)
+            log.info("Loaded regime model from Supabase: %s/%s", bucket, key)
+            return json.loads(data)
+    except Exception as e:
+        log.warning("Supabase storage download failed (%s); trying public URL fallback", e)
+
+    # 2) Public HTTP fallback (works if the bucket/object is public)
+    try:
+        if url:
+            http = f"{url.rstrip('/')}/storage/v1/object/public/{bucket}/{key}"
+            r = requests.get(http, timeout=10)
+            if r.ok:
+                log.info("Loaded regime model via public URL: %s", http)
+                return r.json()
+            else:
+                log.warning("Public URL returned %s for %s", r.status_code, http)
+    except Exception as e:
+        log.warning("Public URL fetch failed: %s", e)
+
+    # 3) Local file fallback
+    local = Path("crypto_bot") / "models" / "regime" / f"{_norm_symbol(symbol)}.json"
+    if local.exists():
+        log.info("Loaded local regime model: %s", local)
+        return json.loads(local.read_text())
+
+    raise FileNotFoundError(f"Regime model not found for {symbol} in Supabase or local path")

--- a/crypto_bot/ml/selfcheck.py
+++ b/crypto_bot/ml/selfcheck.py
@@ -19,7 +19,8 @@ def log_ml_status_once() -> None:
     )
     url_ok = bool(os.getenv("SUPABASE_URL"))
     key_ok = bool(
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
         or os.getenv("SUPABASE_KEY")
         or os.getenv("SUPABASE_API_KEY")
         or os.getenv("SUPABASE_ANON_KEY")

--- a/crypto_bot/regime/api.py
+++ b/crypto_bot/regime/api.py
@@ -94,6 +94,7 @@ def _have_supabase_creds() -> bool:
     key_ok = any(
         os.getenv(k)
         for k in [
+            "SUPABASE_SERVICE_KEY",
             "SUPABASE_SERVICE_ROLE_KEY",
             "SUPABASE_KEY",
             "SUPABASE_API_KEY",
@@ -111,7 +112,7 @@ def predict(
     if not _have_supabase_creds():
         logger.warning(
             "Supabase credentials missing; set SUPABASE_URL and one of "
-            "SUPABASE_SERVICE_ROLE_KEY, SUPABASE_KEY or SUPABASE_API_KEY. "
+            "SUPABASE_SERVICE_KEY, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_KEY or SUPABASE_API_KEY. "
             "Falling back to heuristic regime (set features.ml=false to run heuristics)."
         )
         return _baseline_action(features)

--- a/crypto_bot/regime/regime_classifier.py
+++ b/crypto_bot/regime/regime_classifier.py
@@ -98,7 +98,11 @@ PATTERN_WEIGHTS = {
 def is_ml_available() -> bool:
     """Return ``True`` if ML dependencies and credentials are available."""
     url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+    key = (
+        os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        or os.getenv("SUPABASE_KEY")
+    )
     if not url or not key:
         return False
     try:  # pragma: no cover - optional dependency
@@ -251,7 +255,11 @@ async def load_regime_model(symbol: str) -> tuple[object | None, object | None, 
         return None, None
 
     url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+    key = (
+        os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        or os.getenv("SUPABASE_KEY")
+    )
     bucket = os.getenv("CT_MODELS_BUCKET", "models")
     if not url or not key:
         return None, None

--- a/crypto_bot/regime/registry.py
+++ b/crypto_bot/regime/registry.py
@@ -31,7 +31,7 @@ def load_latest_regime(symbol: str) -> Tuple[Any, Dict]:
     """
 
     bucket = os.environ.get("CT_MODELS_BUCKET", "models")
-    prefix = os.environ.get("CT_REGIME_PREFIX", "models/regime")
+    prefix = os.environ.get("CT_REGIME_PREFIX", "regime")
     template = os.environ.get(
         "CT_REGIME_MODEL_TEMPLATE",
         "{prefix}/{symbol}/{symbol_lower}_regime_lgbm.pkl",
@@ -43,9 +43,9 @@ def load_latest_regime(symbol: str) -> Tuple[Any, Dict]:
 
         url = os.environ["SUPABASE_URL"]
         key = (
-            os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
-            or os.environ.get("SUPABASE_SERVICE_KEY")
-            or os.environ["SUPABASE_KEY"]
+            os.environ.get("SUPABASE_SERVICE_KEY")
+            or os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+            or os.environ.get("SUPABASE_KEY")
         )
         client = create_client(url, key)
 

--- a/crypto_bot/utils/ml_utils.py
+++ b/crypto_bot/utils/ml_utils.py
@@ -43,7 +43,8 @@ def _get_supabase_creds() -> tuple[str | None, str | None]:
     """Return Supabase URL and key from canonical or legacy env names."""
     url = os.getenv("SUPABASE_URL")
     key = (
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
         or os.getenv("SUPABASE_KEY")
         or os.getenv("SUPABASE_API_KEY")
         or os.getenv("SUPABASE_ANON_KEY")

--- a/crypto_bot/utils/supabase_snapshot.py
+++ b/crypto_bot/utils/supabase_snapshot.py
@@ -23,7 +23,11 @@ def fetch_snapshot(mint: str, bucket: str = "snapshots") -> Optional[dict]:
         credentials/SDK are unavailable.
     """
     url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+    key = (
+        os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        or os.getenv("SUPABASE_KEY")
+    )
     if not url or not key:
         logger.error("Missing Supabase credentials")
         return None

--- a/crypto_bot/wallet_manager.py
+++ b/crypto_bot/wallet_manager.py
@@ -61,9 +61,7 @@ def _persist_supabase_env(url: str, key: str) -> None:
         if url:
             set_key(str(ENV_FILE), "SUPABASE_URL", url)
         if key:
-            set_key(str(ENV_FILE), "SUPABASE_SERVICE_ROLE_KEY", key)
-            set_key(str(ENV_FILE), "SUPABASE_API_KEY", key)
-            set_key(str(ENV_FILE), "SUPABASE_KEY", key)
+            set_key(str(ENV_FILE), "SUPABASE_SERVICE_KEY", key)
         logger.info(
             "Wrote Supabase creds to %s (url=%s, key_len=%d)",
             ENV_FILE,
@@ -150,19 +148,18 @@ def prompt_user() -> dict:
         "SUPABASE_URL", "Enter Supabase URL: "
     )
     existing_key = (
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
         or os.getenv("SUPABASE_API_KEY")
         or os.getenv("SUPABASE_KEY")
     )
     if existing_key:
-        os.environ["SUPABASE_SERVICE_ROLE_KEY"] = existing_key
+        os.environ["SUPABASE_SERVICE_KEY"] = existing_key
     data["supabase_key"] = env_or_prompt(
-        "SUPABASE_SERVICE_ROLE_KEY", "Enter Supabase API key: "
+        "SUPABASE_SERVICE_KEY", "Enter Supabase API key: "
     )
     key = data["supabase_key"]
-    os.environ["SUPABASE_SERVICE_ROLE_KEY"] = key
-    os.environ["SUPABASE_API_KEY"] = key
-    os.environ["SUPABASE_KEY"] = key
+    os.environ["SUPABASE_SERVICE_KEY"] = key
     _persist_supabase_env(data["supabase_url"], key)
     data["lunarcrush_api_key"] = env_or_prompt(
         "LUNARCRUSH_API_KEY", "Enter LunarCrush API key: "
@@ -225,6 +222,7 @@ def load_or_create(interactive: bool = False) -> dict:
     }
     fields.update(creds.keys())
     env_mapping: Dict[str, List[str]] = {key: [key.upper()] for key in fields}
+    env_mapping["supabase_key"] = ["SUPABASE_SERVICE_KEY"]
 
     aliases = {
         "coinbase_api_key": ["API_KEY"],
@@ -268,9 +266,7 @@ def load_or_create(interactive: bool = False) -> dict:
     os.environ["HELIUS_KEY"] = helius_val
     os.environ["SUPABASE_URL"] = creds.get("supabase_url", "")
     supabase_key = creds.get("supabase_key", "")
-    os.environ["SUPABASE_KEY"] = supabase_key
-    os.environ["SUPABASE_API_KEY"] = supabase_key
-    os.environ["SUPABASE_SERVICE_ROLE_KEY"] = supabase_key
+    os.environ["SUPABASE_SERVICE_KEY"] = supabase_key
     try:  # refresh ML availability after setting credentials
         from crypto_bot.utils.ml_utils import init_ml_components
 

--- a/src/cointrainer/train/local_csv.py
+++ b/src/cointrainer/train/local_csv.py
@@ -75,7 +75,7 @@ def _maybe_publish_registry(model_bytes: bytes, metadata: Dict, cfg: TrainConfig
         # lazy import to avoid runtime deps
         from cointrainer import registry
         ts = time.strftime("%Y%m%d-%H%M%S")
-        key = f"models/regime/{cfg.symbol}/{ts}_regime_lgbm.pkl"
+        key = f"regime/{cfg.symbol}/{ts}_regime_lgbm.pkl"
         registry.save_model(key, model_bytes, metadata)
         return key
     except Exception:

--- a/tests/test_ml_selfcheck.py
+++ b/tests/test_ml_selfcheck.py
@@ -14,6 +14,7 @@ def reload_selfcheck():
 def _clear_supabase_env(monkeypatch):
     for var in [
         "SUPABASE_URL",
+        "SUPABASE_SERVICE_KEY",
         "SUPABASE_SERVICE_ROLE_KEY",
         "SUPABASE_KEY",
         "SUPABASE_API_KEY",

--- a/tests/test_regime_api_predict.py
+++ b/tests/test_regime_api_predict.py
@@ -24,7 +24,7 @@ def test_predict_uses_supabase_model(monkeypatch):
     monkeypatch.setattr(api, "load_latest_regime", fake_load_latest)
     monkeypatch.setattr(api, "_load_model_from_bytes", lambda blob: DummyModel())
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "key")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "key")
     monkeypatch.delenv("CT_SYMBOL", raising=False)
 
     df = pd.DataFrame({"close": [1, 2, 3]})
@@ -45,7 +45,7 @@ def test_predict_allows_symbol_override(monkeypatch):
     monkeypatch.setattr(api, "load_latest_regime", fake_load_latest)
     monkeypatch.setattr(api, "_load_model_from_bytes", lambda blob: DummyModel())
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "key")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "key")
     monkeypatch.setenv("CT_SYMBOL", "ETHUSD")
 
     df = pd.DataFrame({"close": [1, 2, 3]})
@@ -66,6 +66,7 @@ def test_predict_falls_back_without_creds(monkeypatch):
     monkeypatch.setattr(api, "load_latest_regime", fake_load_latest)
     for var in [
         "SUPABASE_URL",
+        "SUPABASE_SERVICE_KEY",
         "SUPABASE_SERVICE_ROLE_KEY",
         "SUPABASE_KEY",
         "SUPABASE_API_KEY",
@@ -106,7 +107,7 @@ def test_predict_uses_direct_path_when_latest_missing(monkeypatch):
         sys.modules, "supabase", types.SimpleNamespace(create_client=lambda u, k: Client())
     )
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "key")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "key")
     monkeypatch.delenv("CT_SYMBOL", raising=False)
     monkeypatch.setattr(api, "_load_model_from_bytes", lambda blob: DummyModel())
 
@@ -160,7 +161,7 @@ def test_missing_model_logs_once(monkeypatch, caplog):
 
     monkeypatch.setitem(sys.modules, "supabase", types.SimpleNamespace(create_client=create_client))
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "key")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "key")
     monkeypatch.setattr(registry, "_load_fallback", lambda: object())
     monkeypatch.setattr(registry, "_no_model_logged", False)
 

--- a/tests/test_regime_registry.py
+++ b/tests/test_regime_registry.py
@@ -36,9 +36,9 @@ def test_loads_direct_model_when_latest_missing(monkeypatch, caplog):
         sys.modules, "supabase", types.SimpleNamespace(create_client=create_client)
     )
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "key")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "key")
     monkeypatch.setenv("CT_MODELS_BUCKET", "models")
-    monkeypatch.setenv("CT_REGIME_PREFIX", "models/regime")
+    monkeypatch.setenv("CT_REGIME_PREFIX", "regime")
     monkeypatch.setenv(
         "CT_REGIME_MODEL_TEMPLATE", "{prefix}/{symbol}/{symbol_lower}_regime_lgbm.pkl"
     )
@@ -51,8 +51,8 @@ def test_loads_direct_model_when_latest_missing(monkeypatch, caplog):
     assert blob == b"direct-bytes"
     assert meta == {}
     assert calls == [
-        "models/regime/BTCUSD/LATEST.json",
-        "models/regime/BTCUSD/btcusd_regime_lgbm.pkl",
+        "regime/BTCUSD/LATEST.json",
+        "regime/BTCUSD/btcusd_regime_lgbm.pkl",
     ]
     assert not [r for r in caplog.records if "No regime model found" in r.message]
 

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -89,14 +89,13 @@ def test_load_exports_supabase_creds(tmp_path, monkeypatch):
     cfg.write_text(yaml.safe_dump(data))
     monkeypatch.setattr(wallet_manager, "CONFIG_FILE", cfg)
     monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
     monkeypatch.delenv("SUPABASE_KEY", raising=False)
     monkeypatch.delenv("SUPABASE_API_KEY", raising=False)
-    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
     creds = wallet_manager.load_or_create()
     assert os.environ["SUPABASE_URL"] == "url"
-    assert os.environ["SUPABASE_KEY"] == "key"
-    assert os.environ["SUPABASE_API_KEY"] == "key"
-    assert os.environ["SUPABASE_SERVICE_ROLE_KEY"] == "key"
+    assert os.environ["SUPABASE_SERVICE_KEY"] == "key"
     assert creds["supabase_url"] == "url"
     assert creds["supabase_key"] == "key"
 

--- a/tools/train_regime_model.py
+++ b/tools/train_regime_model.py
@@ -61,7 +61,11 @@ def save_model(model, path: Path) -> None:
 
 def upload_to_supabase(path: Path) -> None:
     url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+    key = (
+        os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        or os.getenv("SUPABASE_KEY")
+    )
     if not url or not key:
         LOG.error("Missing Supabase credentials")
         return


### PR DESCRIPTION
## Summary
- simplify Supabase env settings and fix duplicate regime prefix
- add resilient regime model loader with Supabase, public URL and local fallbacks
- update utilities, docs and tests to prefer `SUPABASE_SERVICE_KEY`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis'; ModuleNotFoundError: No module named 'cointrainer'; SyntaxError in tests/test_initial_scan.py)*
- `PYTHONPATH=src pytest tests/test_ml_selfcheck.py tests/test_regime_api_predict.py tests/test_regime_registry.py tests/test_wallet_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a479c603108330b5c570dee2ad41d9