### PR TITLE
refactor tests for btcusdt symbol normalization

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -282,7 +282,7 @@ def test_load_config_normalizes_symbol(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "CONFIG_PATH", path)
     monkeypatch.setattr(main, "yaml", types.SimpleNamespace(safe_load=_simple_yaml))
     loaded = main.load_config()
-    assert loaded["symbol"] == "BTC/USDT"
+    assert loaded["symbol"] == "BTCUSDT"
 
 
 def test_reload_config_clears_symbol_cache(monkeypatch, tmp_path):
@@ -303,7 +303,7 @@ def test_reload_config_clears_symbol_cache(monkeypatch, tmp_path):
 
     def fake_load_config():
         return {
-            "symbol": "BTC/USDT",
+            "symbol": "BTCUSDT",
             "risk": {
                 "max_drawdown": 1.0,
                 "stop_loss_pct": 0.0,

--- a/tests/test_fetch_candidates_logging.py
+++ b/tests/test_fetch_candidates_logging.py
@@ -54,11 +54,11 @@ def test_fetch_candidates_dedupes_and_filters(monkeypatch):
     df = pd.DataFrame({"high": [1, 2], "low": [0, 1], "close": [1, 2]})
     ctx = BotContext(
         positions={},
-        df_cache={"1h": {"BTC/USDT": df}},
+        df_cache={"1h": {"BTCUSDT": df}},
         regime_cache={},
         config={
             "timeframe": "1h",
-            "symbols": ["BTC/USDT"],
+            "symbols": ["BTCUSDT"],
             "symbol_batch_size": 5,
             "benchmark_symbols": [],
         },
@@ -66,16 +66,16 @@ def test_fetch_candidates_dedupes_and_filters(monkeypatch):
 
     class DummyExchange:
         def list_markets(self):
-            return ["BTC/USDT", "ETH/USDT"]
+            return ["BTCUSDT", "ETHUSDT"]
 
     ctx.exchange = DummyExchange()
 
     async def fake_get_filtered_symbols(ex, cfg):
         return [
-            ("ETH/USDT", 2.0),
-            ("BTC/USDT", 1.0),
-            ("DOGE/USDT", 0.5),
-            ("ETH/USDT", 0.1),
+            ("ETHUSDT", 2.0),
+            ("BTCUSDT", 1.0),
+            ("DOGEUSDT", 0.5),
+            ("ETHUSDT", 0.1),
         ], []
 
     monkeypatch.setattr(main, "symbol_priority_queue", deque())
@@ -86,5 +86,5 @@ def test_fetch_candidates_dedupes_and_filters(monkeypatch):
 
     asyncio.run(main.fetch_candidates(ctx))
 
-    assert ctx.current_batch == ["BTC/USDT"]
+    assert ctx.current_batch == ["BTCUSDT"]
     assert len(ctx.current_batch) == len(set(ctx.current_batch))

--- a/tests/test_fix_symbol.py
+++ b/tests/test_fix_symbol.py
@@ -3,8 +3,12 @@ import pytest
 from crypto_bot.main import _fix_symbol as fix_symbol
 
 
-def test_fix_symbol_converts_xbt():
-    assert fix_symbol("XBT/USDT") == "BTC/USDT"
+@pytest.mark.parametrize(
+    "input_sym",
+    ["XBT/USDT", "XBTUSDT", "BTC/USDT"],
+)
+def test_fix_symbol_converts_xbt(input_sym):
+    assert fix_symbol(input_sym) == "BTCUSDT"
 
 
 @pytest.mark.parametrize("value", [None, 42, 1.0, [], {"a": 1}])

--- a/tests/test_market_loader_quotes.py
+++ b/tests/test_market_loader_quotes.py
@@ -11,7 +11,7 @@ class QuoteExchange:
         return {
             "BTC/USD": {"active": True, "type": "spot", "quote": "USD"},
             "BTC/EUR": {"active": True, "type": "spot", "quote": "EUR"},
-            "BTC/USDT": {"active": True, "type": "spot", "quote": "USDT"},
+            "BTCUSDT": {"active": True, "type": "spot", "quote": "USDT"},
             "BTC/JPY": {"active": True, "type": "spot", "quote": "JPY"},
         }
 
@@ -19,7 +19,7 @@ class QuoteExchange:
 def test_load_kraken_symbols_filters_quotes():
     ex = QuoteExchange()
     symbols = asyncio.run(load_kraken_symbols(ex))
-    assert set(symbols) == {"BTC/USD", "BTC/EUR", "BTC/USDT"}
+    assert set(symbols) == {"BTC/USD", "BTC/EUR", "BTCUSDT"}
 
 
 class SyntheticExchange:

--- a/tests/test_ohlcv_storage.py
+++ b/tests/test_ohlcv_storage.py
@@ -19,12 +19,12 @@ def _df(ts_list, values):
 def test_save_and_load_sorted(tmp_path):
     base = 1_000_000_000_000  # ms epoch
     df = _df([base + 60_000, base], [2, 1])  # milliseconds and unsorted
-    save_ohlcv("binance", "BTC/USDT", "1m", df, tmp_path)
+    save_ohlcv("binance", "BTCUSDT", "1m", df, tmp_path)
 
-    file_path = tmp_path / "binance" / "BTC-USDT_1m.parquet"
+    file_path = tmp_path / "binance" / "BTCUSDT_1m.parquet"
     assert file_path.exists()
 
-    loaded = load_ohlcv("binance", "BTC/USDT", "1m", tmp_path)
+    loaded = load_ohlcv("binance", "BTCUSDT", "1m", tmp_path)
     assert loaded is not None
     assert loaded["timestamp"].tolist() == [base // 1000, (base + 60_000) // 1000]
 
@@ -33,10 +33,10 @@ def test_save_merges_dropping_duplicates(tmp_path):
     df1 = _df([1000, 2000], [1, 2])
     df2 = _df([2000, 3000], [4, 5])
 
-    save_ohlcv("binance", "BTC/USDT", "1m", df1, tmp_path)
-    save_ohlcv("binance", "BTC/USDT", "1m", df2, tmp_path)
+    save_ohlcv("binance", "BTCUSDT", "1m", df1, tmp_path)
+    save_ohlcv("binance", "BTCUSDT", "1m", df2, tmp_path)
 
-    loaded = load_ohlcv("binance", "BTC/USDT", "1m", tmp_path)
+    loaded = load_ohlcv("binance", "BTCUSDT", "1m", tmp_path)
     assert loaded is not None
     assert loaded["timestamp"].tolist() == [1000, 2000, 3000]
     # ensure duplicate timestamp uses latest values

--- a/tests/test_order_executor.py
+++ b/tests/test_order_executor.py
@@ -21,7 +21,7 @@ def test_execute_trade_async_live_calls_cex(monkeypatch):
         order_executor.execute_trade_async(
             exchange=object(),
             ws_client=None,
-            symbol="BTC/USDT",
+            symbol="BTCUSDT",
             side="buy",
             amount=1.0,
             notifier=DummyNotifier(),

--- a/tests/test_position_sizing.py
+++ b/tests/test_position_sizing.py
@@ -10,7 +10,7 @@ from crypto_bot.risk.position_sizing import (
 
 
 def test_compute_realized_vol_and_size_for_sigma():
-    symbol = "BTC/USDT"
+    symbol = "BTCUSDT"
     t = time.time()
     prices = [100.0, 101.0, 99.0, 100.0]
     for i, p in enumerate(prices):

--- a/tests/test_symbol_pre_filter.py
+++ b/tests/test_symbol_pre_filter.py
@@ -175,9 +175,9 @@ class AltnameMappingExchange:
         self.markets_by_id = {"XXBTZUSD": {"symbol": "XBT/USDT", "altname": "XBTUSDT"}}
 
     async def fetch_tickers(self, symbols):
-        assert symbols == ["XBT/USDT"]
+        assert symbols == ["XBTUSDT"]
         data = (await fake_fetch(None))["result"]
-        return {"XBT/USDT": data["XXBTZUSD"]}
+        return {"XBTUSDT": data["XXBTZUSD"]}
 
 
 def test_altname_mapping(monkeypatch):
@@ -191,7 +191,7 @@ def test_altname_mapping(monkeypatch):
     ex = AltnameMappingExchange()
     symbols = asyncio.run(filter_symbols(ex, ["XBT/USDT"], CONFIG))
 
-    assert symbols == [("BTC/USDT", 0.6)]
+    assert symbols == [("BTCUSDT", 0.6)]
 
 
 class RawIdMappingExchange:
@@ -216,7 +216,7 @@ def test_raw_id_mapping(monkeypatch):
     ex = RawIdMappingExchange()
     symbols = asyncio.run(filter_symbols(ex, ["XBTUSDT"], CONFIG))
 
-    assert symbols == [("BTC/USDT", 0.6)]
+    assert symbols == [("BTCUSDT", 0.6)]
 
 
 class USDCVolumeExchange:
@@ -1365,10 +1365,10 @@ def test_log_ticker_exceptions(monkeypatch, caplog):
 
 class MarketIDExchange:
     has = {}
-    markets_by_id = {"XXBTZUSD": {"symbol": "BTC/USDT"}}
+    markets_by_id = {"XXBTZUSD": {"symbol": "BTCUSDT"}}
 
     def market_id(self, symbol):
-        assert symbol == "BTC/USDT"
+        assert symbol == "BTCUSDT"
         return "XBTUSDT"
 
 
@@ -1393,7 +1393,7 @@ def test_market_id_used_for_public_api(monkeypatch):
     monkeypatch.setattr(sp, "_fetch_ticker_async", fake_fetch_market_id)
     result = asyncio.run(sp.filter_symbols(MarketIDExchange(), ["BTC/USDT"], CONFIG))
     assert calls == [["XBTUSDT"]]
-    assert result == [("BTC/USDT", 0.6)]
+    assert result == [("BTCUSDT", 0.6)]
 
 
 async def fake_fetch_unknown(pairs):
@@ -1406,7 +1406,7 @@ def test_unknown_pair_not_cached(monkeypatch):
     monkeypatch.setattr(sp, "_fetch_ticker_async", fake_fetch_unknown)
     result = asyncio.run(sp.filter_symbols(MarketIDExchange(), ["BTC/USDT"], CONFIG))
     assert result == []
-    assert "BTC/USDT" not in sp.liq_cache
+    assert "BTCUSDT" not in sp.liq_cache
 
 
 def test_refresh_tickers_empty_result(monkeypatch, caplog):
@@ -1521,9 +1521,9 @@ class BTCQuoteExchange:
         self.has = {"fetchTickers": True, "fetchTicker": True}
         self.markets_by_id = {
             "XETHXXBT": {"symbol": "ETH/BTC"},
-            "XXBTZUSD": {"symbol": "BTC/USDT"},
+            "XXBTZUSD": {"symbol": "BTCUSDT"},
         }
-        self.markets = {"ETH/BTC": {}, "BTC/USDT": {}}
+        self.markets = {"ETH/BTC": {}, "BTCUSDT": {}}
 
     async def fetch_tickers(self, symbols):
         assert symbols == ["ETH/BTC"]
@@ -1538,7 +1538,7 @@ class BTCQuoteExchange:
         return {"ETH/BTC": ticker}
 
     async def fetch_ticker(self, symbol):
-        assert symbol == "BTC/USDT"
+        assert symbol == "BTCUSDT"
         return {"last": 50000.0}
 
 

--- a/tests/test_telegram_bot_ui.py
+++ b/tests/test_telegram_bot_ui.py
@@ -505,7 +505,7 @@ def test_pnl_stats_output(monkeypatch, tmp_path):
     state = {"running": True, "mode": "cex"}
     ui, _ = make_ui(tmp_path, state, exchange=DummyExchange())
 
-    lines = ["BTC/USDT -- 100.00 -- +5.00"]
+    lines = ["BTCUSDT -- 100.00 -- +5.00"]
     async def fake_lines(*_a, **_k):
         return lines
     monkeypatch.setattr(telegram_bot_ui.console_monitor, "trade_stats_lines", fake_lines)

--- a/tests/test_universe_guard.py
+++ b/tests/test_universe_guard.py
@@ -15,22 +15,22 @@ def reset_symbol_utils(monkeypatch):
 
 def test_auto_mode_falls_back_to_cex(monkeypatch, caplog):
     async def fake_filter_symbols(exchange, symbols, config):
-        return [("BTC/USDT", 1.0)], []
+        return [("BTCUSDT", 1.0)], []
     monkeypatch.setattr(su, "filter_symbols", fake_filter_symbols, raising=False)
-    cfg = {"mode": "auto", "symbol_filter": {}, "symbols": ["BTC/USDT"]}
+    cfg = {"mode": "auto", "symbol_filter": {}, "symbols": ["BTCUSDT"]}
     ex = types.SimpleNamespace(markets={})
     caplog.set_level(logging.DEBUG)
     scored, onchain = asyncio.run(su.get_filtered_symbols(ex, cfg))
-    assert scored == [("BTC/USDT", 1.0)]
+    assert scored == [("BTCUSDT", 1.0)]
     assert onchain == []
     assert cfg["mode"] == "cex"
     assert "using CEX mode" in caplog.text
 
 def test_empty_universe_raises(monkeypatch):
     async def fake_filter_symbols(exchange, symbols, config):
-        return [("BTC/USDT", 1.0)], []
+        return [("BTCUSDT", 1.0)], []
     monkeypatch.setattr(su, "filter_symbols", fake_filter_symbols, raising=False)
-    cfg = {"mode": "onchain", "symbol_filter": {}, "symbols": ["BTC/USDT"]}
+    cfg = {"mode": "onchain", "symbol_filter": {}, "symbols": ["BTCUSDT"]}
     ex = types.SimpleNamespace(markets={})
     with pytest.raises(RuntimeError, match=r"Universe is empty \(mode=onchain\)"):
         asyncio.run(su.get_filtered_symbols(ex, cfg))

--- a/tests/test_update_caches.py
+++ b/tests/test_update_caches.py
@@ -21,7 +21,7 @@ def test_update_caches_default_limit(monkeypatch):
         positions={}, df_cache={}, regime_cache={}, config={"timeframe": "1h"}
     )
     ctx.exchange = object()
-    ctx.current_batch = ["BTC/USDT"]
+    ctx.current_batch = ["BTCUSDT"]
     monkeypatch.setattr(main, "update_multi_tf_ohlcv_cache", dummy_update)
     monkeypatch.setattr(main, "update_regime_tf_cache", dummy_update_regime)
     asyncio.run(main.update_caches(ctx))
@@ -37,7 +37,7 @@ def test_update_caches_override(monkeypatch):
         config={"timeframe": "1h", "cycle_lookback_limit": 50},
     )
     ctx.exchange = object()
-    ctx.current_batch = ["BTC/USDT"]
+    ctx.current_batch = ["BTCUSDT"]
     monkeypatch.setattr(main, "update_multi_tf_ohlcv_cache", dummy_update)
     monkeypatch.setattr(main, "update_regime_tf_cache", dummy_update)
     asyncio.run(main.update_caches(ctx))
@@ -94,7 +94,7 @@ def test_update_caches_volatility_adjusts_concurrency(monkeypatch):
         config={"timeframe": "1h", "max_concurrent_ohlcv": 8},
     )
     ctx.exchange = object()
-    ctx.current_batch = ["BTC/USDT"]
+    ctx.current_batch = ["BTCUSDT"]
     ctx.volatility_factor = 6.0
     monkeypatch.setattr(main, "update_multi_tf_ohlcv_cache", dummy_update_multi)
     monkeypatch.setattr(main, "update_regime_tf_cache", dummy_update_regime)
@@ -116,7 +116,7 @@ def test_update_caches_logs_counts(monkeypatch, caplog):
     )
 
     async def fake_update(*args, **kwargs):
-        return {"1h": {"BTC/USDT": df}}
+        return {"1h": {"BTCUSDT": df}}
 
     ctx = BotContext(
         positions={},
@@ -125,14 +125,14 @@ def test_update_caches_logs_counts(monkeypatch, caplog):
         config={"timeframe": "1h"},
     )
     ctx.exchange = object()
-    ctx.current_batch = ["BTC/USDT"]
+    ctx.current_batch = ["BTCUSDT"]
     monkeypatch.setattr(main, "update_multi_tf_ohlcv_cache", fake_update)
     monkeypatch.setattr(main, "update_regime_tf_cache", dummy_update)
     caplog.set_level("INFO")
 
     asyncio.run(main.update_caches(ctx))
 
-    assert "BTC/USDT OHLCV: 1 candles" in caplog.text
+    assert "BTCUSDT OHLCV: 1 candles" in caplog.text
 
 async def success_update(*args, **kwargs):
     success_update.called = True
@@ -156,7 +156,7 @@ def test_update_caches_regime_called_normal(monkeypatch):
         positions={}, df_cache={}, regime_cache={}, config={"timeframe": "1h"}
     )
     ctx.exchange = object()
-    ctx.current_batch = ["BTC/USDT"]
+    ctx.current_batch = ["BTCUSDT"]
     monkeypatch.setattr(main, "update_multi_tf_ohlcv_cache", success_update)
     record_regime.called = False
     monkeypatch.setattr(main, "update_regime_tf_cache", record_regime)
@@ -169,7 +169,7 @@ def test_update_caches_regime_called_on_fallback(monkeypatch):
         positions={}, df_cache={}, regime_cache={}, config={"timeframe": "1h"}
     )
     ctx.exchange = object()
