### PR TITLE
Handle low volatility with too_flat flag

### DIFF
--- a/crypto_bot/utils/market_analyzer.py
+++ b/crypto_bot/utils/market_analyzer.py
@@ -30,7 +30,7 @@ from crypto_bot.signals.signal_scoring import evaluate_async, evaluate_strategie
 from crypto_bot.utils.rank_logger import log_second_place
 from crypto_bot.strategy import grid_bot
 from crypto_bot.strategy import micro_scalp_bot
-from crypto_bot.volatility_filter import calc_atr
+from crypto_bot.volatility_filter import calc_atr, too_flat
 from ta.volatility import BollingerBands
 from ta.trend import ADXIndicator
 from crypto_bot.utils.stats import zscore
@@ -390,6 +390,9 @@ async def analyze_symbol(
     if total > 0:
         probs = {k: v / total for k, v in probs.items()}
 
+    min_atr_pct = float(config.get("volatility_filter", {}).get("min_atr_pct", 0.0))
+    is_flat = too_flat(df, threshold=min_atr_pct)
+
     result = {
         "symbol": symbol,
         "df": df,
@@ -400,6 +403,7 @@ async def analyze_symbol(
         "confidence": confidence,
         "min_confidence": min_conf_adaptive,
         "probabilities": probs,
+        "too_flat": is_flat,
     }
 
     if regime != "unknown":

--- a/tests/test_execute_signals.py
+++ b/tests/test_execute_signals.py
@@ -106,6 +106,44 @@ async def test_execute_signals_respects_allow_short(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
+async def test_execute_signals_respects_too_flat(monkeypatch, caplog):
+    df = pd.DataFrame({"close": [100.0]})
+    candidate = {
+        "symbol": "XBT/USDT",
+        "direction": "long",
+        "df": df,
+        "name": "test",
+        "probabilities": {},
+        "regime": "bull",
+        "score": 1.0,
+        "too_flat": True,
+    }
+    ctx = BotContext(
+        positions={},
+        df_cache={"1h": {"XBT/USDT": df}},
+        regime_cache={},
+        config={"execution_mode": "dry_run", "top_n_symbols": 1},
+        exchange=object(),
+        ws_client=None,
+        risk_manager=DummyRM(),
+        notifier=None,
+        paper_wallet=PaperWallet(1000.0),
+        position_guard=DummyPG(),
+    )
+    ctx.balance = 1000.0
+    ctx.analysis_results = [candidate]
+    ctx.timing = {}
+
+    execute_signals, called = load_execute_signals()
+    caplog.set_level(logging.INFO)
+    await execute_signals(ctx)
+
+    assert ctx.positions == {}
+    assert not called["called"]
+    assert "[EVAL] XBT/USDT -> atr too flat" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_execute_signals_logs_execution(monkeypatch, caplog):
     df = pd.DataFrame({"close": [100.0]})
     candidate = {


### PR DESCRIPTION
## Summary
- compute `too_flat` in `analyze_symbol` using configured `min_atr_pct`
- skip execution in `execute_signals` when a symbol is flagged `too_flat`
- add tests ensuring analysis sets the flag and execution respects it

## Testing
- `pre-commit run --files crypto_bot/utils/market_analyzer.py crypto_bot/main.py tests/test_execute_signals.py tests/test_regime_classifier.py` *(fails: command not found)*
- `pytest tests/test_execute_signals.py::test_execute_signals_respects_too_flat tests/test_regime_classifier.py::test_analyze_symbol_flags_too_flat -q`

------
https://chatgpt.com/codex/tasks/task_e_68a532ca417c833085b3a414bca45ca8