### PR TITLE
Lower breakout bot ADX threshold

### DIFF
--- a/config/strategies/breakout_bot.yaml
+++ b/config/strategies/breakout_bot.yaml
@@ -3,7 +3,7 @@ vol_confirmation: true
 vol_multiplier: 0.5  # momentum filter remains disabled
 ema_window: 200
 adx_window: 14
-adx_threshold: 20
+adx_threshold: 15
 setup_window: 10
 trigger_window: 3
 risk:

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -68,6 +68,7 @@ strategies:
   breakout_bot:
     enabled: true
     tf: "1m"
+    adx_threshold: 15
 
   sniper_bot:
     enabled: true

--- a/crypto_bot/strategy/breakout_bot.py
+++ b/crypto_bot/strategy/breakout_bot.py
@@ -11,7 +11,7 @@ The ``breakout`` section of the config may include:
 ``adx_window`` (int)
     Lookback window for the ADX calculation (default ``14``).
 ``adx_threshold`` (float)
-    Minimum ADX value required to qualify a breakout (default ``20``).
+    Minimum ADX value required to qualify a breakout (default ``15``).
 
 Existing options such as ``bb_length`` or ``donchian_window`` remain
 unchanged.
@@ -115,7 +115,7 @@ def generate_signal(
 
     - ``ema_window`` – window for the EMA trend filter (default ``200``)
     - ``adx_window`` – lookback window for ADX (default ``14``)
-    - ``adx_threshold`` – minimum ADX value required (default ``20``)
+    - ``adx_threshold`` – minimum ADX value required (default ``15``)
 
     Returns
     -------
@@ -147,7 +147,7 @@ def generate_signal(
     vol_window = int(cfg.get("volume_window", 20))
     ema_window = int(cfg.get("ema_window", 200))
     adx_window = int(cfg.get("adx_window", 14))
-    adx_threshold = float(cfg.get("adx_threshold", 20))
+    adx_threshold = float(cfg.get("adx_threshold", 15))
     # Volume confirmation is now optional by default to allow breakouts without
     # a prior volume spike. Users can enable the old behaviour by explicitly
     # setting ``vol_confirmation: true`` in the strategy config.


### PR DESCRIPTION
## Summary
- Reduce `adx_threshold` default for breakout bot from 20 to 15
- Expose `adx_threshold` setting in main config for breakout bot

## Testing
- `pytest -q` *(fails: KeyboardInterrupt, no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68a52fbb27a88330bff46fea6e177192