### PR TITLE
refactor atr computations for strategies

### DIFF
--- a/crypto_bot/utils/volatility.py
+++ b/crypto_bot/utils/volatility.py
@@ -3,48 +3,31 @@ from __future__ import annotations
 
 import math
 import pandas as pd
+from ta.volatility import AverageTrueRange
 
 
-def calc_atr(
-    df: pd.DataFrame | None,
-    length: int = 14,
-    *,
-    period: int | None = None,
-    window: int | None = None,
-) -> pd.Series:
-    """Compute the Average True Range.
+def calc_atr(df: pd.DataFrame | None, period: int | None = None, window: int = 14) -> pd.Series:
+    """Return the Average True Range (ATR) as a :class:`pandas.Series`.
 
-    The lookback window may be provided via ``period``, ``window`` or
-    ``length``. These names are treated as aliases with the first
-    non-``None`` value taking precedence. A :class:`pandas.Series` of ATR
-    values is returned regardless of the input.
+    ``period`` takes precedence over ``window`` when both are provided. The
+    underlying calculation uses :class:`ta.volatility.AverageTrueRange`.
     """
 
-    n = int(period or window or length or 14)
+    n = int(period or window or 14)
     if df is None or df.empty or len(df) < max(2, n):
         if df is not None and "close" in df:
             return df["close"].iloc[:0]
         return pd.Series([], dtype=float)
 
-    h, l, c = df["high"], df["low"], df["close"]
-    tr = pd.concat(
-        [(h - l).abs(), (h - c.shift(1)).abs(), (l - c.shift(1)).abs()],
-        axis=1,
-    ).max(axis=1)
-    return tr.rolling(n, min_periods=n).mean()
+    atr = AverageTrueRange(high=df["high"], low=df["low"], close=df["close"], window=n)
+    return pd.Series(atr.average_true_range())
 
 
-def atr_percent(
-    df: pd.DataFrame,
-    length: int = 14,
-    *,
-    period: int | None = None,
-    window: int | None = None,
-) -> float:
+def atr_percent(df: pd.DataFrame, period: int | None = None, window: int = 14) -> float:
     """Return ATR as a percentage of the latest close price."""
 
     last_close = float(df["close"].iloc[-1])
-    atr_series = calc_atr(df, length=length, period=period, window=window)
+    atr_series = calc_atr(df, period=period, window=window)
     if atr_series.empty:
         return float("nan")
     atr_val = float(atr_series.iloc[-1])
@@ -53,30 +36,24 @@ def atr_percent(
     return 100.0 * atr_val / last_close
 
 
-def normalize_score_by_volatility(
-    df: pd.DataFrame,
-    score: float,
-    atr_period: int = 14,
-    *,
-    period: int | None = None,
-    length: int | None = None,
-    window: int | None = None,
-) -> float:
+def normalize_score_by_volatility(df: pd.DataFrame, score: float, atr_period: int = 14) -> float:
     """Normalize ``score`` by dividing by the latest ATR.
 
-    If the ATR cannot be computed or is zero the ``score`` is returned
+    If the ATR cannot be computed or is non‑positive the ``score`` is returned
     unchanged. This helper is used to de‑emphasise trading signals during
     periods of heightened volatility.
     """
 
-    n = int(period or length or window or atr_period)
-    atr_series = calc_atr(df, period=n)
-    if atr_series.empty:
-        return float(score)
-    atr_val = float(atr_series.iloc[-1])
-    if not math.isfinite(atr_val) or atr_val == 0:
-        return float(score)
-    return float(score) / float(atr_val)
+    atr = calc_atr(df, period=atr_period)
+    if hasattr(atr, "iloc"):
+        if len(atr) == 0:
+            return float(score)
+        atr_last = float(atr.iloc[-1])
+    else:
+        atr_last = float(atr)
+    if atr_last > 0:
+        score /= atr_last
+    return float(score)
 
 
 __all__ = ["calc_atr", "atr_percent", "normalize_score_by_volatility"]


### PR DESCRIPTION
## Summary
- refactor `calc_atr` to use `ta.volatility.AverageTrueRange` and accept `period` or `window`
- make `normalize_score_by_volatility` robust to ATR series or scalar outputs
- simplify `atr_percent` to follow new `calc_atr` API

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager')*
- `pytest tests/test_volatility_utils.py tests/test_risk_manager.py`
- `pytest tests/test_grid_bot.py`
- `pytest tests/test_volatility_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_68a538bc61348330b5d19a7628af67bf