### PR TITLE
Ensure ADX strategies handle short data

### DIFF
--- a/crypto_bot/strategy/breakout_bot.py
+++ b/crypto_bot/strategy/breakout_bot.py
@@ -160,7 +160,7 @@ def generate_signal(
     lookback_cfg = int(cfg_all.get("indicator_lookback", 250))
     squeeze_pct = float(cfg_all.get("bb_squeeze_pct", 20))
 
-    min_bars = adx_window + 1
+    min_bars = max(100, adx_window + 1)
     lookback = max(
         bb_len,
         kc_len,

--- a/crypto_bot/strategy/dip_hunter.py
+++ b/crypto_bot/strategy/dip_hunter.py
@@ -88,14 +88,14 @@ def generate_signal(
     atr_normalization = bool(params.get("atr_normalization", True))
     ema_slow = int(params.get("ema_slow", 20))
 
-    min_bars = max(adx_window, rsi_window, ema_slow) + 5
+    min_bars = max(100, adx_window, rsi_window, ema_slow) + 5
     if len(df) < min_bars:
         return 0.0, "none", {
             "reason": f"insufficient_bars: need>={min_bars}, have={len(df)}"
         }
 
     lookback = max(rsi_window, vol_window, adx_window, bb_window, dip_bars)
-    recent = df.tail(max(60, adx_window * 4, lookback + 1))
+    recent = df.tail(max(100, adx_window * 4, lookback + 1))
 
     rsi = ta.momentum.rsi(recent["close"], window=rsi_window)
     if len(recent) <= adx_window:

--- a/crypto_bot/strategy/mean_bot.py
+++ b/crypto_bot/strategy/mean_bot.py
@@ -65,7 +65,7 @@ def generate_signal(
     config = kwargs.get("config") or {}
     symbol = config.get("symbol", "")
     adx_window = 14
-    min_bars = max(50, adx_window + 1)
+    min_bars = max(100, adx_window + 1)
     if len(df) < min_bars:
         score_logger.info(
             "Signal for %s:%s -> %.3f, %s",

--- a/crypto_bot/strategy/mean_revert.py
+++ b/crypto_bot/strategy/mean_revert.py
@@ -71,7 +71,7 @@ def generate_signal(
     cfg = Config.from_dict(config)
 
     std_len = cfg.std_len or cfg.ema_len
-    min_bars = cfg.adx_window + 1
+    min_bars = max(100, cfg.adx_window + 1)
     lookback = max(cfg.ema_len, std_len, cfg.adx_window, cfg.atr_period) + 1
     lookback = max(lookback, min_bars)
     if len(df) < lookback:

--- a/crypto_bot/strategy/trend_bot.py
+++ b/crypto_bot/strategy/trend_bot.py
@@ -65,7 +65,7 @@ def generate_signal(
     config = kwargs.get("config") or {}
     symbol = config.get("symbol", "")
     adx_window = 7
-    min_bars = max(50, adx_window + 1)
+    min_bars = max(100, adx_window + 1)
     if df.empty or len(df) < min_bars:
         score_logger.info(
             "Signal for %s:%s -> %.3f, %s",
@@ -109,7 +109,7 @@ def generate_signal(
         df["high"], df["low"], df["close"], window=atr_period
     )
 
-    lookback = max(50, volume_window)
+    lookback = max(100, volume_window)
 
     rsi_full = ta.momentum.rsi(df["close"], window=14)
     rsi_full = cache_series("rsi", df, rsi_full, lookback)


### PR DESCRIPTION
## Summary
- safeguard ADX-based strategies by requiring at least 100 bars before indicator calculations
- extend trend bot lookbacks to 100 bars for stable ADX readings
- guard dip hunter's data window to always fetch enough history

## Testing
- `pytest` *(fails: ImportError while importing tests/test_wallet_manager.py, missing crypto_bot.wallet_manager)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a71fc608330856d0aaa633cd06f