### PR TITLE
Normalize SignalEnvelope inputs in execute_signals

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -2143,8 +2143,53 @@ async def _analyse_batch_impl(ctx: BotContext) -> None:
 async def execute_signals(ctx: BotContext) -> None:
     """Open trades for qualified analysis results."""
     from collections import Counter
+    import dataclasses
 
-    results = getattr(ctx, "analysis_results", [])
+    raw_results = getattr(ctx, "analysis_results", [])
+    results: list[dict[str, Any]] = []
+    for res in raw_results:
+        if isinstance(res, dict):
+            data = dict(res)
+        elif dataclasses.is_dataclass(res):  # pragma: no cover - defensive
+            data = dataclasses.asdict(res)
+        elif hasattr(res, "__dict__"):
+            data = dict(res.__dict__)
+        else:  # pragma: no cover - best effort
+            logger.warning("Skipping %s: unsupported signal type", type(res).__name__)
+            continue
+
+        entry_obj = data.get("entry") or getattr(res, "entry", None)
+        entry_price = None
+        if isinstance(entry_obj, dict):
+            entry_price = entry_obj.get("price")
+        elif entry_obj is not None:
+            entry_price = getattr(entry_obj, "price", None)
+
+        size = data.get("size") if "size" in data else getattr(res, "size", None)
+        valid = data.get("valid") if "valid" in data else getattr(res, "valid", None)
+        sym = data.get("symbol") or getattr(res, "symbol", "")
+
+        missing = [
+            name
+            for name, val in [
+                ("entry.price", entry_price),
+                ("size", size),
+                ("valid", valid),
+            ]
+            if val is None
+        ]
+        if missing:
+            logger.warning("Skipping %s: missing %s", sym or "<unknown>", ", ".join(missing))
+            continue
+        if not bool(valid):
+            logger.info("Skipping %s: signal marked invalid", sym or "<unknown>")
+            continue
+
+        data["entry"] = {"price": entry_price}
+        data["size"] = size
+        data["valid"] = bool(valid)
+        results.append(data)
+
     if not results:
         logger.info("No analysis results to act on")
         return

--- a/tests/test_balance_position_size.py
+++ b/tests/test_balance_position_size.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 import ast
 from pathlib import Path
+from crypto_bot.utils.logger import LOG_DIR, setup_logger
 
 from crypto_bot.phase_runner import BotContext
 from crypto_bot.paper_wallet import PaperWallet
@@ -49,6 +50,7 @@ def load_execute_signals():
     ns = {
         "asyncio": asyncio,
         "logger": logging.getLogger("test"),
+        "score_logger": setup_logger("symbol_filter", LOG_DIR / "symbol_filter.log", to_console=False),
         "cex_trade_async": _trade,
         "fetch_order_book_async": lambda *a, **k: {},
         "_closest_wall_distance": lambda *a, **k: None,
@@ -60,7 +62,7 @@ def load_execute_signals():
         "refresh_balance": lambda ctx: asyncio.sleep(0),
         "Counter": __import__("collections").Counter,
     }
-
+    ns["score_logger"].setLevel(logging.DEBUG)
     exec(funcs["direction_to_side"], ns)
     exec(funcs["execute_signals"], ns)
     return ns["execute_signals"], called
@@ -77,6 +79,9 @@ async def test_positive_balance_generates_position():
         "probabilities": {},
         "regime": "bull",
         "score": 1.0,
+        "entry": {"price": 100.0},
+        "size": 1.0,
+        "valid": True,
     }
     ctx = BotContext(
         positions={},

--- a/tests/test_execute_signals.py
+++ b/tests/test_execute_signals.py
@@ -83,6 +83,9 @@ async def test_execute_signals_respects_allow_short(monkeypatch, caplog):
         "probabilities": {},
         "regime": "bull",
         "score": 1.0,
+        "entry": {"price": 100.0},
+        "size": 1.0,
+        "valid": True,
     }
     ctx = BotContext(
         positions={},
@@ -122,6 +125,9 @@ async def test_execute_signals_respects_too_flat(monkeypatch, caplog):
         "regime": "bull",
         "score": 1.0,
         "too_flat": True,
+        "entry": {"price": 100.0},
+        "size": 1.0,
+        "valid": True,
     }
     ctx = BotContext(
         positions={},
@@ -159,6 +165,9 @@ async def test_execute_signals_logs_execution(monkeypatch, caplog):
         "probabilities": {},
         "regime": "bull",
         "score": 1.0,
+        "entry": {"price": 100.0},
+        "size": 1.0,
+        "valid": True,
     }
     ctx = BotContext(
         positions={},
@@ -197,6 +206,9 @@ async def test_execute_signals_no_symbols_qualify(monkeypatch, caplog):
         "regime": "bull",
         "score": 0.05,
         "min_confidence": 0.1,
+        "entry": {"price": 100.0},
+        "size": 1.0,
+        "valid": True,
     }
 
     class DummyNotifier:


### PR DESCRIPTION
## Summary
- normalize incoming signals to handle raw dicts or SignalEnvelope objects
- ensure entry.price, size and valid fields are validated and logged
- update tests to include required signal fields and stubs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `pytest tests/test_execute_signals.py tests/test_balance_position_size.py tests/test_sniper_async.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a75e3497f4833095a0d7e30dbb7fc7