### PR TITLE
Add optional sentiment gating toggle

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -822,6 +822,9 @@ def _load_config_file() -> dict:
     trading_cfg.setdefault("hft_enabled", False)
     trading_cfg.setdefault("hft_symbols", [])
     trading_cfg.setdefault("exclude_symbols", [])
+    sent_cfg = data.get("sentiment_filter", {}) or {}
+    sent_cfg.setdefault("require_sentiment", trading_cfg["require_sentiment"])
+    data["sentiment_filter"] = sent_cfg
     data["trading"] = trading_cfg
     data.setdefault("allowed_quotes", allowed_quotes)
     sf_cfg = data.get("symbol_filter", {}) or {}


### PR DESCRIPTION
## Summary
- add `require_sentiment` flag to `RiskConfig` and honor `CT_REQUIRE_SENTIMENT` env in `allow_trade`
- propagate sentiment requirement through config loader to `RiskManager`
- cover sentiment disable scenarios with unit tests

## Testing
- `pytest tests/test_risk_manager.py::test_allow_trade_proceeds_without_sentiment_when_disabled tests/test_risk_manager.py::test_allow_trade_proceeds_when_env_disables_sentiment -q`
- `pytest tests/test_risk_manager.py::test_allow_trade_rejects_bearish_sentiment tests/test_risk_manager.py::test_allow_trade_rejects_on_bearish_sentiment tests/test_risk_manager.py::test_allow_trade_allows_on_positive_sentiment -q`
- `pytest tests/test_risk_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7918d4ef08330aa769e5f4a3bfa4b