### PR TITLE
docs: describe require_sentiment flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,10 @@ symbol_score_weights:
   order may consume.
 * **weight_liquidity** – scoring weight for available pool liquidity on Solana pairs.
 * **volatility_filter** - skips trading when ATR is too low or funding exceeds `max_funding_rate`. The minimum ATR percent is `0.0001`.
-* **sentiment_filter** - checks the Fear & Greed index and Twitter sentiment to avoid bearish markets.
+* **sentiment_filter** - checks the Fear & Greed index and Twitter sentiment
+  to avoid bearish markets. Set `require_sentiment` to `true` to block trades
+  when sentiment data is missing. Leave it `false` in dry-run or tests to treat
+  missing data as a neutral score.
 * **sl_pct**/**tp_pct** – defaults for Solana scalper strategies.
 * **mempool_monitor** – pause or reprice when Solana fees spike.
 * **priority_fee_cap_micro_lamports** – abort scalper trades when priority fees exceed this.
@@ -948,6 +951,12 @@ and sentiment fetches will fail until real values are supplied.
 
 To experiment with other sentiment providers, point `TWITTER_SENTIMENT_URL` at
 a different API and extend `sentiment_filter.py` to parse that service's response.
+
+When `require_sentiment` is `false` (the default for dry-run and testing), the
+sentiment gate falls back to a neutral score of `50` whenever the endpoint or
+API key is missing so simulations continue deterministically. Set
+`require_sentiment: true` in the config to fail closed instead of using this
+placeholder value.
 
 ### Funding Rate API
 

--- a/config.example.testing.yaml
+++ b/config.example.testing.yaml
@@ -39,3 +39,9 @@ ohlcv_chunk_size: 20
 volatility_filter:
   max_funding_rate: 0.3
   min_atr_pct: 0.0001
+
+# === sentiment filter ===
+sentiment_filter:
+  require_sentiment: false
+  min_fng: 20
+  min_sentiment: 40

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -131,3 +131,9 @@ telegram:
 volatility_filter:
   max_funding_rate: 0.3
   min_atr_pct: 0.0001
+
+# === sentiment filter ===
+sentiment_filter:
+  require_sentiment: false    # neutral defaults during dry-run/tests
+  min_fng: 20
+  min_sentiment: 40

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -510,6 +510,7 @@ scoring_weights:
   volume_score: 0.05
 secondary_exchange: coinbase
 sentiment_filter:
+  require_sentiment: false  # treat missing sentiment as neutral in dry-run/testing
   bull_fng: 50
   bull_sentiment: 45
   min_fng: 20  # Lower if current FNG is blocking


### PR DESCRIPTION
## Summary
- document `require_sentiment` config option and its behavior in dry-run/test modes
- add examples showing neutral fallback for sentiment gate

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fakeredis and cointrainer; SyntaxError in test_initial_scan.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a75e123a4483308a7fa8b10c5f6089