### PR TITLE
docs: describe CT_REQUIRE_SENTIMENT override

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ TELE_CHAT_ADMINS=123456,789012         # optional comma separated admin IDs
 TELE_CHAT_ADMINS=12345,67890          # comma-separated chat IDs
 GOOGLE_CRED_JSON=path_to_google_credentials.json
 TWITTER_SENTIMENT_URL=https://lunarcrush.com/api/v2  # LunarCrush sentiment endpoint (requires LUNARCRUSH_API_KEY)
+CT_REQUIRE_SENTIMENT=false             # skip sentiment vetoes entirely when set to false
 FUNDING_RATE_URL=https://futures.kraken.com/derivatives/api/v3/historical-funding-rates?symbol=
 SECRETS_PROVIDER=aws                     # optional
 SECRETS_PATH=/path/to/secret
@@ -544,7 +545,8 @@ symbol_score_weights:
 * **sentiment_filter** - checks the Fear & Greed index and Twitter sentiment
   to avoid bearish markets. Set `require_sentiment` to `true` to block trades
   when sentiment data is missing. Leave it `false` in dry-run or tests to treat
-  missing data as a neutral score.
+  missing data as a neutral score. Set `CT_REQUIRE_SENTIMENT=false` to skip
+  sentiment vetoes entirely, ignoring `min_fng` and `min_sentiment` thresholds.
 * **sl_pct**/**tp_pct** – defaults for Solana scalper strategies.
 * **mempool_monitor** – pause or reprice when Solana fees spike.
 * **priority_fee_cap_micro_lamports** – abort scalper trades when priority fees exceed this.
@@ -968,7 +970,25 @@ When `require_sentiment` is `false` (the default for dry-run and testing), the
 sentiment gate falls back to a neutral score of `50` whenever the endpoint or
 API key is missing so simulations continue deterministically. Set
 `require_sentiment: true` in the config to fail closed instead of using this
-placeholder value.
+placeholder value. Alternatively, set `CT_REQUIRE_SENTIMENT=false` to disable
+sentiment vetoes entirely.
+
+### CT_REQUIRE_SENTIMENT
+
+`CT_REQUIRE_SENTIMENT` overrides all sentiment requirements. When set to
+`false`, the bot skips Fear & Greed and Twitter sentiment vetoes even if
+`min_fng`, `min_sentiment` or `require_sentiment` are configured. Use this for
+backtests or integrations where sentiment data is unreliable.
+
+```bash
+# .env
+CT_REQUIRE_SENTIMENT=false
+
+# inline when launching
+CT_REQUIRE_SENTIMENT=false python -m crypto_bot.main
+```
+
+Leave the variable unset or set to `true` to respect configured thresholds.
 
 ### Funding Rate API
 

--- a/config.example.testing.yaml
+++ b/config.example.testing.yaml
@@ -4,7 +4,7 @@ trading:
   min_score: 0.20
   min_confidence: 0.30
   consensus: weighted
-  require_sentiment: false
+  require_sentiment: false   # CT_REQUIRE_SENTIMENT=false also disables checks
 exchange:
   name: kraken
   max_concurrency: 3
@@ -43,6 +43,6 @@ volatility_filter:
 
 # === sentiment filter ===
 sentiment_filter:
-  require_sentiment: false
+  require_sentiment: false   # CT_REQUIRE_SENTIMENT=false skips vetoes regardless
   min_fng: 20
   min_sentiment: 40

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,7 +16,7 @@ trading:
   hft_enabled: true
   hft_symbols: ["BTC/USD","ETH/USD","SOL/USDC","BONK/USDC"]   # seed list, can expand
   exclude_symbols: ["AIBTC/USD"]   # remove noisy/synthetic pairs
-  require_sentiment: true
+  require_sentiment: true          # override with CT_REQUIRE_SENTIMENT=false to bypass
 
 # === ohlcv cache ===
 ohlcv:
@@ -137,6 +137,6 @@ volatility_filter:
 
 # === sentiment filter ===
 sentiment_filter:
-  require_sentiment: false    # neutral defaults during dry-run/tests
+  require_sentiment: false    # neutral defaults; CT_REQUIRE_SENTIMENT=false also bypasses checks
   min_fng: 20
   min_sentiment: 40

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -510,7 +510,7 @@ scoring_weights:
   volume_score: 0.05
 secondary_exchange: coinbase
 sentiment_filter:
-  require_sentiment: false  # treat missing sentiment as neutral in dry-run/testing
+  require_sentiment: false  # treat missing sentiment as neutral; CT_REQUIRE_SENTIMENT=false bypasses
   bull_fng: 50
   bull_sentiment: 45
   min_fng: 20  # Lower if current FNG is blocking


### PR DESCRIPTION
## Summary
- document `CT_REQUIRE_SENTIMENT` environment variable for skipping sentiment vetoes
- mention override in risk parameters and sentiment filter guidance
- reference `CT_REQUIRE_SENTIMENT` in config examples

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cointrainer')*


------
https://chatgpt.com/codex/tasks/task_e_68a78c7c23b08330bf63214cfa3d964d