### PR TITLE
Route unknown regimes through fallback strategy

### DIFF
--- a/crypto_bot/strategy_router.py
+++ b/crypto_bot/strategy_router.py
@@ -682,15 +682,16 @@ def route(
         sym = (
             cfg.raw.get("symbol", "") if isinstance(cfg, RouterConfig) else cfg.get("symbol", "")
         )
-        logger.warning("Unknown regime for %s; no strategy selected", sym)
+        strategy_fn = strategy_for("unknown", cfg)
+        logger.warning(
+            "Unknown regime for %s; falling back to %s", sym, strategy_fn.__name__
+        )
         telemetry.inc("router.unknown_regime")
         if notifier is not None:
-            notifier.notify(f"Unknown regime for {sym}; no signal generated")
-
-        def _no_signal(df: pd.DataFrame | None = None, cfg=None) -> tuple[float, str]:
-            return 0.0, "none"
-
-        return _wrap(_no_signal)
+            notifier.notify(
+                f"Unknown regime for {sym}; using {strategy_fn.__name__}"
+            )
+        return _wrap(strategy_fn)
 
     def _post_fastpath():
         symbol = ""


### PR DESCRIPTION
## Summary
- Route unknown regimes to `strategy_for("unknown")`, logging the fallback strategy
- Adjust tests to expect fallback strategy execution instead of zero signal

## Testing
- `pytest tests/test_strategy_router.py -k "route_unknown_fallback or route_unknown_invokes_strategy" -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76c9bedb48330a57fd571d565232c