### PR TITLE
Adjust dry-run thresholds for throughput testing

### DIFF
--- a/config.example.testing.yaml
+++ b/config.example.testing.yaml
@@ -1,4 +1,9 @@
 mode: paper
+
+trading:
+  min_score: 0.20
+  min_confidence: 0.30
+  consensus: weighted
 exchange:
   name: kraken
   max_concurrency: 3

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -10,6 +10,9 @@ trading:
   allowed_quotes: [USD, USDT, USDC, EUR]
   min_ticker_volume: 10000
   timeframes: ["1m","5m","15m","1h"]
+  min_score: 0.20
+  min_confidence: 0.30
+  consensus: weighted
   backfill:
     warmup_high_tf: ["1h","4h","1d"]
     deep_low_tf: true        # backfill 1m/5m history for strategies
@@ -647,8 +650,9 @@ strategy_router:
   trending_timeframe: 1h
   volatile_timeframe: 1m
 yamlrouter:
-  min_score: 0.1  # Lower to allow weaker signals
-  min_confidence: 0.1
+  min_score: 0.20
+  min_confidence: 0.30
+  consensus: weighted
   regimes:
     unknown:  # Fallback strategy for unknown
       - mean_bot


### PR DESCRIPTION
## Summary
- add trading min score and confidence thresholds for testing config
- raise default trading thresholds and set weighted consensus

## Testing
- `pytest tests/test_config.py -q` *(fails: AttributeError: <module 'crypto_bot.main' ...>; 2 other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a73b1357688330a4f16b39e5a9b36c