### PR TITLE
Guard dry-run execution in execute_signals

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -2161,22 +2161,23 @@ async def execute_signals(ctx: BotContext) -> None:
         if reasons:
             logger.warning("Skipping %s: %s", sym, ", ".join(reasons))
             continue
-        logger.info("Executing dry-run trade...")
-        try:
-            await cex_trade_async(
-                ctx.exchange,
-                ctx.ws_client,
-                sym,
-                direction_to_side(direction),
-                0.0,
-                ctx.notifier,
-                dry_run=True,
-                config=ctx.config.get("exec"),
-                score=score,
-                reason="pre-filter",
-            )
-        except Exception as exc:  # pragma: no cover - best effort logging
-            logger.warning("Dry-run trade failed for %s: %s", sym, exc)
+        if ctx.config.get("execution_mode") == "dry_run":
+            logger.info("Executing dry-run trade...")
+            try:
+                await cex_trade_async(
+                    ctx.exchange,
+                    ctx.ws_client,
+                    sym,
+                    direction_to_side(direction),
+                    0.0,
+                    ctx.notifier,
+                    dry_run=True,
+                    config=ctx.config.get("exec"),
+                    score=score,
+                    reason="pre-filter",
+                )
+            except Exception as exc:  # pragma: no cover - best effort logging
+                logger.warning("Dry-run trade failed for %s: %s", sym, exc)
     ctx.reject_reasons = {}
     reject_counts = Counter()
 


### PR DESCRIPTION
## Summary
- Only execute placeholder CEX trades when execution_mode is set to `dry_run`

## Testing
- `pytest -q` *(fails: No module named 'cointrainer', FileNotFoundError: 'crypto_bot/logs/rl_selector.log')*

------
https://chatgpt.com/codex/tasks/task_e_68a62d665ffc8330a424202406d4cf69