### PR TITLE
refactor: handle atr calculation safely

### DIFF
--- a/crypto_bot/strategy_router.py
+++ b/crypto_bot/strategy_router.py
@@ -535,8 +535,12 @@ def _bandit_context(
             except Exception:
                 pass
 
-        atr_val = calc_atr(df).iloc[-1]
-        context["atr_pct"] = atr_val / price if price else 0.0
+        atr_series = calc_atr(df)
+        atr_val = float(atr_series.iloc[-1]) if len(atr_series) else np.nan
+        if np.isnan(atr_val) or atr_val <= 0 or price <= 0:
+            context["atr_pct"] = 0.0
+        else:
+            context["atr_pct"] = atr_val / price
 
         ts = df.index[-1]
         if not isinstance(ts, pd.Timestamp):


### PR DESCRIPTION
## Summary
- guard ATR calculation in `_bandit_context` to avoid invalid values
- ensure `atr_pct` set only when ATR and price are positive

## Testing
- `pytest tests/test_bandit_context.py tests/test_strategy_router.py -q` *(fails: assert '_no_signal' == 'generate_signal')*

------
https://chatgpt.com/codex/tasks/task_e_68a73c1b8d788330a011c1b2b147759b