### PR TITLE
chore: update voting strategies

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -735,7 +735,6 @@ voting_strategies:
   strategies:
     - trend_bot
     - momentum_bot
-    - mean_bot
     - sniper_solana
   min_agreeing_votes: 1
 wallet_address: your_wallet


### PR DESCRIPTION
## Summary
- remove `mean_bot` from `voting_strategies` in crypto_bot config
- keep voting only for active bots `trend_bot`, `momentum_bot`, and `sniper_solana`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68a5314848248330b18fbd3f5a969ece