-    ctx.current_batch = ["BTC/USDT"]
+    ctx.current_batch = ["BTCUSDT"]
     fail_then_succeed.calls = 0
     record_regime.called = False
     monkeypatch.setattr(main, "update_multi_tf_ohlcv_cache", fail_then_succeed)
@@ -182,20 +182,20 @@ def test_update_caches_warns_and_skips_empty_df(monkeypatch, caplog):
     df = pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
 
     async def fake_update(*args, **kwargs):
-        return {"1h": {"BTC/USDT": df}}
+        return {"1h": {"BTCUSDT": df}}
 
     ctx = BotContext(
         positions={}, df_cache={}, regime_cache={}, config={"timeframe": "1h"}
     )
     ctx.exchange = object()
-    ctx.current_batch = ["BTC/USDT"]
+    ctx.current_batch = ["BTCUSDT"]
     monkeypatch.setattr(main, "update_multi_tf_ohlcv_cache", fake_update)
     monkeypatch.setattr(main, "update_regime_tf_cache", dummy_update)
     caplog.set_level("WARNING")
 
     asyncio.run(main.update_caches(ctx))
 
-    assert "No OHLCV data for BTC/USDT" in caplog.text
+    assert "No OHLCV data for BTCUSDT" in caplog.text
     assert ctx.current_batch == []
 
 
