### PR TITLE
tune trend bot default thresholds

### DIFF
--- a/config/strategies/trend_bot.yaml
+++ b/config/strategies/trend_bot.yaml
@@ -1,8 +1,8 @@
 atr_period: 14
 k: 1.0
-trend_ema_fast: 3
-trend_ema_slow: 10
-adx_threshold: 25
+trend_ema_fast: 10
+trend_ema_slow: 30
+adx_threshold: 15
 setup_window: 10
 trigger_window: 3
 risk:

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -719,9 +719,9 @@ trade_size_pct: 0.3
 trend_bot:
   atr_period: 10
   k: 0.8
-  adx_threshold: 20
-  trend_ema_fast: 12
-  trend_ema_slow: 35
+  adx_threshold: 15
+  trend_ema_fast: 10
+  trend_ema_slow: 30
 twap_enabled: true
 twap_interval_seconds: 5
 twap_slices: 6


### PR DESCRIPTION
## Summary
- adjust trend bot EMA and ADX defaults
- sync trend bot parameters in crypto_bot config

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68a52fb8114c83309cf82610ed8d01a8