### PR TITLE
Add sentiment gating to risk manager

### DIFF
--- a/crypto_bot/risk/sentiment_gate.py
+++ b/crypto_bot/risk/sentiment_gate.py
@@ -1,0 +1,80 @@
+import json
+import os
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+from crypto_bot.utils.logger import LOG_DIR, setup_logger
+
+logger = setup_logger(__name__, LOG_DIR / "bot.log")
+
+SENTIMENT_FILE = LOG_DIR / "sentiment.json"
+
+
+def load_sentiment(path: Path = SENTIMENT_FILE) -> Optional[Tuple[float, float]]:
+    """Return the timestamp and sentiment score.
+
+    The score is loaded from ``path`` if it exists. During testing the
+    ``MOCK_TWITTER_SENTIMENT`` or ``MOCK_FNG_VALUE`` environment variables can
+    provide a temporary score so that sentiment checks proceed without an
+    external service.
+
+    Parameters
+    ----------
+    path : Path, optional
+        Location of the sentiment data file. Defaults to :data:`SENTIMENT_FILE`.
+
+    Returns
+    -------
+    tuple[float, float] | None
+        ``(timestamp, score)`` if available, otherwise ``None``.
+    """
+    if os.getenv("MOCK_TWITTER_SENTIMENT") or os.getenv("MOCK_FNG_VALUE"):
+        score = float(os.getenv("MOCK_TWITTER_SENTIMENT", 50))
+        return time.time(), score
+    try:
+        data = json.loads(Path(path).read_text())
+    except FileNotFoundError:
+        return None
+    except Exception as exc:  # pragma: no cover - corrupted file
+        logger.error("Failed to load sentiment data: %s", exc)
+        return None
+    ts = float(data.get("timestamp") or data.get("ts") or 0.0)
+    score = float(data.get("score") or data.get("factor") or 1.0)
+    return ts, score
+
+
+def sentiment_factor_or_default(
+    now_ts: float, require_sentiment: bool, max_age_s: float
+) -> float:
+    """Return sentiment score or ``1.0`` when data is missing or stale.
+
+    Parameters
+    ----------
+    now_ts : float
+        Current timestamp used for age comparison.
+    require_sentiment : bool
+        Whether sentiment data is required. If ``False`` the function
+        immediately returns ``1.0``.
+    max_age_s : float
+        Maximum allowed age in seconds for the sentiment data.
+    """
+    if not require_sentiment:
+        return 1.0
+
+    data = load_sentiment()
+    if not data:
+        logger.warning("No sentiment data available; using default factor 1.0")
+        return 1.0
+    ts, score = data
+    if now_ts - ts > max_age_s:
+        logger.warning(
+            "Sentiment data too old (age %.0fs > %.0fs); using default factor 1.0",
+            now_ts - ts,
+            max_age_s,
+        )
+        return 1.0
+    return float(score)
+
+
+__all__ = ["sentiment_factor_or_default"]


### PR DESCRIPTION
## Summary
- add `sentiment_gate` module to safely load sentiment data or default when absent/stale
- integrate `sentiment_factor_or_default` with risk manager to skip sentiment rejections when data missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cointrainer')*
- `pytest tests/test_risk_manager.py::test_allow_trade_rejects_on_bearish_sentiment tests/test_risk_manager.py::test_allow_trade_allows_on_positive_sentiment -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75e0abd10833087b4b6d5f42279dd