### PR TITLE
Include timeframe in signal logs and propagate through generate_signal calls

### DIFF
--- a/backtest/historical_pools.py
+++ b/backtest/historical_pools.py
@@ -112,7 +112,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "volume": [1, 1],
             }
         )
-        sig_score, sig_dir = generate_signal(df, {"token": evt.token_mint})
+        sig_score, sig_dir = generate_signal(
+            df, {"token": evt.token_mint}, timeframe=cfg.get("timeframe")
+        )
         print(
             f"{evt.pool_address} score={score:.2f} dir={direction} "
             f"signal={sig_dir} ({sig_score:.2f})"

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -2407,7 +2407,11 @@ async def execute_signals(ctx: BotContext) -> None:
                     NEW_SOLANA_TOKENS.discard(sym)
                     continue
 
-            sol_score, _ = sniper_solana.generate_signal(df)
+            sol_score, _ = sniper_solana.generate_signal(
+                df,
+                symbol=sym,
+                timeframe=ctx.config.get("timeframe"),
+            )
             if sym in NEW_SOLANA_TOKENS:
                 NEW_SOLANA_TOKENS.discard(sym)
             if sol_score > 0.7:
@@ -2571,7 +2575,9 @@ async def handle_exits(ctx: BotContext) -> None:
 
         # DCA before evaluating exit conditions
         dca_cfg = ctx.config.get("dca", {})
-        dca_score, dca_dir = dca_bot.generate_signal(df)
+        dca_score, dca_dir = dca_bot.generate_signal(
+            df, symbol=sym, timeframe=tf
+        )
         if (
             dca_score > 0
             and pos.get("dca_count", 0) < dca_cfg.get("max_entries", 0)
@@ -2691,7 +2697,9 @@ async def handle_exits(ctx: BotContext) -> None:
             except Exception:
                 pass
         else:
-            score, direction = dca_bot.generate_signal(df)
+            score, direction = dca_bot.generate_signal(
+                df, symbol=sym, timeframe=tf
+            )
             dca_cfg = ctx.config.get("dca", {})
             max_entries = dca_cfg.get("max_entries", 0)
             size_pct = dca_cfg.get("size_pct", 1.0)

--- a/crypto_bot/strategy/dip_hunter.py
+++ b/crypto_bot/strategy/dip_hunter.py
@@ -65,7 +65,13 @@ def generate_signal(
     strategy = "dip_hunter"
 
     if cooldown_enabled and symbol and in_cooldown(symbol, strategy):
-        score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "cooldown")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            0.0,
+            "cooldown",
+        )
         return 0.0, "none"
 
     rsi_window = int(params.get("rsi_window", 14))
@@ -122,7 +128,13 @@ def generate_signal(
 
     with cooldown(symbol, strategy) as cd:
         if cooldown_enabled and symbol and not cd.allowed:
-            score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+            score_logger.info(
+                "Signal for %s:%s -> %.3f, %s",
+                symbol or "unknown",
+                timeframe or "N/A",
+                0.0,
+                "none",
+            )
             return 0.0, "none"
 
         oversold = latest["rsi"] < rsi_oversold and latest["bb_pct"] < 0
@@ -161,7 +173,13 @@ def generate_signal(
                 score = normalize_score_by_volatility(df, score)
 
             score = max(0.0, min(score, 1.0))
-            score_logger.info("Signal for %s: %s, %s", symbol, score, "long")
+            score_logger.info(
+                "Signal for %s:%s -> %.3f, %s",
+                symbol or "unknown",
+                timeframe or "N/A",
+                score,
+                "long",
+            )
             if cooldown_enabled and symbol:
                 cd.mark()
             return score, "long"

--- a/crypto_bot/strategy/grid_bot.py
+++ b/crypto_bot/strategy/grid_bot.py
@@ -212,10 +212,22 @@ def generate_signal(
         win_rate = get_recent_win_rate(4, strategy="grid_bot")
         skip_cd = win_rate > 0.7
         if not skip_cd and grid_state.in_cooldown(symbol, cfg.cooldown_bars):
-            score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+            score_logger.info(
+                "Signal for %s:%s -> %.3f, %s",
+                symbol or "unknown",
+                timeframe or "N/A",
+                0.0,
+                "none",
+            )
             return 0.0, "none"
         if grid_state.active_leg_count(symbol) >= cfg.max_active_legs:
-            score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+            score_logger.info(
+                "Signal for %s:%s -> %.3f, %s",
+                symbol or "unknown",
+                timeframe or "N/A",
+                0.0,
+                "none",
+            )
             return 0.0, "none"
 
     min_len = max(20, cfg.volume_ma_window)
@@ -324,7 +336,9 @@ def generate_signal(
     breakout_range = (high - low) / 2
     breakout_threshold = breakout_range * cfg.breakout_mult
     if price > centre + breakout_threshold or price < centre - breakout_threshold:
-        return breakout_bot.generate_signal(df, _as_dict(config))
+        return breakout_bot.generate_signal(
+            df, symbol=symbol, timeframe=timeframe, config=_as_dict(config)
+        )
 
     lower_bound = levels[1]
     upper_bound = levels[-2]
@@ -341,7 +355,9 @@ def generate_signal(
             if micro_scalp_bot is not None:
                 scalp_score, scalp_dir = micro_scalp_bot.generate_signal(
                     df,
-                    _as_dict(config),
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    config=_as_dict(config),
                     higher_df=higher_df,
                     mempool_monitor=mempool_monitor,
                     mempool_cfg=mempool_cfg,
@@ -362,7 +378,13 @@ def generate_signal(
                 pass
         if cfg.atr_normalization:
             score = normalize_score_by_volatility(df, score)
-        score_logger.info("Signal for %s: %s, %s", symbol, score, "long")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            score,
+            "long",
+        )
         return score, "long"
 
     if price >= upper_bound:
@@ -378,10 +400,22 @@ def generate_signal(
                 pass
         if cfg.atr_normalization:
             score = normalize_score_by_volatility(df, score)
-        score_logger.info("Signal for %s: %s, %s", symbol, score, "short")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            score,
+            "short",
+        )
         return score, "short"
 
-    score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+    score_logger.info(
+        "Signal for %s:%s -> %.3f, %s",
+        symbol or "unknown",
+        timeframe or "N/A",
+        0.0,
+        "none",
+    )
     return 0.0, "none"
 
 

--- a/crypto_bot/strategy/mean_bot.py
+++ b/crypto_bot/strategy/mean_bot.py
@@ -68,7 +68,13 @@ async def generate_signal(
     adx_window = 14
     min_bars = max(50, adx_window + 1)
     if len(df) < min_bars:
-        score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            0.0,
+            "none",
+        )
         return 0.0, "none"
 
     try:
@@ -258,7 +264,13 @@ async def generate_signal(
         score = normalize_score_by_volatility(df, score)
 
     score = float(max(0.0, min(score, 1.0)))
-    score_logger.info("Signal for %s: %s, %s", symbol, score, direction)
+    score_logger.info(
+        "Signal for %s:%s -> %.3f, %s",
+        symbol or "unknown",
+        timeframe or "N/A",
+        score,
+        direction,
+    )
     return score, direction
 
 

--- a/crypto_bot/strategy/meme_sniper.py
+++ b/crypto_bot/strategy/meme_sniper.py
@@ -68,7 +68,12 @@ async def monitor_pump_websocket(
                             df = await fetch_early_ohlcv(mint)
                             if df is None:
                                 continue
-                            score, direction, _ = generate_signal(df, cfg)
+                            score, direction, _ = generate_signal(
+                                df,
+                                cfg,
+                                symbol=symbol,
+                                timeframe=cfg.get("timeframe"),
+                            )
                             if score > 0.7 and direction == "buy":
                                 await execute_snipe(mint, cfg, exchange)
             except Exception as exc:  # pragma: no cover - network

--- a/crypto_bot/strategy/sniper_bot.py
+++ b/crypto_bot/strategy/sniper_bot.py
@@ -125,7 +125,13 @@ def generate_signal(
         and ALLOWED_PAIRS
         and symbol not in ALLOWED_PAIRS
     ):
-        score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            0.0,
+            "none",
+        )
         return 0.0, "none", 0.0, False
 
     if config:
@@ -146,14 +152,20 @@ def generate_signal(
         initial_window = max(1, initial_window // 2)
 
     if len(df) < initial_window:
-        msg = "Signal for %s: %s, %s"
-        score_logger.info(msg, symbol, 0.0, "none")
-        logger.info(msg, symbol, 0.0, "none")
+        msg = "Signal for %s:%s -> %.3f, %s"
+        score_logger.info(msg, symbol or "unknown", timeframe or "N/A", 0.0, "none")
+        logger.info(msg, symbol or "unknown", timeframe or "N/A", 0.0, "none")
         return 0.0, "none", 0.0, False
 
     first_close = df["close"].iloc[0]
     if first_close == 0:
-        score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            0.0,
+            "none",
+        )
         return 0.0, "none", 0.0, False
 
     price_change = df["close"].iloc[-1] / first_close - 1
@@ -162,7 +174,13 @@ def generate_signal(
         atr_series = volatility.calc_atr(df, period=atr_window)
         atr = float(atr_series.iloc[-1]) if not atr_series.empty else float("nan")
         if not np.isfinite(atr) or atr <= 0.0:
-            score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+            score_logger.info(
+                "Signal for %s:%s -> %.3f, %s",
+                symbol or "unknown",
+                timeframe or "N/A",
+                0.0,
+                "none",
+            )
             return 0.0, "none", {"reason": "bad_atr"}, False
         score = 1.0
         if MODEL is not None:
@@ -173,7 +191,13 @@ def generate_signal(
                 pass
         if config is None or config.get("atr_normalization", True):
             score = volatility.normalize_score_by_volatility(df, score)
-        score_logger.info("Signal for %s: %s, %s", symbol, score, "short")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            score,
+            "short",
+        )
         return score, "short", float(atr), False
 
     base_volume = df["volume"].iloc[:initial_window].mean()
@@ -185,7 +209,13 @@ def generate_signal(
     atr = atr_last
     event = False
     if not np.isfinite(atr_last) or atr_last <= 0.0:
-        score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            0.0,
+            "none",
+        )
         return 0.0, "none", {"reason": "bad_atr"}, event
 
     if len(df) > volume_window:
@@ -200,7 +230,13 @@ def generate_signal(
             event = True
 
     if df["volume"].iloc[-1] < min_volume:
-        score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            0.0,
+            "none",
+        )
         return 0.0, "none", float(atr_last), event
 
     if (
@@ -224,7 +260,13 @@ def generate_signal(
         trade_direction = direction
         if direction == "auto":
             trade_direction = "short" if price_change < 0 else "long"
-        score_logger.info("Signal for %s: %s, %s", symbol, score, trade_direction)
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            score,
+            trade_direction,
+        )
         return score, trade_direction, float(atr), event
 
     trade_direction = direction
@@ -234,7 +276,13 @@ def generate_signal(
         atr_series = volatility.calc_atr(df, period=atr_window)
         atr = float(atr_series.iloc[-1]) if not atr_series.empty else float("nan")
         if not np.isfinite(atr) or atr <= 0.0:
-            score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+            score_logger.info(
+                "Signal for %s:%s -> %.3f, %s",
+                symbol or "unknown",
+                timeframe or "N/A",
+                0.0,
+                "none",
+            )
             return 0.0, "none", {"reason": "bad_atr"}, event
         body = abs(df["close"].iloc[-1] - df["open"].iloc[-1])
         avg_vol = df["volume"].iloc[:-1].mean()
@@ -261,10 +309,22 @@ def generate_signal(
                     if df["close"].iloc[-1] < df["open"].iloc[-1]
                     else "long"
                 )
-            score_logger.info("Signal for %s: %s, %s", symbol, score, trade_direction)
+            score_logger.info(
+                "Signal for %s:%s -> %.3f, %s",
+                symbol or "unknown",
+                timeframe or "N/A",
+                score,
+                trade_direction,
+            )
             return score, trade_direction, atr, event
 
-    score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+    score_logger.info(
+        "Signal for %s:%s -> %.3f, %s",
+        symbol or "unknown",
+        timeframe or "N/A",
+        0.0,
+        "none",
+    )
     return 0.0, "none", float(atr) if atr is not None else 0.0, event
 
 

--- a/crypto_bot/strategy/trend_bot.py
+++ b/crypto_bot/strategy/trend_bot.py
@@ -67,7 +67,13 @@ def generate_signal(
     adx_window = 7
     min_bars = max(50, adx_window + 1)
     if df.empty or len(df) < min_bars:
-        score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            0.0,
+            "none",
+        )
         return 0.0, "none"
 
     df = df.copy()
@@ -131,7 +137,13 @@ def generate_signal(
     if (
         pd.isna(latest["ema_fast"]) or pd.isna(latest["ema_slow"]) or pd.isna(latest["rsi"])
     ):
-        score_logger.info("Signal for %s: %s, %s", symbol, 0.0, "none")
+        score_logger.info(
+            "Signal for %s:%s -> %.3f, %s",
+            symbol or "unknown",
+            timeframe or "N/A",
+            0.0,
+            "none",
+        )
         return 0.0, "none"
 
     adx = float(latest["adx"])
@@ -302,7 +314,13 @@ def generate_signal(
                 score = max(0.0, min(score, 1.0))
             except Exception:
                 pass
-    score_logger.info("Signal for %s: %s, %s", symbol, score, direction)
+    score_logger.info(
+        "Signal for %s:%s -> %.3f, %s",
+        symbol or "unknown",
+        timeframe or "N/A",
+        score,
+        direction,
+    )
     return score, direction
 
 


### PR DESCRIPTION
## Summary
- unify signal logging across strategies to include symbol and timeframe context
- pass timeframe to `generate_signal` in backtesting, strategies, and main execution flow

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68a53c7172f88330a5bdc19b688dc169