### PR TITLE
feat: centralize regime model loading

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -41,6 +41,7 @@ from crypto_bot.risk.risk_manager import RiskManager, RiskConfig
 from crypto_bot.utils.logger import pipeline_logger
 from crypto_bot.ml.selfcheck import log_ml_status_once
 from crypto_bot.utils.ml_utils import ML_AVAILABLE
+from crypto_bot.ml.model_loader import load_regime_model, _norm_symbol
 
 # Internal project modules are imported lazily in `_import_internal_modules()`
 
@@ -717,10 +718,10 @@ def _ensure_ml_if_needed(cfg: dict) -> None:
         try:
             from crypto_bot.regime import regime_classifier as rc
 
-            model, scaler, model_path = asyncio.run(rc.load_regime_model(symbol))
+            model, scaler, model_path = load_regime_model(symbol)
             rc._supabase_model = model
             rc._supabase_scaler = scaler
-            rc._supabase_symbol = symbol
+            rc._supabase_symbol = _norm_symbol(symbol)
             logger.info(
                 "Loaded global regime model for %s from Supabase: %s",
                 symbol,

--- a/crypto_bot/ml/model_loader.py
+++ b/crypto_bot/ml/model_loader.py
@@ -1,13 +1,22 @@
-import os, json, logging, requests
+"""Utilities for loading ML regime models from Supabase or local files."""
+
+from __future__ import annotations
+
+import logging
+import os
+import pickle
+from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Optional, Tuple
+
+import requests
 
 log = logging.getLogger(__name__)
 
 
-def supabase_key() -> Optional[str]:
-    """Return the Supabase key from canonical or legacy env vars."""
-    # Prefer canonical SUPABASE_KEY, but fall back to legacy names
+def _supabase_key() -> Optional[str]:
+    """Return Supabase key from canonical or legacy environment variables."""
+
     return (
         os.getenv("SUPABASE_KEY")
         or os.getenv("SUPABASE_SERVICE_KEY")
@@ -16,46 +25,98 @@ def supabase_key() -> Optional[str]:
         or os.getenv("SUPABASE_ANON_KEY")
     )
 
-def _norm_symbol(symbol: str) -> str:
-    # normalize to the naming convention used in storage
-    return symbol.replace("/", "_").replace(":", "_")
 
-def load_regime_model(symbol: str) -> Dict[str, Any]:
+def _norm_symbol(symbol: str) -> str:
+    """Normalise exchange symbols to storage naming convention."""
+
+    return symbol.replace("/", "_").replace(":", "_").upper()
+
+
+def _deserialize(data: bytes) -> Tuple[object | None, object | None]:
+    """Deserialize model data into (model, scaler)."""
+
+    try:
+        obj = pickle.loads(data)
+    except Exception:
+        try:  # pragma: no cover - optional dependency
+            import joblib
+
+            obj = joblib.load(BytesIO(data))
+        except Exception as exc:  # pragma: no cover - joblib optional
+            log.error("Failed to deserialize regime model: %s", exc)
+            return None, None
+
+    if isinstance(obj, dict):
+        return obj.get("model"), obj.get("scaler")
+    return obj, None
+
+
+def load_regime_model(symbol: str) -> Tuple[object | None, object | None, str | None]:
+    """Load a regime model for ``symbol`` with multiple fallbacks.
+
+    The loader attempts three strategies in order:
+
+    1. Supabase storage using ``supabase-py`` if available.
+    2. Direct HTTP request to the public object URL.
+    3. Local file located under ``crypto_bot/models/regime``.
+
+    ``CT_MODELS_BUCKET`` specifies the bucket name (default ``"models"``) and
+    ``CT_REGIME_PREFIX`` controls the prefix/path within the bucket (default
+    ``"regime"``).
+    """
+
     bucket = os.getenv("CT_MODELS_BUCKET", "models")
     prefix = os.getenv("CT_REGIME_PREFIX", "regime").strip("/")
+    norm = _norm_symbol(symbol)
+    filename = f"{norm.lower()}_regime_lgbm.pkl"
+    key = f"{prefix}/{filename}" if prefix else filename
 
-    key = f"{prefix}/{_norm_symbol(symbol)}.json"
     url = os.getenv("SUPABASE_URL")
-    sb_key = supabase_key()
+    sb_key = _supabase_key()
 
-    # 1) Supabase storage client path (if you use supabase-py)
-    try:
-        from supabase import create_client  # type: ignore
-        if url and sb_key:
+    # 1) Supabase storage client path
+    if url and sb_key:
+        try:  # pragma: no cover - supabase optional
+            from supabase import create_client  # type: ignore
+
             supa = create_client(url, sb_key)
             data = supa.storage.from_(bucket).download(key)
-            log.info("Loaded regime model from Supabase: %s/%s", bucket, key)
-            return json.loads(data)
-    except Exception as e:
-        log.warning("Supabase storage download failed (%s); trying public URL fallback", e)
+            model, scaler = _deserialize(data)
+            if model is not None:
+                log.info("Loaded regime model from Supabase: %s/%s", bucket, key)
+                return model, scaler, key
+        except Exception as exc:
+            log.warning(
+                "Supabase storage download failed (%s); trying public URL fallback",
+                exc,
+            )
 
-    # 2) Public HTTP fallback (works if the bucket/object is public)
-    try:
-        if url:
-            http = f"{url.rstrip('/')}/storage/v1/object/public/{bucket}/{key}"
-            r = requests.get(http, timeout=10)
-            if r.ok:
-                log.info("Loaded regime model via public URL: %s", http)
-                return r.json()
+    # 2) Public HTTP fallback
+    if url:
+        http_url = f"{url.rstrip('/')}/storage/v1/object/public/{bucket}/{key}"
+        try:
+            resp = requests.get(http_url, timeout=10)
+            if resp.ok:
+                model, scaler = _deserialize(resp.content)
+                if model is not None:
+                    log.info("Loaded regime model via public URL: %s", http_url)
+                    return model, scaler, http_url
             else:
-                log.warning("Public URL returned %s for %s", r.status_code, http)
-    except Exception as e:
-        log.warning("Public URL fetch failed: %s", e)
+                log.warning("Public URL returned %s for %s", resp.status_code, http_url)
+        except Exception as exc:
+            log.warning("Public URL fetch failed: %s", exc)
 
     # 3) Local file fallback
-    local = Path("crypto_bot") / "models" / "regime" / f"{_norm_symbol(symbol)}.json"
-    if local.exists():
-        log.info("Loaded local regime model: %s", local)
-        return json.loads(local.read_text())
+    local_path = Path("crypto_bot") / "models" / "regime" / filename
+    if local_path.exists():
+        try:
+            data = local_path.read_bytes()
+            model, scaler = _deserialize(data)
+            if model is not None:
+                log.info("Loaded local regime model: %s", local_path)
+                return model, scaler, str(local_path)
+        except Exception as exc:
+            log.warning("Local regime model load failed: %s", exc)
 
-    raise FileNotFoundError(f"Regime model not found for {symbol} in Supabase or local path")
+    return None, None, None
+

--- a/crypto_bot/ml/selfcheck.py
+++ b/crypto_bot/ml/selfcheck.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 import os
 
-from .model_loader import supabase_key
+from .model_loader import _supabase_key
 
 _logged = False
 
@@ -20,7 +20,7 @@ def log_ml_status_once() -> None:
         importlib.util.find_spec(name) is not None for name in _REQUIRED_PACKAGES
     )
     url_ok = bool(os.getenv("SUPABASE_URL"))
