### PR TITLE
Ensure voting strategy names match available bots

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -751,11 +751,7 @@ voting_strategies:
     - trend_bot
     - momentum_bot
     - mean_revert
-
     - breakout_bot
-
-    - breakout
-
     - micro_scalp_bot
   weights:
     trend_bot: 1.0


### PR DESCRIPTION
## Summary
- Align `voting_strategies` configuration with available bots
- Remove stray `breakout` entry so voting uses `breakout_bot`

## Testing
- `pytest tests/test_config.py::test_load_config_returns_dict -q`


------
https://chatgpt.com/codex/tasks/task_e_68a757ae56148330aaeddb4f2284d7dd