### PR TITLE
feat: infer unknown regime heuristically

### DIFF
--- a/crypto_bot/strategy_router.py
+++ b/crypto_bot/strategy_router.py
@@ -686,6 +686,11 @@ def route(
         cfg_get(cfg, "commit_lock_intervals", 0),
     )
 
+    from crypto_bot.utils.market_analyzer import _heuristic_regime
+
+    if regime == "unknown" and df is not None:
+        regime, _ = _heuristic_regime(df)
+
     if regime == "unknown":
         sym = (
             cfg.raw.get("symbol", "") if isinstance(cfg, RouterConfig) else cfg.get("symbol", "")


### PR DESCRIPTION
## Summary
- fall back to heuristic regime detection when input regime is unknown
- ensure unknown regimes still warn and return existing strategy

## Testing
- `pytest` *(fails: cannot import name 'wallet_manager' from 'crypto_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68a770828688833099dd717c7c0ed02d