### PR TITLE
Add warm-up defaults for 15m/1h and document guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ on startup, and the bot begins scoring once these frames are ready. Additional
 initialization is not blocked. The legacy `trading.backfill.warmup_high_tf`
 option has been removed.
 
+### Warm-up candles
+
+The `warmup_candles` mapping controls how many bars are preloaded for each
+timeframe. Ensure the count for a given timeframe exceeds the longest
+indicator lookback used by your strategies plus a safety margin so indicators
+have enough history to stabilize.
+
 ### Optional ML Fallback
 
 Set `use_ml_regime_classifier` to `true` in `crypto_bot/config.yaml` to fall

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -111,6 +111,8 @@ timeframes: ['1m','5m']
 warmup_candles:
   '1m': 1000
   '5m': 600
+  '15m': 500
+  '1h': 500
 
 backfill_days:
   '1m': 2

--- a/crypto_bot/config.py
+++ b/crypto_bot/config.py
@@ -27,7 +27,7 @@ class Config:
 
     timeframes: List[str] = field(default_factory=lambda: ["1m", "5m"])
     warmup_candles: Dict[str, int] = field(
-        default_factory=lambda: {"1m": 1000, "5m": 600}
+        default_factory=lambda: {"1m": 1000, "5m": 600, "15m": 500, "1h": 500}
     )
     deep_backfill_days: Dict[str, int] = field(default_factory=dict)
     backfill_days: Dict[str, int] = field(


### PR DESCRIPTION
## Summary
- include 15m and 1h warm-up counts in default Config
- mirror new warm-up defaults in example YAML
- document that warm-up bars must exceed longest indicator lookback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `pytest tests/test_ohlcv_cache_manager.py tests/test_warmup_guard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75e29526c8330bd571918cb5adc36