### PR TITLE
Handle invalid ATR values in compute_average_atr

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -515,7 +515,11 @@ def compute_average_atr(symbols: list[str], df_cache: dict, timeframe: str) -> f
         df = tf_cache.get(sym)
         if df is None or df.empty or "close" not in df:
             continue
-        atr_values.append(calc_atr(df).iloc[-1])
+        atr_series = calc_atr(df)
+        atr_val = float(atr_series.iloc[-1]) if len(atr_series) else np.nan
+        if np.isnan(atr_val) or atr_val <= 0:
+            continue
+        atr_values.append(atr_val)
     return sum(atr_values) / len(atr_values) if atr_values else 0.0
 
 


### PR DESCRIPTION
## Summary
- Filter out invalid or non-positive ATR values when calculating the average
- Ensure ATR computation handles empty series or NaN values gracefully

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_68a73c15e04c8330afc6dd2b0b519df6