### PR TITLE
refactor: consolidate Supabase key configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Supabase credentials (required when features.ml=true)
 SUPABASE_URL=https://your-project-ref.supabase.co  # e.g., https://xyzcompany.supabase.co
-SUPABASE_SERVICE_KEY=your_service_role_key_here  # Use service key for private buckets
+SUPABASE_KEY=your_supabase_key  # service role for private buckets or anon for public
 
 # ML-specific (defaults from repo; customize for your models)
 CT_MODELS_BUCKET=models  # Bucket for stored models

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 
 # Supabase credentials required to download ML regime models
 SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_SERVICE_KEY=your_service_or_anon_key  # use service key for private buckets
+SUPABASE_KEY=your_supabase_key  # service role for private buckets or anon for public
 
 # Default model and regime locations
 CT_MODELS_BUCKET=models

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ Configure the loader with the following environment variables:
 
 ```ini
 SUPABASE_URL=
-# Required: service or anon key with access to the storage bucket
-SUPABASE_SERVICE_KEY=
+# Required: Supabase key (service role for private buckets or anon for public)
+SUPABASE_KEY=
 # Storage bucket holding uploaded models
 CT_MODELS_BUCKET=models
 # Prefix within the bucket for regime models
@@ -169,7 +169,7 @@ CT_SYMBOL=XRPUSD
 
 `CT_SYMBOL` controls which Supabase regime model is loaded. For instance,
 setting `CT_SYMBOL=XRPUSD` downloads the `xrpusd_regime_lgmb.pkl` model from the
-`regime/XRPUSD/` path in the configured bucket. When the Supabase
+`models/regime/XRPUSD/` path in the storage bucket. When the Supabase
 download fails the loader uses `CT_MODEL_FALLBACK_URL` (or the corresponding
 `model_fallback_url` configuration) and logs when this fallback is used, allowing
 ML scoring to continue.

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -705,7 +705,7 @@ def _ensure_ml_if_needed(cfg: dict) -> None:
         if not ML_AVAILABLE:
             symbol = cfg.get("symbol") or os.getenv("CT_SYMBOL", "XRPUSD")
             logger.info(
-                "ML model for %s unavailable; ensure SUPABASE_URL and SUPABASE_SERVICE_KEY (or legacy SUPABASE_SERVICE_ROLE_KEY/SUPABASE_KEY) are set. "
+                "ML model for %s unavailable; ensure SUPABASE_URL and SUPABASE_KEY are set. "
                 "Install cointrader-trainer only when training new models.",
                 symbol,
             )

--- a/crypto_bot/ml/model_loader.py
+++ b/crypto_bot/ml/model_loader.py
@@ -6,15 +6,8 @@ log = logging.getLogger(__name__)
 
 
 def supabase_key() -> Optional[str]:
-    """Return the Supabase key from canonical or legacy env vars."""
-    # Prefer canonical SUPABASE_KEY, but fall back to legacy names
-    return (
-        os.getenv("SUPABASE_KEY")
-        or os.getenv("SUPABASE_SERVICE_KEY")
-        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_API_KEY")
-        or os.getenv("SUPABASE_ANON_KEY")
-    )
+    """Return the Supabase key from environment variables."""
+    return os.getenv("SUPABASE_KEY")
 
 def _norm_symbol(symbol: str) -> str:
     # normalize to the naming convention used in storage

--- a/crypto_bot/regime/api.py
+++ b/crypto_bot/regime/api.py
@@ -90,18 +90,7 @@ def _load_model_from_bytes(blob: bytes):
 def _have_supabase_creds() -> bool:
     """Return ``True`` if Supabase credentials are present."""
 
-    url_ok = bool(os.getenv("SUPABASE_URL"))
-    key_ok = any(
-        os.getenv(k)
-        for k in [
-            "SUPABASE_SERVICE_KEY",
-            "SUPABASE_SERVICE_ROLE_KEY",
-            "SUPABASE_KEY",
-            "SUPABASE_API_KEY",
-            "SUPABASE_ANON_KEY",
-        ]
-    )
-    return url_ok and key_ok
+    return bool(os.getenv("SUPABASE_URL") and os.getenv("SUPABASE_KEY"))
 
 
 def predict(
@@ -111,8 +100,7 @@ def predict(
 
     if not _have_supabase_creds():
         logger.warning(
-            "Supabase credentials missing; set SUPABASE_URL and one of "
-            "SUPABASE_SERVICE_KEY, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_KEY or SUPABASE_API_KEY. "
+            "Supabase credentials missing; set SUPABASE_URL and SUPABASE_KEY. "
             "Falling back to heuristic regime (set features.ml=false to run heuristics)."
         )
         return _baseline_action(features)

--- a/crypto_bot/regime/regime_classifier.py
+++ b/crypto_bot/regime/regime_classifier.py
@@ -98,11 +98,7 @@ PATTERN_WEIGHTS = {
 def is_ml_available() -> bool:
     """Return ``True`` if ML dependencies and credentials are available."""
     url = os.getenv("SUPABASE_URL")
-    key = (
-        os.getenv("SUPABASE_SERVICE_KEY")
-        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_KEY")
-    )
+    key = os.getenv("SUPABASE_KEY")
     if not url or not key:
         return False
     try:  # pragma: no cover - optional dependency
@@ -255,17 +251,14 @@ async def load_regime_model(symbol: str) -> tuple[object | None, object | None, 
         return None, None
 
     url = os.getenv("SUPABASE_URL")
-    key = (
-        os.getenv("SUPABASE_SERVICE_KEY")
-        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_KEY")
-    )
+    key = os.getenv("SUPABASE_KEY")
     bucket = os.getenv("CT_MODELS_BUCKET", "models")
+    prefix = os.getenv("CT_REGIME_PREFIX", "regime").strip("/")
     if not url or not key:
         return None, None
 
     client = create_client(url, key)
-    latest_path = f"regime/{symbol}/LATEST.json"
+    latest_path = f"{prefix}/{symbol}/LATEST.json"
     model_path = None
     try:
         latest_bytes = client.storage.from_(bucket).download(latest_path)
@@ -306,7 +299,7 @@ async def load_regime_model(symbol: str) -> tuple[object | None, object | None, 
         if "not_found" in msg:
             logger.warning("Supabase regime model for %s not found", symbol)
             try:
-                direct_key = f"regime/{symbol}/{symbol.lower()}_regime_lgbm.pkl"
+                direct_key = f"{prefix}/{symbol}/{symbol.lower()}_regime_lgbm.pkl"
                 model_path = direct_key
                 model_bytes = client.storage.from_(bucket).download(direct_key)
                 model_obj = pickle.loads(model_bytes)

--- a/crypto_bot/regime/registry.py
+++ b/crypto_bot/regime/registry.py
@@ -31,7 +31,7 @@ def load_latest_regime(symbol: str) -> Tuple[Any, Dict]:
     """
 
     bucket = os.environ.get("CT_MODELS_BUCKET", "models")
-    prefix = os.environ.get("CT_REGIME_PREFIX", "regime")
+    prefix = os.environ.get("CT_REGIME_PREFIX", "regime").strip("/")
     template = os.environ.get(
         "CT_REGIME_MODEL_TEMPLATE",
         "{prefix}/{symbol}/{symbol_lower}_regime_lgbm.pkl",
@@ -42,11 +42,7 @@ def load_latest_regime(symbol: str) -> Tuple[Any, Dict]:
         from supabase import create_client  # type: ignore
 
         url = os.environ["SUPABASE_URL"]
-        key = (
-            os.environ.get("SUPABASE_SERVICE_KEY")
-            or os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
-            or os.environ.get("SUPABASE_KEY")
-        )
+        key = os.environ.get("SUPABASE_KEY")
         client = create_client(url, key)
 
         latest_key = f"{prefix}/{symbol}/LATEST.json"

--- a/crypto_bot/utils/supabase_snapshot.py
+++ b/crypto_bot/utils/supabase_snapshot.py
@@ -23,11 +23,7 @@ def fetch_snapshot(mint: str, bucket: str = "snapshots") -> Optional[dict]:
         credentials/SDK are unavailable.
     """
     url = os.getenv("SUPABASE_URL")
-    key = (
-        os.getenv("SUPABASE_SERVICE_KEY")
-        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_KEY")
-    )
+    key = os.getenv("SUPABASE_KEY")
     if not url or not key:
         logger.error("Missing Supabase credentials")
         return None

--- a/crypto_bot/wallet_manager.py
+++ b/crypto_bot/wallet_manager.py
@@ -61,7 +61,7 @@ def _persist_supabase_env(url: str, key: str) -> None:
         if url:
             set_key(str(ENV_FILE), "SUPABASE_URL", url)
         if key:
-            set_key(str(ENV_FILE), "SUPABASE_SERVICE_KEY", key)
+            set_key(str(ENV_FILE), "SUPABASE_KEY", key)
         logger.info(
             "Wrote Supabase creds to %s (url=%s, key_len=%d)",
             ENV_FILE,
@@ -147,19 +147,14 @@ def prompt_user() -> dict:
     data["supabase_url"] = env_or_prompt(
         "SUPABASE_URL", "Enter Supabase URL: "
     )
-    existing_key = (
-        os.getenv("SUPABASE_SERVICE_KEY")
-        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_API_KEY")
-        or os.getenv("SUPABASE_KEY")
-    )
+    existing_key = os.getenv("SUPABASE_KEY")
     if existing_key:
-        os.environ["SUPABASE_SERVICE_KEY"] = existing_key
+        os.environ["SUPABASE_KEY"] = existing_key
     data["supabase_key"] = env_or_prompt(
-        "SUPABASE_SERVICE_KEY", "Enter Supabase API key: "
+        "SUPABASE_KEY", "Enter Supabase API key: "
     )
     key = data["supabase_key"]
-    os.environ["SUPABASE_SERVICE_KEY"] = key
+    os.environ["SUPABASE_KEY"] = key
     _persist_supabase_env(data["supabase_url"], key)
     data["lunarcrush_api_key"] = env_or_prompt(
         "LUNARCRUSH_API_KEY", "Enter LunarCrush API key: "
@@ -222,7 +217,6 @@ def load_or_create(interactive: bool = False) -> dict:
     }
     fields.update(creds.keys())
     env_mapping: Dict[str, List[str]] = {key: [key.upper()] for key in fields}
-    env_mapping["supabase_key"] = ["SUPABASE_SERVICE_KEY"]
 
     aliases = {
         "coinbase_api_key": ["API_KEY"],
@@ -231,11 +225,6 @@ def load_or_create(interactive: bool = False) -> dict:
         "kraken_api_key": ["API_KEY"],
         "kraken_api_secret": ["API_SECRET"],
         "helius_api_key": ["HELIUS_API_KEY", "HELIUS_KEY"],
-        "supabase_key": [
-            "SUPABASE_SERVICE_ROLE_KEY",
-            "SUPABASE_API_KEY",
-            "SUPABASE_KEY",
-        ],
     }
 
     for key, env_keys in aliases.items():
@@ -266,7 +255,7 @@ def load_or_create(interactive: bool = False) -> dict:
     os.environ["HELIUS_KEY"] = helius_val
     os.environ["SUPABASE_URL"] = creds.get("supabase_url", "")
     supabase_key = creds.get("supabase_key", "")
-    os.environ["SUPABASE_SERVICE_KEY"] = supabase_key
+    os.environ["SUPABASE_KEY"] = supabase_key
     try:  # refresh ML availability after setting credentials
         from crypto_bot.utils.ml_utils import init_ml_components
 

--- a/tests/test_ml_selfcheck.py
+++ b/tests/test_ml_selfcheck.py
@@ -14,11 +14,7 @@ def reload_selfcheck():
 def _clear_supabase_env(monkeypatch):
     for var in [
         "SUPABASE_URL",
-        "SUPABASE_SERVICE_KEY",
-        "SUPABASE_SERVICE_ROLE_KEY",
         "SUPABASE_KEY",
-        "SUPABASE_API_KEY",
-        "SUPABASE_ANON_KEY",
     ]:
         monkeypatch.delenv(var, raising=False)
 
@@ -43,7 +39,7 @@ def test_log_ml_status_once_detects_credentials(monkeypatch, caplog):
     _clear_supabase_env(monkeypatch)
     monkeypatch.setattr(selfcheck, "_REQUIRED_PACKAGES", ())
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_API_KEY", "x")
+    monkeypatch.setenv("SUPABASE_KEY", "x")
     caplog.set_level(logging.INFO, logger="crypto_bot.ml")
 
     selfcheck.log_ml_status_once()

--- a/tests/test_regime_api_predict.py
+++ b/tests/test_regime_api_predict.py
@@ -24,7 +24,7 @@ def test_predict_uses_supabase_model(monkeypatch):
     monkeypatch.setattr(api, "load_latest_regime", fake_load_latest)
     monkeypatch.setattr(api, "_load_model_from_bytes", lambda blob: DummyModel())
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "key")
+    monkeypatch.setenv("SUPABASE_KEY", "key")
     monkeypatch.delenv("CT_SYMBOL", raising=False)
 
     df = pd.DataFrame({"close": [1, 2, 3]})
@@ -45,7 +45,7 @@ def test_predict_allows_symbol_override(monkeypatch):
     monkeypatch.setattr(api, "load_latest_regime", fake_load_latest)
     monkeypatch.setattr(api, "_load_model_from_bytes", lambda blob: DummyModel())
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "key")
+    monkeypatch.setenv("SUPABASE_KEY", "key")
     monkeypatch.setenv("CT_SYMBOL", "ETHUSD")
 
     df = pd.DataFrame({"close": [1, 2, 3]})
@@ -64,14 +64,7 @@ def test_predict_falls_back_without_creds(monkeypatch):
         return b"", {}
 
     monkeypatch.setattr(api, "load_latest_regime", fake_load_latest)
-    for var in [
-        "SUPABASE_URL",
-        "SUPABASE_SERVICE_KEY",
-        "SUPABASE_SERVICE_ROLE_KEY",
-        "SUPABASE_KEY",
-        "SUPABASE_API_KEY",
-        "SUPABASE_ANON_KEY",
-    ]:
+    for var in ["SUPABASE_URL", "SUPABASE_KEY"]:
         monkeypatch.delenv(var, raising=False)
 
     df = pd.DataFrame({"close": [1, 2, 3]})
@@ -107,7 +100,7 @@ def test_predict_uses_direct_path_when_latest_missing(monkeypatch):
         sys.modules, "supabase", types.SimpleNamespace(create_client=lambda u, k: Client())
     )
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "key")
+    monkeypatch.setenv("SUPABASE_KEY", "key")
     monkeypatch.delenv("CT_SYMBOL", raising=False)
     monkeypatch.setattr(api, "_load_model_from_bytes", lambda blob: DummyModel())
 
@@ -161,7 +154,7 @@ def test_missing_model_logs_once(monkeypatch, caplog):
 
     monkeypatch.setitem(sys.modules, "supabase", types.SimpleNamespace(create_client=create_client))
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "key")
+    monkeypatch.setenv("SUPABASE_KEY", "key")
     monkeypatch.setattr(registry, "_load_fallback", lambda: object())
     monkeypatch.setattr(registry, "_no_model_logged", False)
 

--- a/tests/test_regime_registry.py
+++ b/tests/test_regime_registry.py
@@ -36,7 +36,7 @@ def test_loads_direct_model_when_latest_missing(monkeypatch, caplog):
         sys.modules, "supabase", types.SimpleNamespace(create_client=create_client)
     )
     monkeypatch.setenv("SUPABASE_URL", "http://example")
-    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "key")
+    monkeypatch.setenv("SUPABASE_KEY", "key")
     monkeypatch.setenv("CT_MODELS_BUCKET", "models")
     monkeypatch.setenv("CT_REGIME_PREFIX", "regime")
     monkeypatch.setenv(
@@ -63,7 +63,7 @@ def test_http_fallback_used_when_supabase_unavailable(monkeypatch, tmp_path, cap
     remote.write_bytes(data)
 
     monkeypatch.delenv("SUPABASE_URL", raising=False)
-    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+    monkeypatch.delenv("SUPABASE_KEY", raising=False)
     monkeypatch.setenv("CT_MODEL_FALLBACK_URL", remote.as_uri())
     monkeypatch.setattr(registry, "_no_model_logged", False)
 

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -89,13 +89,10 @@ def test_load_exports_supabase_creds(tmp_path, monkeypatch):
     cfg.write_text(yaml.safe_dump(data))
     monkeypatch.setattr(wallet_manager, "CONFIG_FILE", cfg)
     monkeypatch.delenv("SUPABASE_URL", raising=False)
-    monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
-    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
     monkeypatch.delenv("SUPABASE_KEY", raising=False)
-    monkeypatch.delenv("SUPABASE_API_KEY", raising=False)
     creds = wallet_manager.load_or_create()
     assert os.environ["SUPABASE_URL"] == "url"
-    assert os.environ["SUPABASE_SERVICE_KEY"] == "key"
+    assert os.environ["SUPABASE_KEY"] == "key"
     assert creds["supabase_url"] == "url"
     assert creds["supabase_key"] == "key"
 

--- a/tools/train_regime_model.py
+++ b/tools/train_regime_model.py
@@ -61,11 +61,7 @@ def save_model(model, path: Path) -> None:
 
 def upload_to_supabase(path: Path) -> None:
     url = os.getenv("SUPABASE_URL")
-    key = (
-        os.getenv("SUPABASE_SERVICE_KEY")
-        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_KEY")
-    )
+    key = os.getenv("SUPABASE_KEY")
     if not url or not key:
         LOG.error("Missing Supabase credentials")
         return


### PR DESCRIPTION
## Summary
- replace assorted Supabase key env vars with unified `SUPABASE_KEY`
- document `CT_REGIME_PREFIX=regime` to yield `models/regime/...` path
- adjust wallet manager, API helpers, and examples for new key name

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis'; ModuleNotFoundError: No module named 'cointrainer'; SyntaxError in tests/test_initial_scan.py; ImportError: crypto_bot not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68a48a6220fc83309bda4db4021d3408