### PR TITLE
Default logs directory inside repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 
-crypto_bot/logs/
+crypto_bot/logs/*
+!crypto_bot/logs/.gitignore
 crypto_bot/user_config.yaml
 crypto_bot/state/
 *.log

--- a/README.md
+++ b/README.md
@@ -1452,10 +1452,10 @@ lets you select the execution mode (dry run or live) before launching.
 ## Log Files
 
 All runtime information is written under the directory specified by the
-`LOG_DIR` environment variable. If unset, logs default to
-`~/.cointrader/logs`. References in this README to paths like
-`crypto_bot/logs/*.log` refer to files under this directory. Important files
-include:
+`LOG_DIR` environment variable. If unset, logs default to the
+`crypto_bot/logs` directory in this repository. References in this README to
+paths like `crypto_bot/logs/*.log` refer to files under this directory.
+Important files include:
 
 - `bot.log` – main log file containing startup events, strategy choices and all
   decision messages. `[EVAL]` lines record each symbol's evaluation outcome in

--- a/crypto_bot/logs/.gitignore
+++ b/crypto_bot/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/crypto_bot/utils/logger.py
+++ b/crypto_bot/utils/logger.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 # Default directory for all log files used across the project. Users can
 # override the location by setting the ``LOG_DIR`` environment variable.
-# If not provided, logs are written under ``~/.cointrader/logs``.
-LOG_DIR = Path(
-    os.environ.get("LOG_DIR", Path.home() / ".cointrader" / "logs")
-).expanduser()
+# If not provided, logs are written under ``crypto_bot/logs`` within the
+# repository.
+DEFAULT_LOG_DIR = Path(__file__).resolve().parents[1] / "logs"
+LOG_DIR = Path(os.environ.get("LOG_DIR", DEFAULT_LOG_DIR)).expanduser()
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- Store logs under `crypto_bot/logs` by default so users can easily locate them
- Document the new log directory and keep the folder in version control

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_68a724ba58148330b8392a89c768db86