### PR TITLE
Normalize cached timestamp comparison in market loader

### DIFF
--- a/crypto_bot/utils/market_loader.py
+++ b/crypto_bot/utils/market_loader.py
@@ -2907,6 +2907,10 @@ async def update_multi_tf_ohlcv_cache(
                         state = "bootstrap"
                         if sym in tf_cache and not tf_cache[sym].empty:
                             last_ts = tf_cache[sym]["timestamp"].iloc[-1]
+                            # Normalize cached timestamp to seconds so comparison with
+                            # `df_new` integer timestamps is consistent.
+                            if isinstance(last_ts, pd.Timestamp):
+                                last_ts = last_ts.value // 10 ** 9
                             df_new = df_new[df_new["timestamp"] > last_ts]
                             if df_new.empty:
                                 continue


### PR DESCRIPTION
## Summary
- Normalize cached timestamps to integer seconds before comparing with new OHLCV data
- Document the normalization to prevent future regressions

## Testing
- `python3 -m pytest tests/test_market_loader.py tests/test_market_loader_quotes.py tests/test_market_loader_timeout.py tests/test_market_loader_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_68a52245c6708330b9ddef6dc020e468