### PR TITLE
Allow strong single strategy to bypass quorum in dry-run

### DIFF
--- a/crypto_bot/utils/market_analyzer.py
+++ b/crypto_bot/utils/market_analyzer.py
@@ -631,16 +631,17 @@ async def analyze_symbol(
                 strong = [
                     (d, s)
                     for d, s, _w in votes
-                    if d in ("long", "short") and s > 0.5
+                    if d in ("long", "short") and abs(s) >= 0.65
                 ]
-                if strong:
-                    strong.sort(key=lambda x: x[1], reverse=True)
+                if strong and mode == "dry_run" and confidence >= 0.55:
+                    strong.sort(key=lambda x: abs(x[1]), reverse=True)
                     fb_dir, fb_score = strong[0]
                     analysis_logger.info(
-                        "Fallback applied for %s: %s (score=%.2f)",
+                        "Single-strategy override for %s: %s (score=%.2f, conf=%.2f)",
                         symbol,
                         fb_dir,
                         fb_score,
+                        confidence,
                     )
                     result["direction"] = fb_dir
     return result

--- a/tests/test_single_strong_signal_override.py
+++ b/tests/test_single_strong_signal_override.py
@@ -1,0 +1,69 @@
+import asyncio
+import numpy as np
+import pandas as pd
+import pytest
+
+import crypto_bot.utils.market_analyzer as ma
+from crypto_bot import strategy_router
+
+
+def _make_trending_df(rows: int = 50) -> pd.DataFrame:
+    close = np.linspace(1, 2, rows)
+    high = close + 0.1
+    low = close - 0.1
+    volume = np.arange(rows) + 100
+    return pd.DataFrame({
+        "open": close,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": volume,
+    })
+
+
+@pytest.mark.asyncio
+async def test_single_strong_signal_override_dry_run(monkeypatch):
+    df = _make_trending_df()
+
+    def base(df, cfg=None):
+        return 0.4, "short"
+
+    def strong(df, cfg=None):
+        return 0.7, "long"
+
+    monkeypatch.setattr(ma, "route", lambda *a, **k: base)
+    monkeypatch.setattr(strategy_router, "route", lambda *a, **k: base)
+    monkeypatch.setattr(ma, "get_strategy_by_name", lambda n: {"s": strong}.get(n))
+    monkeypatch.setattr(strategy_router, "get_strategy_by_name", lambda n: {"s": strong}.get(n))
+
+    cfg = {
+        "timeframe": "1h",
+        "regime_timeframes": ["1h"],
+        "voting_strategies": {"strategies": ["s"], "min_agreeing_votes": 2},
+    }
+    res = await ma.analyze_symbol("AAA", {"1h": df}, "dry_run", cfg, None)
+    assert res["direction"] == "long"
+
+
+@pytest.mark.asyncio
+async def test_single_strong_signal_live_respects_quorum(monkeypatch):
+    df = _make_trending_df()
+
+    def base(df, cfg=None):
+        return 0.4, "short"
+
+    def strong(df, cfg=None):
+        return 0.7, "long"
+
+    monkeypatch.setattr(ma, "route", lambda *a, **k: base)
+    monkeypatch.setattr(strategy_router, "route", lambda *a, **k: base)
+    monkeypatch.setattr(ma, "get_strategy_by_name", lambda n: {"s": strong}.get(n))
+    monkeypatch.setattr(strategy_router, "get_strategy_by_name", lambda n: {"s": strong}.get(n))
+
+    cfg = {
+        "timeframe": "1h",
+        "regime_timeframes": ["1h"],
+        "voting_strategies": {"strategies": ["s"], "min_agreeing_votes": 2},
+    }
+    res = await ma.analyze_symbol("AAA", {"1h": df}, "cex", cfg, None)
+    assert res["direction"] == "none"


### PR DESCRIPTION
## Summary
- permit trades during dry-run when a single strategy has score ≥0.65 and regime confidence ≥0.55 even without quorum
- add tests covering single-strong-signal override and live-mode behavior

## Testing
- `pre-commit run --files crypto_bot/utils/market_analyzer.py tests/test_single_strong_signal_override.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `pytest -q` *(fails: ImportError: cannot import name 'wallet_manager')*
- `pytest tests/test_single_strong_signal_override.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a73b2381988330b9192180e7148162