### PR TITLE
Make ATR threshold configurable

### DIFF
--- a/crypto_bot/risk/risk_manager.py
+++ b/crypto_bot/risk/risk_manager.py
@@ -293,12 +293,15 @@ class RiskManager:
             logger.info("[EVAL] %s", reason)
             return False, reason
 
-        if too_flat(df, 0.00001):
+        atr_threshold = getattr(self.config, "min_atr_pct", 0.0)
+        logger.info("[EVAL] ATR threshold: %.8f", atr_threshold)
+
+        if atr_threshold > 0 and too_flat(df, atr_threshold * 0.2):
             reason = "Volatility too low for HFT"
             logger.info("[EVAL] %s", reason)
             return False, reason
 
-        if too_flat(df, 0.00005):
+        if atr_threshold > 0 and too_flat(df, atr_threshold):
             reason = "Volatility too low"
             logger.info("[EVAL] %s", reason)
             return False, reason
@@ -309,7 +312,7 @@ class RiskManager:
             "Allow %s: vol=%.6f, flat=%s",
             symbol,
             current_volume,
-            too_flat(df, 0.00005),
+            too_flat(df, atr_threshold) if atr_threshold > 0 else False,
         )
         logger.info("[EVAL] %s", reason)
         return True, reason


### PR DESCRIPTION
## Summary
- use configurable ATR threshold in risk checks
- log ATR threshold and drop hardcoded values
- adjust risk manager tests for new threshold logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `pytest tests/test_risk_manager.py -q`
- `pytest tests/test_volatility_filter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a532ca539c833099e9418c83158dd9