### PR TITLE
Add metrics and notification for unknown trading regimes

### DIFF
--- a/crypto_bot/strategy_router.py
+++ b/crypto_bot/strategy_router.py
@@ -678,8 +678,15 @@ def route(
         sym = (
             cfg.raw.get("symbol", "") if isinstance(cfg, RouterConfig) else cfg.get("symbol", "")
         )
-        logger.warning("Unknown regime for %s; fallback to trend_bot", sym)
-        return _wrap(trend_bot.generate_signal)
+        logger.warning("Unknown regime for %s; no strategy selected", sym)
+        telemetry.inc("router.unknown_regime")
+        if notifier is not None:
+            notifier.notify(f"Unknown regime for {sym}; no signal generated")
+
+        def _no_signal(df: pd.DataFrame | None = None, cfg=None) -> tuple[float, str]:
+            return 0.0, "none"
+
+        return _wrap(_no_signal)
 
     def _post_fastpath():
         symbol = ""


### PR DESCRIPTION
## Summary
- add telemetry counter and optional notifier when router encounters an unknown regime
- short-circuit unknown regimes to return no signal instead of routing to trend bot
- add test for unknown regime short-circuit and adjust telemetry test stubs

## Testing
- `pytest tests/test_router_telemetry.py::test_router_telemetry_counters tests/test_router_telemetry.py::test_unknown_regime_short_circuit -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5d3753c1483309900b5436ccc3194