### PR TITLE
Handle directional scores in router

### DIFF
--- a/crypto_bot/signals/signal_fusion.py
+++ b/crypto_bot/signals/signal_fusion.py
@@ -37,6 +37,7 @@ class SignalFusionEngine:
         long_votes = 0
         short_votes = 0
         signed_sum = 0.0
+        first_direction: str | None = None
 
         for fn, weight in self.strategies:
             w = opt_weights.get(fn.__name__, weight)
@@ -54,6 +55,9 @@ class SignalFusionEngine:
                 short_votes += 1
                 signed_sum -= score * w
 
+            if direction != "none" and first_direction is None:
+                first_direction = direction
+
         if total_weight == 0:
             return 0.0, "none"
 
@@ -68,6 +72,8 @@ class SignalFusionEngine:
                 direction = "long"
             elif signed_sum < 0:
                 direction = "short"
+            elif first_direction is not None:
+                direction = first_direction
             else:
                 direction = "none"
 

--- a/crypto_bot/signals/signal_scoring.py
+++ b/crypto_bot/signals/signal_scoring.py
@@ -26,12 +26,20 @@ def evaluate(
         result = strategy_fn(df)
 
     if isinstance(result, tuple):
-        score, direction, *extras = result
+        raw_score = float(result[0])
+        if len(result) > 1:
+            direction = result[1]
+        else:
+            direction = (
+                "long" if raw_score > 0 else "short" if raw_score < 0 else "none"
+            )
+        extras = result[2:]
         atr = extras[0] if extras else None
     else:
-        score, direction = result, "none"
+        raw_score = float(result)
+        direction = "long" if raw_score > 0 else "short" if raw_score < 0 else "none"
         atr = None
-    score = max(0.0, min(score, 1.0))
+    score = max(0.0, min(abs(raw_score), 1.0))
     if atr is not None and hasattr(atr, "iloc"):
         atr = float(atr.iloc[-1]) if len(atr) else np.nan
     if atr is not None and not (pd.isna(atr) or atr <= 0):

--- a/crypto_bot/strategy_router.py
+++ b/crypto_bot/strategy_router.py
@@ -619,9 +619,17 @@ def route(
                 except TypeError:
                     res = fn(data)
             if isinstance(res, tuple):
-                score, direction = res[0], res[1]
+                raw_score = float(res[0])
+                if len(res) > 1:
+                    direction = res[1]
+                else:
+                    direction = (
+                        "long" if raw_score > 0 else "short" if raw_score < 0 else "none"
+                    )
             else:
-                score, direction = res, "none"
+                raw_score = float(res)
+                direction = "long" if raw_score > 0 else "short" if raw_score < 0 else "none"
+            score = abs(raw_score)
             logger.info(
                 "Regime %s produced score %.2f direction %s", regime, score, direction
             )


### PR DESCRIPTION
## Summary
- derive long/short direction from score-only strategy outputs
- remember first non-neutral vote so fusion keeps a tradeable direction
- test router fusion with score-only strategies

## Testing
- `pytest tests/test_strategy_router.py::test_router_consensus_from_score_only_strats -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cointrainer')*

------
https://chatgpt.com/codex/tasks/task_e_68a76ca5308c83309d2da946a15c8c7e