### PR TITLE
feat: support window alias for ATR

### DIFF
--- a/crypto_bot/indicators/atr.py
+++ b/crypto_bot/indicators/atr.py
@@ -6,15 +6,17 @@ from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.logger import indicator_logger
 
 
-def calc_atr(df: pd.DataFrame, period: int = 14) -> float:
+def calc_atr(df: pd.DataFrame, window: int = 14, **kwargs) -> float:
     """Return the latest Average True Range (ATR) value.
 
     Parameters
     ----------
     df : pandas.DataFrame
         Data containing ``high``, ``low`` and ``close`` columns.
-    period : int, default 14
+    window : int, default 14
         Number of periods used for the ATR calculation.
+    period : int, optional
+        Deprecated alias for ``window`` kept for backwards compatibility.
 
     Returns
     -------
@@ -22,6 +24,13 @@ def calc_atr(df: pd.DataFrame, period: int = 14) -> float:
         The most recent ATR value. ``0.0`` is returned when required
         columns are missing or the input is empty.
     """
+
+    period = kwargs.get("period")
+    if period is not None and window == 14:
+        try:
+            window = int(period)
+        except (TypeError, ValueError):
+            pass
 
     if df.empty or not {"high", "low", "close"}.issubset(df.columns):
         indicator_logger.warning(
@@ -33,13 +42,13 @@ def calc_atr(df: pd.DataFrame, period: int = 14) -> float:
     high_close = (df["high"] - df["close"].shift()).abs()
     low_close = (df["low"] - df["close"].shift()).abs()
     tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
-    atr_series = tr.rolling(period, min_periods=period).mean()
-    cached = cache_series(f"atr_{period}", df, atr_series, period)
+    atr_series = tr.rolling(window, min_periods=window).mean()
+    cached = cache_series(f"atr_{window}", df, atr_series, window)
     if cached.empty:
-        indicator_logger.warning("ATR cache miss for period %d", period)
+        indicator_logger.warning("ATR cache miss for period %d", window)
         return 0.0
     value = float(cached.iloc[-1])
-    indicator_logger.info("ATR(%d) computed %.6f", period, value)
+    indicator_logger.info("ATR(%d) computed %.6f", window, value)
     return value
 
 

--- a/crypto_bot/utils/indicators.py
+++ b/crypto_bot/utils/indicators.py
@@ -51,21 +51,29 @@ def atr(
     return tr.ewm(alpha=1 / period, adjust=False, min_periods=period).mean()
 
 
-def calc_atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
-    """Convenience wrapper around :func:`atr` for OHLC data frames."""
+def calc_atr(df: pd.DataFrame, window: int = 14, **kwargs) -> pd.Series:
+    """Convenience wrapper around :func:`atr` for OHLC data frames.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input OHLC data containing ``high``, ``low`` and ``close`` columns.
+    window : int, default 14
+        Lookback window for the ATR calculation.
+    period : int, optional
+        Alias for ``window`` kept for backwards compatibility.
+    """
 
     cols = {"high", "low", "close"}
     if not cols.issubset(df.columns):
         msg = f"calc_atr expects columns {cols}, got {list(df.columns)}"
         raise ValueError(msg)
-    cols = {"high", "low", "close"}
-    if not cols.issubset(df.columns):
-        message = "calc_atr expects columns {}, got {}".format(
-            cols,
-            list(df.columns),
-        )
-        raise ValueError(message)
-    return atr(df["high"], df["low"], df["close"], period=period)
+
+    period = kwargs.get("period")
+    if period is not None and window == 14:
+        window = int(period)
+
+    return atr(df["high"], df["low"], df["close"], period=window)
 
 
 def rsi(close: pd.Series, period: int = 14) -> pd.Series:

--- a/crypto_bot/volatility_filter.py
+++ b/crypto_bot/volatility_filter.py
@@ -131,14 +131,27 @@ def too_hot(symbol: str, max_funding_rate: float) -> bool:
 
 
 # Keep legacy import path working for existing callers
-def calc_atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+def calc_atr(df: pd.DataFrame, window: int = 14, **kwargs) -> pd.Series:
     """Compatibility wrapper returning an ATR series for backward compatibility.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input OHLC data.
+    window : int, default 14
+        Lookback window for the ATR calculation.
+    period : int, optional
+        Alias for ``window`` kept for backwards compatibility.
 
     Exposes :func:`calc_atr` under the historical import while mirroring the
     original return type.
     """
 
-    return _calc_atr(df, period=period)
+    period = kwargs.get("period")
+    if period is not None and window == 14:
+        window = int(period)
+
+    return _calc_atr(df, window)
 
 
 __all__ = ["atr_pct", "too_flat", "fetch_funding_rate", "too_hot", "calc_atr"]


### PR DESCRIPTION
## Summary
- allow ATR calculators to accept `window` with legacy `period` alias
- forward alias through volatility filter wrapper for backward compatibility
- update ATR indicator to use the new `window` parameter throughout

## Testing
- `pip install fakeredis` (cointrainer missing)
- `pytest -q` *(fails: ModuleNotFoundError: cointrainer, crypto_bot.wallet, etc.)*
- `pytest tests/test_volatility_filter.py -q`
- `pytest tests/test_risk_manager.py -q` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a47b660acc83308fcb70efcb021275