### PR TITLE
Lower ATR threshold for volatility filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ symbol_score_weights:
 * **max_liquidity_usage** – limit how much of the visible liquidity a single
   order may consume.
 * **weight_liquidity** – scoring weight for available pool liquidity on Solana pairs.
-* **volatility_filter** - skips trading when ATR is too low or funding exceeds `max_funding_rate`. The minimum ATR percent is `0.0005`.
+* **volatility_filter** - skips trading when ATR is too low or funding exceeds `max_funding_rate`. The minimum ATR percent is `0.0001`.
 * **sentiment_filter** - checks the Fear & Greed index and Twitter sentiment to avoid bearish markets.
 * **sl_pct**/**tp_pct** – defaults for Solana scalper strategies.
 * **mempool_monitor** – pause or reprice when Solana fees spike.

--- a/config.example.testing.yaml
+++ b/config.example.testing.yaml
@@ -29,3 +29,8 @@ yamlmeme_sniper:
   helius_api_key: your_key_here  # For metadata
 
 ohlcv_chunk_size: 20
+
+# === volatility filter ===
+volatility_filter:
+  max_funding_rate: 0.3
+  min_atr_pct: 0.0001

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -126,3 +126,8 @@ telegram:
   chat_id: YOUR_CHAT_ID
   status_updates: true
   bootstrap_updates: false
+
+# === volatility filter ===
+volatility_filter:
+  max_funding_rate: 0.3
+  min_atr_pct: 0.0001

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -736,7 +736,7 @@ use_per_pair_models: true
 use_websocket: true
 volatility_filter:
   max_funding_rate: 0.3
-  min_atr_pct: 0.0005
+  min_atr_pct: 0.0001
 voting_strategies:
   strategies:
     - trend_bot


### PR DESCRIPTION
## Summary
- decrease `volatility_filter.min_atr_pct` default to `0.0001`
- document new volatility filter threshold
- propagate lower ATR setting to example configurations

## Testing
- `pytest tests/test_volatility_filter.py tests/test_config.py::test_load_config_returns_dict -q`


------
https://chatgpt.com/codex/tasks/task_e_68a532ccd42c8330a0c28115fd99efb9