### PR TITLE
Handle ATR series gracefully in signal scoring

### DIFF
--- a/crypto_bot/signals/signal_scoring.py
+++ b/crypto_bot/signals/signal_scoring.py
@@ -1,5 +1,6 @@
 from typing import Tuple, Callable, Optional, Iterable, Dict, List
 import pandas as pd
+import numpy as np
 import asyncio
 from crypto_bot.ml_signal_model import predict_signal
 from crypto_bot.indicators.cycle_bias import get_cycle_bias
@@ -31,7 +32,9 @@ def evaluate(
         score, direction = result, "none"
         atr = None
     score = max(0.0, min(score, 1.0))
-    if atr is not None:
+    if atr is not None and hasattr(atr, "iloc"):
+        atr = float(atr.iloc[-1]) if len(atr) else np.nan
+    if atr is not None and not (pd.isna(atr) or atr <= 0):
         indicator_logger.info(
             "ATR provided by %s: %.6f",
             getattr(strategy_fn, "__name__", str(strategy_fn)),


### PR DESCRIPTION
## Summary
- convert ATR Series to a float before logging
- skip ATR logging when value is NaN or non-positive

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis'; ModuleNotFoundError: No module named 'cointrainer'; SyntaxError: closing parenthesis '}' does not match opening parenthesis '(' on line 215)*

------
https://chatgpt.com/codex/tasks/task_e_68a73c26b9348330a572673d60277b3a