### PR TITLE
Guard ATR values when sizing positions

### DIFF
--- a/crypto_bot/risk/risk_manager.py
+++ b/crypto_bot/risk/risk_manager.py
@@ -199,9 +199,14 @@ class RiskManager:
 
         if stop_distance is not None or atr is not None:
             risk_value = balance * self.config.risk_pct * confidence
-            stop_loss_distance = atr if atr and atr > 0 else stop_distance
+            atr_value = (
+                float(atr.iloc[-1]) if hasattr(atr, "iloc") else float(atr)
+            ) if atr is not None else None
+            stop_loss_distance = (
+                atr_value if atr_value is not None else stop_distance
+            )
             trade_price = price or 1.0
-            if stop_loss_distance and stop_loss_distance > 0:
+            if stop_loss_distance is not None and stop_loss_distance > 0:
                 size = risk_value * trade_price / stop_loss_distance
             else:
                 size = balance * confidence * self.config.trade_size_pct

--- a/crypto_bot/strategy/sniper_bot.py
+++ b/crypto_bot/strategy/sniper_bot.py
@@ -166,7 +166,7 @@ def generate_signal(
         if config is None or config.get("atr_normalization", True):
             score = volatility.normalize_score_by_volatility(df, score)
         logger.info("Signal for %s: %s, %s", symbol, score, "short")
-        return score, "short", atr_value if atr_value is not None else 0.0, False
+        return score, "short", float(atr_value) if atr_value is not None else 0.0, False
 
     base_volume = df["volume"].iloc[:initial_window].mean()
     vol_ratio = df["volume"].iloc[-1] / base_volume if base_volume > 0 else 0
@@ -191,7 +191,7 @@ def generate_signal(
 
     if df["volume"].iloc[-1] < min_volume:
         logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
-        return 0.0, "none", atr if atr is not None else 0.0, event
+        return 0.0, "none", float(atr) if atr is not None else 0.0, event
 
     if (
         len(df) <= max_history
@@ -215,7 +215,7 @@ def generate_signal(
         if direction == "auto":
             trade_direction = "short" if price_change < 0 else "long"
         logger.info("Signal for %s: %s, %s", symbol, score, trade_direction)
-        return score, trade_direction, atr if atr is not None else 0.0, event
+        return score, trade_direction, float(atr) if atr is not None else 0.0, event
 
     trade_direction = direction
     score = 0.0
@@ -258,7 +258,7 @@ def generate_signal(
             return score, trade_direction, atr_value, event
 
     logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
-    return 0.0, "none", atr if atr is not None else 0.0, event
+    return 0.0, "none", float(atr) if atr is not None else 0.0, event
 
 
 class regime_filter:


### PR DESCRIPTION
## Summary
- prevent ambiguous pandas truthiness in risk manager by extracting ATR scalar before comparing
- return ATR as float in sniper bot to avoid passing non-scalar values

## Testing
- `pip install fakeredis`
- `pytest` *(fails: ModuleNotFoundError for `cointrainer` and `crypto_bot.wallet` plus syntax error in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a47b6ba2308330a9f6c743339be8f7