### PR TITLE
feat: add router acceptance thresholds

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -21,6 +21,14 @@ trading:
   hft_symbols: ["BTC/USD","ETH/USD","SOL/USDC","BONK/USDC","BNB/USDT","SHIB/USDT","PEPE/USD"]   # seed list, can expand
   exclude_symbols: ["AIBTC/USD"]   # remove noisy/synthetic pairs
 
+# === router ===
+router:
+  min_accept_score: 0.5
+  prefer_timeframes: ["5m","15m","1m"]
+  require_warm: true
+  top_k_per_strategy: 3
+  fast_track_score: 0.95
+
 # === ohlcv cache ===
 ohlcv:
   storage_path: crypto_bot/data/ohlcv   # directory for persisted OHLCV data

--- a/crypto_bot/utils/market_analyzer.py
+++ b/crypto_bot/utils/market_analyzer.py
@@ -161,7 +161,19 @@ async def run_candidates(
                 except Exception:  # pragma: no cover - safety
                     pass
 
-    return ranked
+    router_cfg = (cfg or {}).get("router", {}) if isinstance(cfg, dict) else {}
+    fast_track = float(router_cfg.get("fast_track_score", 0.95))
+    min_accept = float(router_cfg.get("min_accept_score", 0.0))
+    top_k = int(router_cfg.get("top_k_per_strategy", 0))
+
+    for fn, sc, d in ranked:
+        if sc >= fast_track:
+            return [(fn, sc, d)]
+
+    filtered = [(fn, sc, d) for fn, sc, d in ranked if sc >= min_accept]
+    if top_k > 0:
+        filtered = filtered[:top_k]
+    return filtered
 
 
 async def analyze_symbol(


### PR DESCRIPTION
## Summary
- support configurable score gating and fast-track logic in `run_candidates`
- expose router acceptance settings in default `config.yaml`
- test candidate selection thresholds and fast-track behavior

## Testing
- `pytest tests/test_run_candidates.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis'; No module named 'cointrainer'; SyntaxError in tests/test_initial_scan.py; ModuleNotFoundError: No module named 'crypto_bot.wallet')*


------
https://chatgpt.com/codex/tasks/task_e_68a78c1e24fc8330bc3e8a7e2c73326f