### PR TITLE
Normalize generate_signal config passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ grid_bot:
 
 * **atr_normalization** – adjust signal scores using ATR.
 ```python
-score, direction, atr = breakout_bot.generate_signal(lower_df, cfg, higher_df)
+score, direction, atr = breakout_bot.generate_signal(lower_df, config=cfg, higher_df=higher_df)
 size = risk_manager.position_size(
     score,
     balance,

--- a/backtest/historical_pools.py
+++ b/backtest/historical_pools.py
@@ -113,7 +113,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             }
         )
         sig_score, sig_dir = generate_signal(
-            df, {"token": evt.token_mint}, timeframe=cfg.get("timeframe")
+            df, config={"token": evt.token_mint}, timeframe=cfg.get("timeframe")
         )
         print(
             f"{evt.pool_address} score={score:.2f} dir={direction} "

--- a/crypto_bot/solana/scalping.py
+++ b/crypto_bot/solana/scalping.py
@@ -4,12 +4,9 @@ import ta
 
 def generate_signal(
     df: pd.DataFrame,
-    config: dict | None = None,
-    *,
-    pyth_price: float | None = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> tuple[float, str]:
     """Return a simple Solana scalping signal using RSI and MACD.
 
@@ -20,6 +17,15 @@ def generate_signal(
     config : dict, optional
         Optional configuration overriding default indicator windows.
     """
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config = kwargs.get("config")
+    pyth_price: float | None = kwargs.get("pyth_price")
+
     if df is None or df.empty:
         return 0.0, "none"
 

--- a/crypto_bot/solana/sniper_solana.py
+++ b/crypto_bot/solana/sniper_solana.py
@@ -23,12 +23,19 @@ class RugCheckAPI:
 
 def generate_signal(
     df: pd.DataFrame,
-    config: Optional[dict] = None,
     symbol: str | None = None,
     timeframe: str | None = None,
-    **_,
+    **kwargs,
 ) -> Tuple[float, str]:
     """Return a signal score and direction based on ATR jumps."""
+
+    if isinstance(symbol, dict) and timeframe is None:
+        kwargs.setdefault("config", symbol)
+        symbol = None
+    if isinstance(timeframe, dict):
+        kwargs.setdefault("config", timeframe)
+        timeframe = None
+    config: Optional[dict] = kwargs.get("config")
 
     if df is None or df.empty:
         return 0.0, "none"

--- a/crypto_bot/strategy/grid_bot.py
+++ b/crypto_bot/strategy/grid_bot.py
@@ -184,8 +184,6 @@ def generate_signal(
     df: pd.DataFrame,
     symbol: str | None = None,
     timeframe: str | None = None,
-    mempool_monitor: SolanaMempoolMonitor | None = None,
-    mempool_cfg: dict | None = None,
     **kwargs,
 ) -> Tuple[float, str]:
     """Generate a grid based trading signal."""

--- a/crypto_bot/strategy/micro_scalp_bot.py
+++ b/crypto_bot/strategy/micro_scalp_bot.py
@@ -52,11 +52,6 @@ def generate_signal(
     df: pd.DataFrame,
     symbol: str | None = None,
     timeframe: str | None = None,
-    mempool_monitor: Optional[SolanaMempoolMonitor] = None,
-    mempool_cfg: Optional[dict] = None,
-    tick_data: pd.DataFrame | None = None,
-    book: Optional[dict] = None,
-    ticks: Optional[pd.DataFrame] = None,
     **kwargs,
 ) -> Tuple[float, str]:
     """Return short-term signal using EMA crossover on 1m data.
@@ -108,8 +103,8 @@ def generate_signal(
         timeframe = None
     config = kwargs.get("config")
     higher_df = kwargs.get("higher_df")
-    mempool_monitor = mempool_monitor or kwargs.get("mempool_monitor")
-    mempool_cfg = mempool_cfg or kwargs.get("mempool_cfg")
+    mempool_monitor: Optional[SolanaMempoolMonitor] = kwargs.get("mempool_monitor")
+    mempool_cfg: Optional[dict] = kwargs.get("mempool_cfg")
     tick_data: pd.DataFrame | None = kwargs.get("tick_data")
     book: Optional[dict] = kwargs.get("book")
     ticks: Optional[pd.DataFrame] = kwargs.get("ticks")

--- a/crypto_bot/strategy/sniper_bot.py
+++ b/crypto_bot/strategy/sniper_bot.py
@@ -34,18 +34,6 @@ def generate_signal(
     df: pd.DataFrame,
     symbol: str | None = None,
     timeframe: str | None = None,
-    breakout_pct: float = 0.01,
-    volume_multiple: float = 1.2,
-    max_history: int = 30,
-    initial_window: int = 3,
-    min_volume: float = 100.0,
-    direction: str = "auto",
-    high_freq: bool = False,
-    atr_window: int = 14,
-    volume_window: int = 5,
-    price_fallback: bool = True,
-    fallback_atr_mult: float = 1.5,
-    fallback_volume_mult: float = 1.2,
     **kwargs,
 ) -> Tuple[float, str, float | dict, bool]:
     """Detect pumps for newly listed tokens using early price and volume action.

--- a/tests/test_bounce_scalper.py
+++ b/tests/test_bounce_scalper.py
@@ -48,7 +48,7 @@ def test_long_bounce_signal(monkeypatch):
         "up_candles": 2,
         "body_pct": 0.5,
     }
-    score, direction = bounce_scalper.generate_signal(df, cfg)
+    score, direction = bounce_scalper.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score > 0
 
@@ -79,7 +79,7 @@ def test_short_bounce_signal(monkeypatch):
         "up_candles": 2,
         "body_pct": 0.5,
     }
-    score, direction = bounce_scalper.generate_signal(df, cfg)
+    score, direction = bounce_scalper.generate_signal(df, config=cfg)
     assert direction == "short"
     assert score > 0
 
@@ -103,7 +103,7 @@ def test_no_signal_without_volume_spike():
         "up_candles": 2,
         "body_pct": 0.5,
     }
-    score, direction = bounce_scalper.generate_signal(df, cfg)
+    score, direction = bounce_scalper.generate_signal(df, config=cfg)
     assert direction == "none"
     assert score == 0.0
 
@@ -119,7 +119,7 @@ def test_respects_cooldown(monkeypatch):
         overbought=70,
         volume_multiple=2.0,
     )
-    score, direction = bounce_scalper.generate_signal(df, cfg)
+    score, direction = bounce_scalper.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score > 0
 
@@ -147,7 +147,7 @@ def test_mark_cooldown_called(monkeypatch):
         overbought=70,
         volume_multiple=2.0,
     )
-    score, direction = bounce_scalper.generate_signal(df, cfg)
+    score, direction = bounce_scalper.generate_signal(df, config=cfg)
     assert direction == "short"
     assert score > 0
 
@@ -159,7 +159,7 @@ def test_mark_cooldown_called(monkeypatch):
 
     monkeypatch.setattr(bounce_scalper.cooldown_manager, "mark_cooldown", fake_mark)
 
-    score, direction = bounce_scalper.generate_signal(df, {"symbol": "ETH/USD"})
+    score, direction = bounce_scalper.generate_signal(df, config={"symbol": "ETH/USD"})
     assert direction == "long"
     assert score > 0.0
     assert called == {"symbol": "ETH/USD", "strategy": "bounce_scalper"}
@@ -184,7 +184,7 @@ def test_order_book_imbalance_blocks(monkeypatch):
     }
 
     cfg = {"symbol": "BTC/USD", "imbalance_ratio": 2.0}
-    score, direction = bounce_scalper.generate_signal(df, cfg, book=snap)
+    score, direction = bounce_scalper.generate_signal(df, config=cfg, book=snap)
     assert direction == "none"
     assert score == 0.0
 
@@ -208,7 +208,7 @@ def test_order_book_imbalance_blocks_short(monkeypatch):
     }
 
     cfg = {"symbol": "BTC/USD", "imbalance_ratio": 2.0}
-    score, direction = bounce_scalper.generate_signal(df, cfg, book=snap)
+    score, direction = bounce_scalper.generate_signal(df, config=cfg, book=snap)
     assert direction == "none"
     assert score == 0.0
 
@@ -235,7 +235,7 @@ def test_imbalance_penalty_reduces_score(monkeypatch):
     }
 
     cfg = {"symbol": "BTC/USD", "imbalance_ratio": 2.0, "imbalance_penalty": 0.5}
-    score, direction = bounce_scalper.generate_signal(df, cfg, book=snap)
+    score, direction = bounce_scalper.generate_signal(df, config=cfg, book=snap)
     assert direction == "long"
     assert 0 < score < base_score
 
@@ -315,8 +315,8 @@ def test_cooldown_blocks_successive_signals(monkeypatch):
         overbought=70,
         volume_multiple=2.0,
     )
-    first = bounce_scalper.generate_signal(df, cfg)
-    second = bounce_scalper.generate_signal(df, cfg)
+    first = bounce_scalper.generate_signal(df, config=cfg)
+    second = bounce_scalper.generate_signal(df, config=cfg)
 
     assert first[1] != "none"
     assert second[1] == "none"
@@ -356,7 +356,7 @@ def test_adaptive_rsi_threshold(monkeypatch):
         "rsi_oversold_pct": 10,
         "body_pct": 0.5,
     }
-    score, direction = bounce_scalper.generate_signal(df, cfg)
+    score, direction = bounce_scalper.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score > 0
 
@@ -388,10 +388,10 @@ def test_trigger_once(monkeypatch):
         bounce_scalper, "normalize_score_by_volatility", lambda df, score: score
     )
     cfg = BounceScalperConfig(symbol="XBT/USDT", cooldown_enabled=True)
-    first = bounce_scalper.generate_signal(df, cfg)
-    second = bounce_scalper.generate_signal(df, cfg)
-    third = bounce_scalper.generate_signal(df, cfg, force=True)
-    fourth = bounce_scalper.generate_signal(df, cfg)
+    first = bounce_scalper.generate_signal(df, config=cfg)
+    second = bounce_scalper.generate_signal(df, config=cfg)
+    third = bounce_scalper.generate_signal(df, config=cfg, force=True)
+    fourth = bounce_scalper.generate_signal(df, config=cfg)
 
     assert first[1] != "none"
     assert second[1] == "none"
@@ -417,10 +417,10 @@ def test_trainer_model_influence(monkeypatch):
         "atr_normalization": False,
     }
     monkeypatch.setattr(bounce_scalper, "MODEL", None)
-    base, direction = bounce_scalper.generate_signal(df, cfg)
+    base, direction = bounce_scalper.generate_signal(df, config=cfg)
     dummy = types.SimpleNamespace(predict=lambda _df: 0.6)
     monkeypatch.setattr(bounce_scalper, "MODEL", dummy)
-    score, direction2 = bounce_scalper.generate_signal(df, cfg)
+    score, direction2 = bounce_scalper.generate_signal(df, config=cfg)
     assert direction2 == direction
     assert score == pytest.approx((base + 0.6) / 2)
 
@@ -459,7 +459,7 @@ def test_lower_df_pattern_detection(monkeypatch):
         "up_candles": 2,
         "body_pct": 0.5,
     }
-    score, direction = bounce_scalper.generate_signal(df, cfg, lower_df=lower_df)
+    score, direction = bounce_scalper.generate_signal(df, config=cfg, lower_df=lower_df)
     assert direction == "long"
     assert score > 0
 
@@ -474,7 +474,7 @@ def test_short_df_returns_none():
             "volume": [1.0],
         }
     )
-    score, direction = bounce_scalper.generate_signal(df, {})
+    score, direction = bounce_scalper.generate_signal(df, config={})
     assert direction == "none"
     assert score == 0.0
 

--- a/tests/test_cross_chain_arb_bot.py
+++ b/tests/test_cross_chain_arb_bot.py
@@ -28,7 +28,7 @@ def test_spread_generates_signal(monkeypatch):
 
     monkeypatch.setattr(cross_chain_arb_bot, "fetch_solana_prices", fake_fetch)
     cfg = {"cross_chain_arb_bot": {"pair": "SOL/USDC", "spread_threshold": 0.05}}
-    score, direction = cross_chain_arb_bot.generate_signal(df, cfg, mempool_monitor=DummyMonitor(False), mempool_cfg={"enabled": True, "suspicious_fee_threshold": 30})
+    score, direction = cross_chain_arb_bot.generate_signal(df, config=cfg, mempool_monitor=DummyMonitor(False), mempool_cfg={"enabled": True, "suspicious_fee_threshold": 30})
     assert direction == "long"
     assert score > 0
 
@@ -40,7 +40,7 @@ def test_below_threshold_no_signal(monkeypatch):
 
     monkeypatch.setattr(cross_chain_arb_bot, "fetch_solana_prices", fake_fetch)
     cfg = {"cross_chain_arb_bot": {"pair": "SOL/USDC", "spread_threshold": 0.05}}
-    score, direction = cross_chain_arb_bot.generate_signal(df, cfg, mempool_monitor=DummyMonitor(False), mempool_cfg={"enabled": True, "suspicious_fee_threshold": 30})
+    score, direction = cross_chain_arb_bot.generate_signal(df, config=cfg, mempool_monitor=DummyMonitor(False), mempool_cfg={"enabled": True, "suspicious_fee_threshold": 30})
     assert (score, direction) == (0.0, "none")
 
 
@@ -51,5 +51,5 @@ def test_fee_blocks_signal(monkeypatch):
 
     monkeypatch.setattr(cross_chain_arb_bot, "fetch_solana_prices", fake_fetch)
     cfg = {"cross_chain_arb_bot": {"pair": "SOL/USDC", "spread_threshold": 0.05}}
-    score, direction = cross_chain_arb_bot.generate_signal(df, cfg, mempool_monitor=DummyMonitor(True), mempool_cfg={"enabled": True, "suspicious_fee_threshold": 5})
+    score, direction = cross_chain_arb_bot.generate_signal(df, config=cfg, mempool_monitor=DummyMonitor(True), mempool_cfg={"enabled": True, "suspicious_fee_threshold": 5})
     assert (score, direction) == (0.0, "none")

--- a/tests/test_dex_scalper.py
+++ b/tests/test_dex_scalper.py
@@ -64,7 +64,7 @@ def test_scalper_custom_config():
     close = pd.Series(range(1, 41))
     df = pd.DataFrame({'close': close})
     cfg = {'dex_scalper': {'ema_fast': 3, 'ema_slow': 10, 'min_signal_score': 0.05}}
-    score, direction = dex_scalper.generate_signal(df, cfg)
+    score, direction = dex_scalper.generate_signal(df, config=cfg)
     assert direction == 'long'
     assert score > 0
 
@@ -74,7 +74,7 @@ def test_priority_fee_aborts(monkeypatch):
     df = pd.DataFrame({"close": close})
     monkeypatch.setenv("MOCK_PRIORITY_FEE", "50")
     cfg = {"dex_scalper": {"priority_fee_cap_micro_lamports": 10}}
-    score, direction = dex_scalper.generate_signal(df, cfg)
+    score, direction = dex_scalper.generate_signal(df, config=cfg)
     assert score == 0.0
     assert direction == "none"
 
@@ -84,7 +84,7 @@ def test_priority_fee_below_threshold(monkeypatch):
     df = pd.DataFrame({"close": close})
     monkeypatch.setenv("MOCK_PRIORITY_FEE", "5")
     cfg = {"dex_scalper": {"priority_fee_cap_micro_lamports": 10}}
-    score, direction = dex_scalper.generate_signal(df, cfg)
+    score, direction = dex_scalper.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score > 0
 
@@ -101,7 +101,7 @@ def test_monitor_fee_blocks_signal():
     df = pd.DataFrame({"close": pd.Series(range(1, 21))})
     cfg = {"dex_scalper": {"priority_fee_cap_micro_lamports": 10}}
     score, direction = dex_scalper.generate_signal(
-        df, cfg, mempool_monitor=DummyMonitor(15)
+        df, config=cfg, mempool_monitor=DummyMonitor(15)
     )
     assert score == 0.0
     assert direction == "none"
@@ -111,7 +111,7 @@ def test_monitor_fee_allows_signal():
     df = pd.DataFrame({"close": pd.Series(range(1, 21))})
     cfg = {"dex_scalper": {"priority_fee_cap_micro_lamports": 10}}
     score, direction = dex_scalper.generate_signal(
-        df, cfg, mempool_monitor=DummyMonitor(5)
+        df, config=cfg, mempool_monitor=DummyMonitor(5)
     )
     assert direction == "long"
     assert score > 0

--- a/tests/test_flash_crash_bot.py
+++ b/tests/test_flash_crash_bot.py
@@ -49,4 +49,4 @@ def test_ema_filter_blocks():
         }
     )
     cfg = {"flash_crash": {"ema_window": 5}}
-    assert flash_crash_bot.generate_signal(df, cfg) == (0.0, "none")
+    assert flash_crash_bot.generate_signal(df, config=cfg) == (0.0, "none")

--- a/tests/test_mean_bot.py
+++ b/tests/test_mean_bot.py
@@ -16,7 +16,7 @@ mean_bot = importlib.import_module("crypto_bot.strategy.mean_bot")
 
 
 def _run(df, cfg=None):
-    return mean_bot.generate_signal(df, cfg)
+    return mean_bot.generate_signal(df, config=cfg)
 
 
 def _df_with_drop(price: float, last_width: float = 5.0) -> pd.DataFrame:

--- a/tests/test_meme_wave_bot.py
+++ b/tests/test_meme_wave_bot.py
@@ -153,7 +153,7 @@ def test_high_volume_positive_sentiment(meme_df, high_monitor, monkeypatch):
     )
     cfg = {"meme_wave_bot": {"volume_threshold": 3, "sentiment_threshold": 0.6}}
     score, direction = asyncio.run(
-        meme_wave_bot.generate_signal(df, cfg, mempool_monitor=high_monitor)
+        meme_wave_bot.generate_signal(df, config=cfg, mempool_monitor=high_monitor)
     )
     assert (score, direction) == (1.0, "long")
 
@@ -175,7 +175,7 @@ def test_high_volume_negative_sentiment(meme_df, high_monitor, monkeypatch):
     )
     cfg = {"meme_wave_bot": {"volume_threshold": 3, "sentiment_threshold": 0.6}}
     score, direction = asyncio.run(
-        meme_wave_bot.generate_signal(df, cfg, mempool_monitor=high_monitor)
+        meme_wave_bot.generate_signal(df, config=cfg, mempool_monitor=high_monitor)
     )
     assert (score, direction) == (0.0, "none")
 
@@ -197,7 +197,7 @@ def test_low_volume_any_sentiment(meme_df, low_monitor, monkeypatch):
     )
     cfg = {"meme_wave_bot": {"volume_threshold": 3, "sentiment_threshold": 0.6}}
     score, direction = asyncio.run(
-        meme_wave_bot.generate_signal(df, cfg, mempool_monitor=low_monitor)
+        meme_wave_bot.generate_signal(df, config=cfg, mempool_monitor=low_monitor)
     )
     assert (score, direction) == (0.0, "none")
 

--- a/tests/test_micro_scalp_bot.py
+++ b/tests/test_micro_scalp_bot.py
@@ -34,7 +34,7 @@ def test_micro_scalp_long_signal(make_df):
     prices = list(range(1, 21))
     volumes = [100] * 19 + [150]
     df = make_df(prices, volumes)
-    score, direction = micro_scalp_bot.generate_signal(df, None)
+    score, direction = micro_scalp_bot.generate_signal(df)
     assert direction == "long"
     assert 0 < score <= 1
 
@@ -53,7 +53,7 @@ def test_cross_with_momentum_and_wick(make_df):
         }
     }
     df = make_df(prices, volumes)
-    score, direction = micro_scalp_bot.generate_signal(df, cfg)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score > 0
 
@@ -63,7 +63,7 @@ def test_volume_filter_blocks_signal(make_df):
     volumes = [1] * 10
     df = make_df(prices, volumes)
     cfg = {"micro_scalp_bot": {"min_vol_z": 2, "volume_window": 5, "fresh_cross_only": False}}
-    score, direction = micro_scalp_bot.generate_signal(df, cfg)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg)
     assert (score, direction) == (0.0, "none")
 
 
@@ -72,7 +72,7 @@ def test_atr_filter_blocks_signal(make_df):
     volumes = [100] * 10
     df = make_df(prices, volumes)
     cfg = {"micro_scalp_bot": {"atr_period": 3, "min_atr_pct": 0.2, "fresh_cross_only": False}}
-    score, direction = micro_scalp_bot.generate_signal(df, cfg)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg)
     assert (score, direction) == (0.0, "none")
 
 
@@ -85,7 +85,7 @@ def test_trend_filter_blocks_long_signal(make_df):
     higher_df = make_df(higher_prices, [100] * len(higher_prices))
     cfg = {"micro_scalp_bot": {"trend_fast": 3, "trend_slow": 5, "fresh_cross_only": False, "min_vol_z": 0}}
 
-    score, direction = micro_scalp_bot.generate_signal(df, cfg, higher_df=higher_df)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg, higher_df=higher_df)
     assert (score, direction) == (0.0, "none")
 
 
@@ -98,7 +98,7 @@ def test_trend_filter_allows_long_signal(make_df):
     higher_df = make_df(higher_prices, [100] * len(higher_prices))
     cfg = {"micro_scalp_bot": {"trend_fast": 3, "trend_slow": 5, "fresh_cross_only": False, "min_vol_z": 0}}
 
-    score, direction = micro_scalp_bot.generate_signal(df, cfg, higher_df=higher_df)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg, higher_df=higher_df)
     assert direction == "long"
     assert score > 0
 
@@ -108,7 +108,7 @@ def test_min_momentum_blocks_signal(make_df):
     volumes = [100] * 10
     df = make_df(prices, volumes)
     cfg = {"micro_scalp_bot": {"min_momentum_pct": 0.01, "fresh_cross_only": False}}
-    score, direction = micro_scalp_bot.generate_signal(df, cfg)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg)
     assert (score, direction) == (0.0, "none")
 
 
@@ -117,7 +117,7 @@ def test_confirm_bars_blocks_fresh_cross(make_df):
     volumes = [100] * len(prices)
     df = make_df(prices, volumes)
     cfg = {"micro_scalp_bot": {"confirm_bars": 2, "fresh_cross_only": False}}
-    score, direction = micro_scalp_bot.generate_signal(df, cfg)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg)
     assert (score, direction) == (0.0, "none")
 
 
@@ -126,7 +126,7 @@ def test_fresh_cross_only_signal(make_df):
     volumes = [100] * len(prices)
     df = make_df(prices, volumes)
     cfg = {"micro_scalp_bot": {"fresh_cross_only": True, "confirm_bars": 1, "min_vol_z": 0}}
-    score, direction = micro_scalp_bot.generate_signal(df, cfg)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg)
     assert direction == "short"
     assert score > 0
 
@@ -136,7 +136,7 @@ def test_fresh_cross_only_requires_change(make_df):
     volumes = [100] * len(prices)
     df = make_df(prices, volumes)
     cfg = {"micro_scalp_bot": {"fresh_cross_only": True, "confirm_bars": 1}}
-    score, direction = micro_scalp_bot.generate_signal(df, cfg)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg)
     assert (score, direction) == (0.0, "none")
 
 
@@ -146,7 +146,7 @@ def test_wick_filter_blocks_long(make_df):
     df = make_df(prices, volumes)
     df.loc[df.index[-1], "low"] = df["close"].iloc[-1] - 0.05
     cfg = {"micro_scalp_bot": {"wick_pct": 0.2, "fresh_cross_only": False}}
-    score, direction = micro_scalp_bot.generate_signal(df, cfg)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg)
     assert (score, direction) == (0.0, "none")
 
 
@@ -156,7 +156,7 @@ def test_wick_filter_blocks_short(make_df):
     df = make_df(prices, volumes)
     df.loc[df.index[-1], "high"] = df["close"].iloc[-1] + 0.05
     cfg = {"micro_scalp_bot": {"wick_pct": 0.2, "fresh_cross_only": False}}
-    score, direction = micro_scalp_bot.generate_signal(df, cfg)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg)
     assert (score, direction) == (0.0, "none")
 
 
@@ -182,7 +182,7 @@ def test_wick_filter_blocks_short(make_df):
 )
 def test_filters_return_none(make_df, prices, volumes, cfg):
     df = make_df(prices, volumes)
-    assert micro_scalp_bot.generate_signal(df, cfg) == (0.0, "none")
+    assert micro_scalp_bot.generate_signal(df, config=cfg) == (0.0, "none")
 
 
 class DummyMempool:
@@ -217,7 +217,7 @@ def test_mempool_fee_boosts_score(make_df):
     prices = list(range(1, 11))
     volumes = [100] * 10
     df = make_df(prices, volumes)
-    base_score, base_dir = micro_scalp_bot.generate_signal(df, {"micro_scalp_bot": {"min_vol_z": 0}})
+    base_score, base_dir = micro_scalp_bot.generate_signal(df, config={"micro_scalp_bot": {"min_vol_z": 0}})
     monitor = LowFeeMempool()
     boosted, boosted_dir = micro_scalp_bot.generate_signal(
         df, {"micro_scalp_bot": {"min_vol_z": 0}}, mempool_monitor=monitor
@@ -230,7 +230,7 @@ def test_tick_data_extends(make_df):
     df = make_df([1, 2, 3], [100, 100, 100])
     tick = make_df([4], [50])
     cfg = {"micro_scalp_bot": {"fresh_cross_only": False, "min_vol_z": 0}}
-    micro_scalp_bot.generate_signal(df, cfg, tick_data=tick)
+    micro_scalp_bot.generate_signal(df, config=cfg, tick_data=tick)
 
 
 def test_trend_filter_disabled_allows_signal(make_df):
@@ -250,7 +250,7 @@ def test_trend_filter_disabled_allows_signal(make_df):
         }
     }
 
-    score, direction = micro_scalp_bot.generate_signal(df, cfg, higher_df=higher_df)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg, higher_df=higher_df)
     assert direction == "long"
     assert score > 0
 
@@ -269,7 +269,7 @@ def test_imbalance_filter_disabled_allows_signal(make_df):
         }
     }
 
-    score, direction = micro_scalp_bot.generate_signal(df, cfg, book=book)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg, book=book)
     assert direction == "long"
     assert score > 0
 
@@ -280,7 +280,7 @@ def test_spread_filter_blocks_signal(make_df):
     df = make_df(prices, volumes)
     book = {"bids": [(9.95, 1)], "asks": [(10.05, 1)]}
     cfg = {"micro_scalp_bot": {"fresh_cross_only": False}}
-    score, direction = micro_scalp_bot.generate_signal(df, cfg, book=book)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg, book=book)
     assert (score, direction) == (0.0, "none")
 
 def test_spread_ratio_blocks_signal(make_df):
@@ -289,7 +289,7 @@ def test_spread_ratio_blocks_signal(make_df):
     df = make_df(prices, volumes)
     book = {"bids": [(10.0, 1)], "asks": [(10.1, 1)]}
     cfg = {"micro_scalp_bot": {"fresh_cross_only": False}}
-    score, direction = micro_scalp_bot.generate_signal(df, cfg, book=book)
+    score, direction = micro_scalp_bot.generate_signal(df, config=cfg, book=book)
     assert (score, direction) == (0.0, "none")
 
 
@@ -299,9 +299,9 @@ def test_trainer_model_influence(make_df, monkeypatch):
     df = make_df(prices, volumes)
     cfg = {"micro_scalp_bot": {"fresh_cross_only": False, "min_vol_z": 0}, "atr_normalization": False}
     monkeypatch.setattr(micro_scalp_bot, "MODEL", None)
-    base, direction = micro_scalp_bot.generate_signal(df, cfg)
+    base, direction = micro_scalp_bot.generate_signal(df, config=cfg)
     dummy = types.SimpleNamespace(predict=lambda _df: 0.3)
     monkeypatch.setattr(micro_scalp_bot, "MODEL", dummy)
-    score, direction2 = micro_scalp_bot.generate_signal(df, cfg)
+    score, direction2 = micro_scalp_bot.generate_signal(df, config=cfg)
     assert direction2 == direction
     assert score == pytest.approx((base + 0.3) / 2)

--- a/tests/test_sniper_bot.py
+++ b/tests/test_sniper_bot.py
@@ -52,7 +52,7 @@ def test_direction_override_short():
         [10, 12, 11, 200]
     )
     config = {"direction": "short"}
-    score, direction, _, event = sniper_bot.generate_signal(df, config)
+    score, direction, _, event = sniper_bot.generate_signal(df, config=config)
     assert direction == "short"
     assert score > 0.8
     assert not event
@@ -88,7 +88,7 @@ def test_symbol_filter_blocks_disallowed():
         [10, 12, 40]
     )
     score, direction, _, event = sniper_bot.generate_signal(
-        df, {"symbol": "XRP/USD"}
+        df, config={"symbol": "XRP/USD"}
     )
     assert direction == "none"
     assert score == 0.0
@@ -141,7 +141,7 @@ def test_price_fallback_long_signal():
         "volume": [100] * (bars - 1) + [250],
     })
     score, direction, atr, event = sniper_bot.generate_signal(
-        df, {"price_fallback": True}
+        df, config={"price_fallback": True}
     )
     assert direction == "long"
     assert score > 0
@@ -156,10 +156,10 @@ def test_trainer_model_influence(monkeypatch):
     )
     cfg = {"atr_normalization": False}
     monkeypatch.setattr(sniper_bot, "MODEL", None)
-    base, direction, _, _ = sniper_bot.generate_signal(df, cfg)
+    base, direction, _, _ = sniper_bot.generate_signal(df, config=cfg)
     dummy = types.SimpleNamespace(predict=lambda _df: 0.5)
     monkeypatch.setattr(sniper_bot, "MODEL", dummy)
-    score, direction2, _, _ = sniper_bot.generate_signal(df, cfg)
+    score, direction2, _, _ = sniper_bot.generate_signal(df, config=cfg)
     assert direction2 == direction
     assert score == pytest.approx((base + 0.5) / 2)
 

--- a/tests/test_sniper_solana_strategy.py
+++ b/tests/test_sniper_solana_strategy.py
@@ -26,11 +26,11 @@ def make_df(prices):
 
 def test_skip_on_flags(monkeypatch):
     df = make_df([1.0, 1.0])
-    score, direction = sniper_solana.generate_signal(df, {"is_trading": False})
+    score, direction = sniper_solana.generate_signal(df, config={"is_trading": False})
     assert score == 0.0
     assert direction == "none"
 
-    score, direction = sniper_solana.generate_signal(df, {"conf_pct": 0.6})
+    score, direction = sniper_solana.generate_signal(df, config={"conf_pct": 0.6})
     assert score == 0.0
     assert direction == "none"
 
@@ -43,6 +43,6 @@ def test_uses_pyth_price(monkeypatch):
 
     monkeypatch.setattr(sniper_solana, "get_pyth_price", fake_price)
     cfg = {"token": "SOL", "atr_window": 1, "jump_mult": 1.0}
-    score, direction = sniper_solana.generate_signal(df, cfg)
+    score, direction = sniper_solana.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score == 1.0

--- a/tests/test_stat_arb_bot.py
+++ b/tests/test_stat_arb_bot.py
@@ -32,7 +32,7 @@ def test_signal_direction_and_score(correlated_dfs):
     score, direction = stat_arb_bot.generate_signal(
         df_a,
         df_b,
-        {"zscore_threshold": 1.0, "lookback": 20},
+        config={"zscore_threshold": 1.0, "lookback": 20},
     )
     assert score > 0
     assert direction == "short"
@@ -40,6 +40,6 @@ def test_signal_direction_and_score(correlated_dfs):
 
 def test_no_signal_when_not_cointegrated(not_cointegrated_dfs):
     df_a, df_b = not_cointegrated_dfs
-    score, direction = stat_arb_bot.generate_signal(df_a, df_b, {"zscore_threshold": 1.0})
+    score, direction = stat_arb_bot.generate_signal(df_a, df_b, config={"zscore_threshold": 1.0})
     assert score == 0.0
     assert direction == "none"

--- a/tests/test_trend_bot.py
+++ b/tests/test_trend_bot.py
@@ -71,7 +71,7 @@ def test_no_signal_when_volume_below_ma():
 def test_long_signal_with_filters():
     df = _df_trend(150.0)
     cfg = {"donchian_confirmation": False}
-    score, direction = trend_bot.generate_signal(df, cfg)
+    score, direction = trend_bot.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score > 0.0
 
@@ -79,7 +79,7 @@ def test_long_signal_with_filters():
 def test_donchian_confirmation_blocks_false_breakout():
     df = _df_trend(150.0)
     cfg = {"donchian_confirmation": True}
-    score, direction = trend_bot.generate_signal(df, cfg)
+    score, direction = trend_bot.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score > 0.0
 
@@ -87,7 +87,7 @@ def test_donchian_confirmation_blocks_false_breakout():
 def test_donchian_confirmation_allows_breakout():
     df = _df_trend(150.0, high_equals_close=True)
     cfg = {"donchian_confirmation": True}
-    score, direction = trend_bot.generate_signal(df, cfg)
+    score, direction = trend_bot.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score > 0.0
 
@@ -100,7 +100,7 @@ def test_rsi_zscore(monkeypatch):
         lambda s, lookback=3: pd.Series([2] * len(s), index=s.index),
     )
     cfg = {"indicator_lookback": 3, "rsi_overbought_pct": 90, "donchian_confirmation": False}
-    score, direction = trend_bot.generate_signal(df, cfg)
+    score, direction = trend_bot.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score > 0.0
 
@@ -113,7 +113,7 @@ def test_rsi_zscore_quantile_threshold(monkeypatch):
         lambda s, lookback=3: pd.Series(range(len(s)), index=s.index, dtype=float),
     )
     cfg = {"indicator_lookback": 3, "rsi_overbought_pct": 90, "donchian_confirmation": False}
-    score, direction = trend_bot.generate_signal(df, cfg)
+    score, direction = trend_bot.generate_signal(df, config=cfg)
     assert direction == "long"
     assert score > 0.0
 
@@ -164,7 +164,7 @@ def test_torch_signal_default_weight(monkeypatch):
         "torch_signal_model": {"enabled": True},
         "adx_threshold": 5,
     }
-    score, _ = trend_bot.generate_signal(df, cfg)
+    score, _ = trend_bot.generate_signal(df, config=cfg)
     expected = base_score * 0.3 + 0.2 * 0.7
     assert score == pytest.approx(expected)
 
@@ -178,10 +178,10 @@ def test_trainer_model_influence(monkeypatch):
         lambda s, lookback=250: pd.Series(range(len(s)), index=s.index, dtype=float),
     )
     monkeypatch.setattr(trend_bot, "MODEL", None)
-    base, direction = trend_bot.generate_signal(df, cfg)
+    base, direction = trend_bot.generate_signal(df, config=cfg)
     dummy = types.SimpleNamespace(predict=lambda _df: 0.7)
     monkeypatch.setattr(trend_bot, "MODEL", dummy)
-    score, direction2 = trend_bot.generate_signal(df, cfg)
+    score, direction2 = trend_bot.generate_signal(df, config=cfg)
     assert direction2 == direction
     assert score == pytest.approx((base + 0.7) / 2)
 

--- a/tests/test_volatility_normalization.py
+++ b/tests/test_volatility_normalization.py
@@ -11,8 +11,8 @@ def test_normalized_score_lower_when_atr_low():
     df = pd.DataFrame({"open": close, "high": high, "low": low, "close": close, "volume": volume})
 
     cfg = {"atr_normalization": False, "donchian_confirmation": False}
-    raw_score, _ = trend_bot.generate_signal(df, cfg)
-    norm_score, _ = trend_bot.generate_signal(df, {"donchian_confirmation": False})
+    raw_score, _ = trend_bot.generate_signal(df, config=cfg)
+    norm_score, _ = trend_bot.generate_signal(df, config={"donchian_confirmation": False})
 
     assert norm_score < raw_score
     assert raw_score > 0


### PR DESCRIPTION
## Summary
- unify `generate_signal` signature across strategies and Solana modules to accept `symbol`, `timeframe`, and `**kwargs`
- forward dict positional args into `config` for backward compatibility
- update tests and backtest utilities to pass strategy configuration via `config=`

## Testing
- `pytest` *(fails: cannot import name 'wallet_manager' from 'crypto_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68a752d46f788330a443082b8f371e9a