### PR TITLE
Disable cycle bias by default

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -212,7 +212,7 @@ breakout:
   vol_multiplier: 0.5
   volume_window: 15
 cycle_bias:
-  enabled: true
+  enabled: false
   mvrv_url: https://api.example.com/mvrv
   nupl_url: https://api.example.com/nupl
   sopr_url: https://api.example.com/sopr


### PR DESCRIPTION
## Summary
- disable cycle bias feature by default in crypto_bot configuration

## Testing
- `pytest tests/test_cycle_bias.py`

------
https://chatgpt.com/codex/tasks/task_e_68a51f3e7404833099ce6ee4f16d1ef4