### PR TITLE
Add strategy config fields for core bots

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -56,18 +56,25 @@ strategies:
     atr_stop_mult: 1.0
     max_spread_bp: 8
     time_exit_bars: 6
+    rsi_oversold: 35
+    rsi_overbought: 65
 
   trend_bot:
     enabled: true
     tf: "1m"
+    adx_threshold: 15
+    trend_ema_fast: 10
+    trend_ema_slow: 30
 
   momentum_bot:
     enabled: true
     tf: "1m"
+    volume_z_min: 0.5
 
   breakout_bot:
     enabled: true
     tf: "1m"
+    adx_threshold: 15
 
   sniper_bot:
     enabled: true
@@ -403,6 +410,7 @@ momentum_bot:
   slow_length: 50
   trigger_window: 3
   vol_multiplier: 1.0
+  volume_z_min: 0.5
 ohlcv_batch_size: 10
 ohlcv_snapshot_frequency_minutes: 720
 ohlcv_snapshot_limit: 500
@@ -719,9 +727,9 @@ trade_size_pct: 0.3
 trend_bot:
   atr_period: 10
   k: 0.8
-  adx_threshold: 20
-  trend_ema_fast: 12
-  trend_ema_slow: 35
+  adx_threshold: 15
+  trend_ema_fast: 10
+  trend_ema_slow: 30
 twap_enabled: true
 twap_interval_seconds: 5
 twap_slices: 6

--- a/crypto_bot/strategy/mean_bot.py
+++ b/crypto_bot/strategy/mean_bot.py
@@ -72,11 +72,15 @@ async def generate_signal(
     except (TypeError, ValueError):
         lookback_cfg = 14
     try:
-        rsi_overbought_pct = float(config.get("rsi_overbought_pct", 70))
+        rsi_overbought_pct = float(
+            config.get("rsi_overbought", config.get("rsi_overbought_pct", 70))
+        )
     except (TypeError, ValueError):
         rsi_overbought_pct = 70.0
     try:
-        rsi_oversold_pct = float(config.get("rsi_oversold_pct", 30))
+        rsi_oversold_pct = float(
+            config.get("rsi_oversold", config.get("rsi_oversold_pct", 30))
+        )
     except (TypeError, ValueError):
         rsi_oversold_pct = 30.0
     try:


### PR DESCRIPTION
## Summary
- extend config for trend, momentum, mean and breakout bots
- support volume z-score filtering in momentum bot
- allow mean bot to read RSI overbought/oversold thresholds

## Testing
- `pytest -q` *(fails: No module named 'cointrainer'; syntax error in tests/test_initial_scan.py)*
- `pytest tests/test_momentum_bot.py tests/test_mean_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a52fbc0a348330ad3bd5ac7c53d7a1