### PR TITLE
refactor user setup into single validation loop

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -314,26 +314,38 @@ def _run_wallet_manager() -> None:
             file=sys.stderr,
         )
         sys.exit(2)
-    result = subprocess.run([sys.executable, "-m", "crypto_bot.wallet_manager"])
-    if result.returncode not in (0, None):
-        sys.exit(result.returncode)
+    code = subprocess.call([sys.executable, "-m", "crypto_bot.wallet_manager"])
+    if code not in (0, None):
+        sys.exit(code)
 
 
 def _ensure_user_setup() -> None:
-    """Ensure required credentials exist or launch the wallet setup wizard."""
-    _load_env()
-    if USER_CONFIG_PATH.exists() and all(os.getenv(var) for var in REQUIRED_ENV_VARS):
-        return
-    _run_wallet_manager()
-    _load_env()
-    env = _load_env()
-    if _needs_wallet_setup(env, USER_CONFIG_PATH) or not all(
-        os.getenv(var) for var in REQUIRED_ENV_VARS
-    ):
+    """Ensure credentials exist, running the setup wizard as needed.
+
+    State transitions
+    -----------------
+    ``CHECK`` → ``READY``
+        Prerequisites are met and the function returns.
+    ``CHECK`` → ``SETUP`` → ``CHECK``
+        Validation fails, the wallet manager runs, and validation repeats.
+
+    Returns
+    -------
+    ``None`` when a configuration file exists and all required environment
+    variables are defined. The loop continues until these conditions are
+    satisfied or the wallet manager exits the process.
+    """
+
+    first = True
+    while True:
+        env = _load_env()
+        if USER_CONFIG_PATH.exists() and all(
+            os.getenv(var) for var in REQUIRED_ENV_VARS
+        ):
+            if first or not _needs_wallet_setup(env, USER_CONFIG_PATH):
+                return
         _run_wallet_manager()
-        _load_env()
-    if _needs_wallet_setup(env):
-        _run_wallet_manager()
+        first = False
 
 
 def _fix_symbol(symbol: str) -> str:


### PR DESCRIPTION
## Summary
- run wallet setup via `subprocess.call` and handle non-zero codes
- refactor `_ensure_user_setup` into a single validation loop
- document user setup state transitions and return conditions

## Testing
- `pytest tests/test_main_wallet_setup.py -q`
- `pytest tests/test_main_wallet_setup.py tests/test_shutdown_reasons.py tests/test_onchain_symbols.py -q` *(fails: missing BONK/USDC and BTC/USD in active_universe)*
- `pytest -q` *(fails: ModuleNotFoundError: cointrainer, fakeredis)*

------
https://chatgpt.com/codex/tasks/task_e_68a7768b8ff48330945440cb3eecae8b