### PR TITLE
Refine dip hunter required bars logic

### DIFF
--- a/crypto_bot/strategy/dip_hunter.py
+++ b/crypto_bot/strategy/dip_hunter.py
@@ -90,15 +90,11 @@ def generate_signal(
 
     min_bars = max(100, adx_window, rsi_window, ema_slow) + 5
     required_bars = max(min_bars, 2 * adx_window + 1)
-    if len(df) < required_bars:
-        return 0.0, "none", {
-            "reason": f"insufficient_bars: need>={required_bars}, have={len(df)}"
-        }
 
     lookback = max(rsi_window, vol_window, adx_window, bb_window, dip_bars)
-    recent = df.tail(
-        max(100, adx_window * 4, lookback + 1, 2 * adx_window + 1)
-    )
+    recent = df.tail(required_bars)
+    if len(recent) < required_bars:
+        return 0.0, "none"
 
     rsi = ta.momentum.rsi(recent["close"], window=rsi_window)
     # ADX requires at least twice the window length for a stable reading

--- a/tests/test_dip_hunter.py
+++ b/tests/test_dip_hunter.py
@@ -90,12 +90,9 @@ def test_cooldown_blocks(monkeypatch):
     assert direction2 == "none" and score2 == 0.0
 
 
-@pytest.mark.parametrize("rows", [15, 27])
+@pytest.mark.parametrize("rows", [15, 104])
 def test_handles_small_frames(monkeypatch, rows):
     df = _df_dip(rows)
     _patch_indicators(monkeypatch, len(df))
     result = dip_hunter.generate_signal(df, config={"symbol": "BTC/USD"})
-    assert result[0] == 0.0
-    assert result[1] == "none"
-    if len(result) == 3:
-        assert "insufficient_bars" in result[2]["reason"]
+    assert result == (0.0, "none")


### PR DESCRIPTION
## Summary
- Simplify dip hunter data requirements by computing `required_bars` once and using it for recent slice
- Return early when sliced data has fewer than the required bars
- Extend dip hunter unit tests to verify the insufficient-data path

## Testing
- `pytest tests/test_dip_hunter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a758dc1ca883309bfcd1d69c2f1874