@@ -212,7 +212,7 @@ def test_update_caches_ws_subscribes_each(monkeypatch):
     )
 
     async def fake_update(*args, **kwargs):
-        return {"1h": {"BTC/USDT": df, "ETH/USDT": df}}
+        return {"1h": {"BTCUSDT": df, "ETHUSDT": df}}
 
     calls: list[str] = []
 
@@ -228,10 +228,10 @@ def test_update_caches_ws_subscribes_each(monkeypatch):
         config={"timeframe": "1h", "use_websocket": True},
     )
     ctx.exchange = DummyExchange()
-    ctx.current_batch = ["BTC/USDT", "ETH/USDT"]
+    ctx.current_batch = ["BTCUSDT", "ETHUSDT"]
     monkeypatch.setattr(main, "update_multi_tf_ohlcv_cache", fake_update)
     monkeypatch.setattr(main, "update_regime_tf_cache", dummy_update)
 
     asyncio.run(main.update_caches(ctx))
 
-    assert set(calls) == {"BTC/USDT", "ETH/USDT"}
+    assert set(calls) == {"BTCUSDT", "ETHUSDT"}


### PR DESCRIPTION
## Summary
- switch test fixtures and assertions to BTCUSDT default
- exercise slash vs non-slash symbol normalization

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager')*

------
https://chatgpt.com/codex/tasks/task_e_68a4a2da51f48330b45ce1bf4b67c67a