### PR TITLE
Adjust yamlrouter defaults to 0.25

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -646,8 +646,8 @@ strategy_router:
   trending_timeframe: 1h
   volatile_timeframe: 1m
 yamlrouter:
-  min_score: 0.4
-  min_confidence: 0.4
+  min_score: 0.25
+  min_confidence: 0.25
 symbol: XRPUSD
 symbol_batch_size: 50
 ohlcv_chunk_size: 20


### PR DESCRIPTION
## Summary
- Lower default yamlrouter thresholds to min_score and min_confidence of 0.25

## Testing
- `python - <<'PY'
import configy
cfg = configy.load_config()
print(cfg['yamlrouter'])
PY`
- `pytest tests/test_config.py::test_load_config_returns_dict -q`
- `pytest tests/test_config.py -q` *(fails: `test_load_config_normalizes_symbol`, `test_load_config_async_detects_section_changes`, `test_ensure_ml_only_on_change`)*

------
https://chatgpt.com/codex/tasks/task_e_68a53466ae3883308ed7ea4c631285d8