### PR TITLE
refactor: centralize Supabase key lookup

### DIFF
--- a/crypto_bot/ml/model_loader.py
+++ b/crypto_bot/ml/model_loader.py
@@ -4,13 +4,16 @@ from typing import Any, Dict, Optional
 
 log = logging.getLogger(__name__)
 
-def _supabase_key() -> Optional[str]:
-    # Prefer canonical service key, then legacy names
+
+def supabase_key() -> Optional[str]:
+    """Return the Supabase key from canonical or legacy env vars."""
+    # Prefer canonical SUPABASE_KEY, but fall back to legacy names
     return (
-        os.getenv("SUPABASE_SERVICE_KEY")
+        os.getenv("SUPABASE_KEY")
+        or os.getenv("SUPABASE_SERVICE_KEY")
         or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_KEY")
         or os.getenv("SUPABASE_API_KEY")
+        or os.getenv("SUPABASE_ANON_KEY")
     )
 
 def _norm_symbol(symbol: str) -> str:
@@ -23,7 +26,7 @@ def load_regime_model(symbol: str) -> Dict[str, Any]:
 
     key = f"{prefix}/{_norm_symbol(symbol)}.json"
     url = os.getenv("SUPABASE_URL")
-    sb_key = _supabase_key()
+    sb_key = supabase_key()
 
     # 1) Supabase storage client path (if you use supabase-py)
     try:

--- a/crypto_bot/ml/selfcheck.py
+++ b/crypto_bot/ml/selfcheck.py
@@ -2,6 +2,8 @@ import importlib
 import logging
 import os
 
+from .model_loader import supabase_key
+
 _logged = False
 
 _REQUIRED_PACKAGES = ("sklearn", "joblib", "ta")
@@ -18,15 +20,9 @@ def log_ml_status_once() -> None:
         importlib.util.find_spec(name) is not None for name in _REQUIRED_PACKAGES
     )
     url_ok = bool(os.getenv("SUPABASE_URL"))
-    key_ok = bool(
-        os.getenv("SUPABASE_SERVICE_KEY")
-        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_KEY")
-        or os.getenv("SUPABASE_API_KEY")
-        or os.getenv("SUPABASE_ANON_KEY")
-    )
+    key_ok = bool(supabase_key())
     log.info(
-        "ML status: packages=%s supabase_url=%s key_present=%s",
+        "ML status: packages=%s SUPABASE_URL=%s SUPABASE_KEY_present=%s",
         pkgs_ok,
         url_ok,
         key_ok,

--- a/crypto_bot/utils/ml_utils.py
+++ b/crypto_bot/utils/ml_utils.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 from typing import Iterable
 
+from crypto_bot.ml.model_loader import supabase_key
+
 logger = logging.getLogger(__name__)
 
 _REQUIRED_PACKAGES: Iterable[str] = ("sklearn", "joblib", "ta")
@@ -40,17 +42,11 @@ def _check_packages(pkgs: Iterable[str]) -> list[str]:
 
 
 def _get_supabase_creds() -> tuple[str | None, str | None]:
-    """Return Supabase URL and key from canonical or legacy env names."""
+    """Return Supabase URL and key using shared helper for key lookup."""
     url = os.getenv("SUPABASE_URL")
-    key = (
-        os.getenv("SUPABASE_SERVICE_KEY")
-        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_KEY")
-        or os.getenv("SUPABASE_API_KEY")
-        or os.getenv("SUPABASE_ANON_KEY")
-    )
+    key = supabase_key()
     logger.debug(
-        "Supabase configured: url=%s key_len=%d",
+        "Supabase configured: SUPABASE_URL=%s SUPABASE_KEY_len=%d",
         bool(url),
         len(key or ""),
     )
@@ -102,7 +98,7 @@ def is_ml_available() -> bool:
         if not url or not key:
             if not _LOGGER_ONCE["missing_supabase_creds"]:
                 logger.info(
-                    "ML unavailable: Missing Supabase credentials (url=%s, key_present=%s)",
+                    "ML unavailable: Missing Supabase credentials (SUPABASE_URL=%s, SUPABASE_KEY_present=%s)",
                     bool(url),
                     bool(key),
                 )

--- a/tests/test_ml_selfcheck.py
+++ b/tests/test_ml_selfcheck.py
@@ -30,7 +30,7 @@ def test_log_ml_status_once_logs_supabase_status(monkeypatch, caplog):
 
     selfcheck.log_ml_status_once()
     assert (
-        "ML status: packages=True supabase_url=False key_present=False"
+        "ML status: packages=True SUPABASE_URL=False SUPABASE_KEY_present=False"
         in caplog.text
     )
 
@@ -48,6 +48,6 @@ def test_log_ml_status_once_detects_credentials(monkeypatch, caplog):
 
     selfcheck.log_ml_status_once()
     assert (
-        "ML status: packages=True supabase_url=True key_present=True"
+        "ML status: packages=True SUPABASE_URL=True SUPABASE_KEY_present=True"
         in caplog.text
     )


### PR DESCRIPTION
## Summary
- add `supabase_key` helper to prioritize `SUPABASE_KEY` and fall back to legacy names
- use new helper in ML utilities and self-check
- update logging to mention canonical `SUPABASE_KEY`

## Testing
- `pytest tests/test_ml_utils.py tests/test_ml_selfcheck.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4864062188330a48c868d4896697e