### PR TITLE
Handle unknown regime in strategy router using trend bot fallback

### DIFF
--- a/crypto_bot/strategy_router.py
+++ b/crypto_bot/strategy_router.py
@@ -672,12 +672,12 @@ def route(
         cfg_get(cfg, "commit_lock_intervals", 0),
     )
 
-    if not ML_AVAILABLE and regime == "unknown":
-        logger.warning(
-            "ML unavailable; using fallback regime and default strategy. falling back to default strategy."
+    if regime == "unknown":
+        sym = (
+            cfg.raw.get("symbol", "") if isinstance(cfg, RouterConfig) else cfg.get("symbol", "")
         )
-        tf = cfg_get(cfg, "timeframe", "1h") if not isinstance(cfg, RouterConfig) else cfg.timeframe
-        return _wrap(wrap_with_tf(grid_bot.generate_signal, tf))
+        logger.warning("Unknown regime for %s; fallback to trend_bot", sym)
+        return _wrap(trend_bot.generate_signal)
 
     def _post_fastpath():
         symbol = ""


### PR DESCRIPTION
## Summary
- Fall back to `trend_bot` when strategy routing receives an `unknown` regime and log the issue
- Add tests verifying fallback behavior and logging for unknown regimes

## Testing
- `pytest tests/test_strategy_router.py -k 'test_route_unknown_fallback or test_route_unknown_returns_trend_bot' -q`
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a5340ae76883308e6717ed43be5c3a