### PR TITLE
feat: support period alias for ATR window

### DIFF
--- a/crypto_bot/strategy/grid_bot.py
+++ b/crypto_bot/strategy/grid_bot.py
@@ -300,7 +300,7 @@ def generate_signal(
     else:
         centre = (high + low) / 2
 
-    atr_pct_1h = atr_percent(higher_df or df, atr_period)
+    atr_pct_1h = atr_percent(higher_df or df, window=atr_period)
     spacing_pct = max(0.3, 1.2 * atr_pct_1h)
     grid_step = price * spacing_pct / 100
 
@@ -336,9 +336,7 @@ def generate_signal(
     breakout_range = (high - low) / 2
     breakout_threshold = breakout_range * cfg.breakout_mult
     if price > centre + breakout_threshold or price < centre - breakout_threshold:
-        return breakout_bot.generate_signal(
-            df, symbol=symbol, timeframe=timeframe, config=_as_dict(config)
-        )
+        return breakout_bot.generate_signal(df, config=_as_dict(config))
 
     lower_bound = levels[1]
     upper_bound = levels[-2]

--- a/crypto_bot/utils/indicators.py
+++ b/crypto_bot/utils/indicators.py
@@ -71,8 +71,8 @@ def calc_atr(
     window : int, default 14
         Lookback window for the ATR calculation.
     period : int, optional
-        Alias for ``window`` kept for backwards compatibility.  When provided it
-        takes precedence over ``window``.
+        Deprecated alias for ``window`` kept for backwards compatibility. When
+        provided it takes precedence over ``window``.
     high, low, close : str
         Column names for the respective OHLC values.
     """

--- a/crypto_bot/utils/volatility.py
+++ b/crypto_bot/utils/volatility.py
@@ -43,6 +43,7 @@ def atr_percent(
 ) -> float:
     """Return ATR as a percentage of the latest close price."""
 
+    n = int(period or window or 14)
     last_close = float(df[close].iloc[-1])
     kwargs = {}
     if high != "high":
@@ -51,7 +52,7 @@ def atr_percent(
         kwargs["low"] = low
     if close != "close":
         kwargs["close"] = close
-    atr_series = calc_atr(df, period=period, window=window, **kwargs)
+    atr_series = calc_atr(df, window=n, **kwargs)
     if atr_series.empty:
         return float("nan")
     atr_val = float(atr_series.iloc[-1])
@@ -83,7 +84,7 @@ def normalize_score_by_volatility(
         kwargs["low"] = low
     if close != "close":
         kwargs["close"] = close
-    atr = calc_atr(df, period=atr_period, **kwargs)
+    atr = calc_atr(df, window=atr_period, **kwargs)
     if hasattr(atr, "iloc"):
         if len(atr) == 0:
             return float(score)


### PR DESCRIPTION
## Summary
- extend ATR utilities to accept legacy `period` keyword
- allow volatility wrappers to forward the alias as `window`
- update grid bot to use `atr_percent` with explicit window and simplify breakout handoff

## Testing
- `pytest tests/test_momentum_bot.py tests/test_micro_scalp_bot.py tests/test_grid_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68a752b91a648330958834a0abbc72d0