### PR TITLE
Use volume z-score for momentum bot

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -64,6 +64,7 @@ strategies:
   momentum_bot:
     enabled: true
     tf: "1m"
+    volume_z_min: 0.5
 
   breakout_bot:
     enabled: true
@@ -403,6 +404,7 @@ momentum_bot:
   slow_length: 50
   trigger_window: 3
   vol_multiplier: 1.0
+  volume_z_min: 0.5
 ohlcv_batch_size: 10
 ohlcv_snapshot_frequency_minutes: 720
 ohlcv_snapshot_limit: 500
@@ -533,6 +535,7 @@ sniper_solana:
 momentum_bot:
   donchian_period: 20
   vol_multiplier: 1.0
+  volume_z_min: 0.5
   atr_period: 14
   setup_window: 10
   trigger_window: 3


### PR DESCRIPTION
## Summary
- compute rolling volume z-score and replace multiplier check in momentum bot
- gate short entries on configurable volume_z_min and scale score by z-score
- expose new volume_z_min option in momentum_bot config

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*


------
https://chatgpt.com/codex/tasks/task_e_68a52fb9f5408330b4daf61fc3cae8b6