-    key_ok = bool(supabase_key())
+    key_ok = bool(_supabase_key())
     log.info(
         "ML status: packages=%s SUPABASE_URL=%s SUPABASE_KEY_present=%s",
         pkgs_ok,

--- a/crypto_bot/regime/regime_classifier.py
+++ b/crypto_bot/regime/regime_classifier.py
@@ -4,14 +4,11 @@ import asyncio
 import time
 import logging
 import os
-from io import BytesIO
 
 import pandas as pd
 import numpy as np
 import ta
 import yaml
-import json
-import pickle
 
 from crypto_bot.utils.telegram import TelegramNotifier
 
@@ -20,7 +17,7 @@ from crypto_bot.utils.pattern_logger import log_patterns
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
 from crypto_bot.utils.market_loader import timeframe_seconds
 from crypto_bot.utils.telemetry import telemetry
-from crypto_bot.utils.telegram import TelegramNotifier
+from crypto_bot.ml.model_loader import load_regime_model, _norm_symbol
 
 
 # Thresholds and ML blend settings are defined in ``regime_config.yaml``
@@ -227,10 +224,10 @@ def _ml_fallback(
 
 
 async def _download_supabase_model(symbol: str | None = None) -> tuple[object | None, object | None]:
-    """Download LightGBM model and scaler from Supabase."""
+    """Download LightGBM model and scaler using the shared loader."""
     async with _supabase_model_lock:
-        target_symbol = symbol or os.getenv("CT_SYMBOL", "XRPUSD")
-        model, scaler, _path = await load_regime_model(target_symbol)
+        target_symbol = _norm_symbol(symbol or os.getenv("CT_SYMBOL", "XRPUSD"))
+        model, scaler, _path = await asyncio.to_thread(load_regime_model, target_symbol)
         if model is None:
             return None, None
         return model, scaler
@@ -240,111 +237,13 @@ async def _get_supabase_model(symbol: str | None = None) -> tuple[object | None,
     """Return cached Supabase model and scaler, downloading if needed."""
     global _supabase_model, _supabase_scaler, _supabase_symbol
     async with _model_lock:
-        resolved_symbol = symbol or os.getenv("CT_SYMBOL", "XRPUSD")
+        resolved_symbol = _norm_symbol(symbol or os.getenv("CT_SYMBOL", "XRPUSD"))
         if _supabase_model is None or resolved_symbol != _supabase_symbol:
             _supabase_model, _supabase_scaler = await _download_supabase_model(resolved_symbol)
             _supabase_symbol = resolved_symbol
         return _supabase_model, _supabase_scaler
 
 
-async def load_regime_model(symbol: str) -> tuple[object | None, object | None, str | None]:
-    try:
-        from supabase import create_client
-    except Exception as exc:  # pragma: no cover - optional dependency
-        logger.warning("Supabase client unavailable: %s", exc)
-        return None, None
-
-    url = os.getenv("SUPABASE_URL")
-    key = (
-        os.getenv("SUPABASE_SERVICE_KEY")
-        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_KEY")
-    )
-    bucket = os.getenv("CT_MODELS_BUCKET", "models")
-    if not url or not key:
-        return None, None
-
-    client = create_client(url, key)
-    latest_path = f"regime/{symbol}/LATEST.json"
-    model_path = None
-    try:
-        latest_bytes = client.storage.from_(bucket).download(latest_path)
-    except Exception:
-        latest_bytes = None
-
-    if latest_bytes:
-        try:
-            data = json.loads(latest_bytes.decode("utf-8"))
-            model_path = data["key"]
-            model_bytes = client.storage.from_(bucket).download(model_path)
-            model_obj = pickle.loads(model_bytes)
-            if isinstance(model_obj, dict):
-                model = model_obj.get("model")
-                scaler = model_obj.get("scaler")
-            else:
-                model = model_obj
-                scaler = None
-            logger.info("Loaded global regime model from Supabase: %s", model_path)
-            return model, scaler, model_path
-        except Exception as exc:
-            msg = str(getattr(exc, "message", exc))
-            logger.error("Failed to load regime model: %s", exc)
-            return None, None, model_path
-
-    # LATEST.json missing or invalid; attempt direct file fallback
-    template = os.getenv("CT_REGIME_MODEL_TEMPLATE", "{symbol_lower}_regime_lgbm.pkl")
-    fallback_name = template.format(symbol=symbol, symbol_lower=symbol.lower())
-    logger.info(
-        "LATEST metadata missing for %s; falling back to direct file %s",
-        symbol,
-        fallback_name,
-    )
-    try:
-        model_bytes = client.storage.from_(bucket).download(fallback_name)
-    except Exception as exc:
-        msg = str(getattr(exc, "message", exc))
-        if "not_found" in msg:
-            logger.warning("Supabase regime model for %s not found", symbol)
-            try:
-                direct_key = f"regime/{symbol}/{symbol.lower()}_regime_lgbm.pkl"
-                model_path = direct_key
-                model_bytes = client.storage.from_(bucket).download(direct_key)
-                model_obj = pickle.loads(model_bytes)
-                if isinstance(model_obj, dict):
-                    model = model_obj.get("model")
-                    scaler = model_obj.get("scaler")
-                else:
-                    model = model_obj
-                    scaler = None
-                logger.info("Loaded direct regime model from Supabase: %s", direct_key)
-                return model, scaler, model_path
-            except Exception:
-                return None, None, None
-        logger.error("Failed to load regime model: %s", exc)
-        return None, None, fallback_name
-
-    try:
-        model_obj = pickle.loads(model_bytes)
-    except Exception:
-        try:
-            import joblib
-
-            model_obj = joblib.load(BytesIO(model_bytes))
-        except Exception as exc:  # pragma: no cover - joblib optional
-            logger.error("Failed to deserialize regime model: %s", exc)
-            return None, None, fallback_name
-
-    if isinstance(model_obj, dict):
-        model = model_obj.get("model")
-        scaler = model_obj.get("scaler")
-    else:
-        model = model_obj
-        scaler = None
-
-    logger.info(
-        "Loaded global regime model from Supabase fallback file: %s", fallback_name
-    )
-    return model, scaler, fallback_name
 
 
 async def _ml_recovery_loop(notifier: TelegramNotifier | None) -> None:

--- a/crypto_bot/utils/ml_utils.py
+++ b/crypto_bot/utils/ml_utils.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Iterable
 
-from crypto_bot.ml.model_loader import supabase_key
+from crypto_bot.ml.model_loader import _supabase_key
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ def _check_packages(pkgs: Iterable[str]) -> list[str]:
 def _get_supabase_creds() -> tuple[str | None, str | None]:
     """Return Supabase URL and key using shared helper for key lookup."""
     url = os.getenv("SUPABASE_URL")
-    key = supabase_key()
+    key = _supabase_key()
     logger.debug(
         "Supabase configured: SUPABASE_URL=%s SUPABASE_KEY_len=%d",
         bool(url),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ import asyncio
 import types
 import os
 
+from crypto_bot import main
 from crypto_bot.regime import regime_classifier as rc
 
 if not hasattr(yaml, "__file__"):
@@ -372,11 +373,11 @@ def test_ensure_ml_only_on_change(tmp_path, monkeypatch):
 
     calls: list[bool] = []
 
-    async def fake_load(symbol):
+    def fake_load(symbol):
         calls.append(True)
         return object(), None, "path"
 
-    monkeypatch.setattr(rc, "load_regime_model", fake_load)
+    monkeypatch.setattr(main, "load_regime_model", fake_load)
     monkeypatch.setattr(main, "ML_AVAILABLE", True)
 
     asyncio.run(main.load_config_async())

--- a/tests/test_ml_local_fallback.py
+++ b/tests/test_ml_local_fallback.py
@@ -13,10 +13,10 @@ def test_ensure_ml_uses_fallback_url(monkeypatch, tmp_path, caplog):
     rc._supabase_scaler = None
     rc._supabase_symbol = None
 
-    async def fail_load(_symbol):
+    def fail_load(_symbol):
         raise Exception("supabase down")
 
-    monkeypatch.setattr(rc, "load_regime_model", fail_load)
+    monkeypatch.setattr(main, "load_regime_model", fail_load)
     monkeypatch.setattr(main, "ML_AVAILABLE", True)
 
     cfg = {


### PR DESCRIPTION
## Summary
- add shared ML model loader with Supabase, HTTP, and local file fallbacks
- normalize symbols and delegate regime model retrieval to new loader
- update main and tests to use centralized loader

## Testing
- `pytest tests/test_ml_local_fallback.py tests/test_config.py`
- `pytest` *(fails: cannot import wallet_manager)*

------
https://chatgpt.com/codex/tasks/task_e_68a48c85cce48330b83206b31f320f22