### PR TITLE
Adjust mean bot RSI thresholds

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -56,6 +56,8 @@ strategies:
     atr_stop_mult: 1.0
     max_spread_bp: 8
     time_exit_bars: 6
+    rsi_overbought_pct: 65
+    rsi_oversold_pct: 35
 
   trend_bot:
     enabled: true

--- a/crypto_bot/strategy/mean_bot.py
+++ b/crypto_bot/strategy/mean_bot.py
@@ -72,13 +72,13 @@ async def generate_signal(
     except (TypeError, ValueError):
         lookback_cfg = 14
     try:
-        rsi_overbought_pct = float(config.get("rsi_overbought_pct", 70))
+        rsi_overbought_pct = float(config.get("rsi_overbought_pct", 65))
     except (TypeError, ValueError):
-        rsi_overbought_pct = 70.0
+        rsi_overbought_pct = 65.0
     try:
-        rsi_oversold_pct = float(config.get("rsi_oversold_pct", 30))
+        rsi_oversold_pct = float(config.get("rsi_oversold_pct", 35))
     except (TypeError, ValueError):
-        rsi_oversold_pct = 30.0
+        rsi_oversold_pct = 35.0
     try:
         adx_threshold = float(config.get("adx_threshold", 25))
     except (TypeError, ValueError):


### PR DESCRIPTION
## Summary
- lower mean bot's default RSI overbought threshold to 65 and raise oversold to 35
- allow configuring these RSI thresholds via `config.yaml`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*
- `pytest tests/test_config.py` *(fails: AttributeError: <module 'crypto_bot.main' has no attribute 'ML_AVAILABLE'>)*

------
https://chatgpt.com/codex/tasks/task_e_68a52fba4cd88330afd9c968db096df8