### PR TITLE
Use SUPABASE_KEY for Supabase credentials

### DIFF
--- a/crypto_bot/wallet_manager.py
+++ b/crypto_bot/wallet_manager.py
@@ -62,7 +62,6 @@ def _persist_supabase_env(url: str, key: str) -> None:
             set_key(str(ENV_FILE), "SUPABASE_URL", url)
         if key:
             set_key(str(ENV_FILE), "SUPABASE_SERVICE_ROLE_KEY", key)
-            set_key(str(ENV_FILE), "SUPABASE_API_KEY", key)
             set_key(str(ENV_FILE), "SUPABASE_KEY", key)
         logger.info(
             "Wrote Supabase creds to %s (url=%s, key_len=%d)",
@@ -151,7 +150,6 @@ def prompt_user() -> dict:
     )
     existing_key = (
         os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_API_KEY")
         or os.getenv("SUPABASE_KEY")
     )
     if existing_key:
@@ -161,7 +159,6 @@ def prompt_user() -> dict:
     )
     key = data["supabase_key"]
     os.environ["SUPABASE_SERVICE_ROLE_KEY"] = key
-    os.environ["SUPABASE_API_KEY"] = key
     os.environ["SUPABASE_KEY"] = key
     _persist_supabase_env(data["supabase_url"], key)
     data["lunarcrush_api_key"] = env_or_prompt(
@@ -235,7 +232,6 @@ def load_or_create(interactive: bool = False) -> dict:
         "helius_api_key": ["HELIUS_API_KEY", "HELIUS_KEY"],
         "supabase_key": [
             "SUPABASE_SERVICE_ROLE_KEY",
-            "SUPABASE_API_KEY",
             "SUPABASE_KEY",
         ],
     }
@@ -269,7 +265,6 @@ def load_or_create(interactive: bool = False) -> dict:
     os.environ["SUPABASE_URL"] = creds.get("supabase_url", "")
     supabase_key = creds.get("supabase_key", "")
     os.environ["SUPABASE_KEY"] = supabase_key
-    os.environ["SUPABASE_API_KEY"] = supabase_key
     os.environ["SUPABASE_SERVICE_ROLE_KEY"] = supabase_key
     try:  # refresh ML availability after setting credentials
         from crypto_bot.utils.ml_utils import init_ml_components

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -90,12 +90,10 @@ def test_load_exports_supabase_creds(tmp_path, monkeypatch):
     monkeypatch.setattr(wallet_manager, "CONFIG_FILE", cfg)
     monkeypatch.delenv("SUPABASE_URL", raising=False)
     monkeypatch.delenv("SUPABASE_KEY", raising=False)
-    monkeypatch.delenv("SUPABASE_API_KEY", raising=False)
     monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
     creds = wallet_manager.load_or_create()
     assert os.environ["SUPABASE_URL"] == "url"
     assert os.environ["SUPABASE_KEY"] == "key"
-    assert os.environ["SUPABASE_API_KEY"] == "key"
     assert os.environ["SUPABASE_SERVICE_ROLE_KEY"] == "key"
     assert creds["supabase_url"] == "url"
     assert creds["supabase_key"] == "key"


### PR DESCRIPTION
## Summary
- drop legacy `SUPABASE_API_KEY` usage in wallet manager
- adjust Supabase credential persistence and environment exports to rely on `SUPABASE_KEY`
- update wallet manager tests for the new variable name

## Testing
- `pytest tests/test_wallet_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68a47b5b21588330aeb1af982b2307f5