### PR TITLE
Adjust warmup candles for lower timeframes

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -40,10 +40,10 @@ ohlcv:
   bootstrap_timeframes: ["1m","5m","15m","1h"]
   defer_timeframes: ["4h","1d"]
   warmup_candles:
-    "1m": 500
-    "5m": 500
+    "1m": 400
+    "5m": 400
     "15m": 400
-    "1h": 300
+    "1h": 400
     "1d": 120
   initial_history_candles: 600
   scan_lookback_limit: 1200
@@ -756,10 +756,10 @@ deep_backfill_days:
   '15m': 60
   '1h': 180
 warmup_candles:
-  '1m': 500
-  '5m': 500
+  '1m': 400
+  '5m': 400
   '15m': 400
-  '1h': 300
+  '1h': 400
   '1d': 120
 allowed_quotes: ['USD','USDT','USDC','EUR']
 hft: true


### PR DESCRIPTION
## Summary
- set 1m, 5m, 15m, and 1h warmup candles to 400 in crypto bot config

## Testing
- `pytest` *(fails: ImportError while importing test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a872ceb8f4833098ee832a477f5484