### PR TITLE
Skip ADX fast-path when insufficient data

### DIFF
--- a/crypto_bot/strategy_router.py
+++ b/crypto_bot/strategy_router.py
@@ -834,14 +834,21 @@ def route(
         from ta.trend import ADXIndicator
 
         adx_thr = float(fp.get('trend_adx_threshold', 25))
-        adx_val = (
-            ADXIndicator(df['high'], df['low'], df['close'], window=window)
-            .adx()
-            .iloc[-1]
-        )
-        if adx_val > adx_thr:
-            logger.info('FAST-PATH: trend_bot via ADX > %.1f', adx_thr)
-            return _wrap(trend_bot.generate_signal)
+        if len(df) < window + 1:
+            logger.debug(
+                'FAST-PATH: skipping ADX check; need at least %d rows (got %d)',
+                window + 1,
+                len(df),
+            )
+        else:
+            adx_val = (
+                ADXIndicator(df['high'], df['low'], df['close'], window=window)
+                .adx()
+                .iloc[-1]
+            )
+            if adx_val > adx_thr:
+                logger.info('FAST-PATH: trend_bot via ADX > %.1f', adx_thr)
+                return _wrap(trend_bot.generate_signal)
 
         # 3) breakdown pattern with heavy volume
         from crypto_bot.regime.pattern_detector import detect_patterns

--- a/tests/test_strategy_router.py
+++ b/tests/test_strategy_router.py
@@ -141,6 +141,27 @@ def test_route_returns_lstm_bot():
     assert fn.__name__ == lstm_bot.generate_signal.__name__
 
 
+def test_route_skips_adx_fast_path_for_small_df(caplog):
+    cfg = {
+        "strategy_router": {
+            "regimes": {"trending": ["trend_bot"]},
+            "fast_path": {"trend_adx_threshold": 0},
+        }
+    }
+    df = pd.DataFrame(
+        {
+            "high": [1] * 10,
+            "low": [1] * 10,
+            "close": [1] * 10,
+            "volume": [1] * 10,
+        }
+    )
+    with caplog.at_level("DEBUG", logger="crypto_bot.strategy_router"):
+        fn = route("trending", "cex", cfg, df_map=df)
+    assert fn.__name__ == trend_bot.generate_signal.__name__
+    assert "skipping ADX" in caplog.text
+
+
 def test_route_handles_none_df_map():
     cfg = {"strategy_router": {"regimes": {"trending": ["trend_bot"]}}}
     fn = route("trending", "cex", cfg, df_map=None)


### PR DESCRIPTION
## Summary
- avoid building ADXIndicator when there are not enough rows and log a debug message
- test that the router skips ADX fast-path for short dataframes

## Testing
- `pytest tests/test_strategy_router.py::test_route_skips_adx_fast_path_for_small_df -q`


------
https://chatgpt.com/codex/tasks/task_e_68a758dfb4848330a419c23a1dcebefc