### PR TITLE
Skip neutral signals in fusion engine

### DIFF
--- a/crypto_bot/signals/signal_fusion.py
+++ b/crypto_bot/signals/signal_fusion.py
@@ -41,17 +41,23 @@ class SignalFusionEngine:
         for fn, weight in self.strategies:
             w = opt_weights.get(fn.__name__, weight)
             score, direction, _ = evaluate(fn, df, config)
+            if direction == "none" and score == 0.0:
+                continue
+
             weighted_score += score * w
             total_weight += w
 
             if direction == "long":
                 long_votes += 1
-                signed_sum += score * weight
+                signed_sum += score * w
             elif direction == "short":
                 short_votes += 1
-                signed_sum -= score * weight
+                signed_sum -= score * w
 
-        score = weighted_score / total_weight if total_weight else 0.0
+        if total_weight == 0:
+            return 0.0, "none"
+
+        score = weighted_score / total_weight
 
         if long_votes > short_votes:
             direction = "long"


### PR DESCRIPTION
## Summary
- ignore strategies that return `(0.0, "none")` during signal fusion
- compute weights and votes only from valid strategy outputs
- return neutral result when no weighted signals are available

## Testing
- `pytest -q` *(fails: No module named 'fakeredis'; No module named 'cointrainer'; SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a73c957db48330986714a3a627f52c