### PR TITLE
feat: add execution limits for paper wallet

### DIFF
--- a/crypto_bot/bot_controller.py
+++ b/crypto_bot/bot_controller.py
@@ -41,10 +41,14 @@ class TradingBotController:
         self.rotator = PortfolioRotator()
         self.wallet = wallet or paper_wallet
         if self.wallet is None and self.config.get("execution_mode") == "dry_run":
+            exec_cfg = self.config.get("execution", {}) or {}
             self.wallet = Wallet(
                 self.config.get("start_balance", 1000.0),
-                self.config.get("max_open_trades", 1),
+                exec_cfg.get("max_positions", self.config.get("max_open_trades", 1)),
                 self.config.get("allow_short", False),
+                stake_usd=exec_cfg.get("stake_usd"),
+                min_price=exec_cfg.get("min_price", 0.0),
+                min_notional=exec_cfg.get("min_notional", 0.0),
             )
         # Backwards compat – retain attribute name expected in some tests
         self.paper_wallet = self.wallet

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -510,8 +510,10 @@ router:
   top_k_per_strategy: 3
 
 execution:
-  dry_run: true
-  min_notional_usd: 20
+  mode: dry_run
+  stake_usd: 50
+  min_price: 0.00000001
+  min_notional: 5
   max_positions: 3
 rl_selector:
   enabled: true

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -3572,10 +3572,14 @@ async def _main_impl() -> MainResult:
         start_bal = float(
             os.getenv("PAPER_BALANCE") or config.get("paper_balance", 1000.0)
         )
+        exec_cfg = config.get("execution", {}) or {}
         wallet = Wallet(
             start_bal,
-            config.get("max_open_trades", 1),
+            exec_cfg.get("max_positions", config.get("max_open_trades", 1)),
             config.get("allow_short", False),
+            stake_usd=exec_cfg.get("stake_usd"),
+            min_price=exec_cfg.get("min_price", 0.0),
+            min_notional=exec_cfg.get("min_notional", 0.0),
         )
         log_balance(wallet.total_balance)
         last_balance = notify_balance_change(

--- a/frontend/api.py
+++ b/frontend/api.py
@@ -28,10 +28,14 @@ def get_controller() -> "TradingBotController":
                 cfg = yaml.safe_load(f) or {}
         wallet = None
         if cfg.get("execution_mode") == "dry_run":
+            exec_cfg = cfg.get("execution", {}) or {}
             wallet = Wallet(
                 cfg.get("start_balance", 1000.0),
-                cfg.get("max_open_trades", 1),
+                exec_cfg.get("max_positions", cfg.get("max_open_trades", 1)),
                 cfg.get("allow_short", False),
+                stake_usd=exec_cfg.get("stake_usd"),
+                min_price=exec_cfg.get("min_price", 0.0),
+                min_notional=exec_cfg.get("min_notional", 0.0),
             )
         CONTROLLER = TradingBotController(wallet=wallet)
     return CONTROLLER

--- a/wallet/__init__.py
+++ b/wallet/__init__.py
@@ -41,6 +41,7 @@ class Wallet(PaperWallet):
             # buying back part of a short position
             self.close(symbol, amount, price)
             return
+        self._check_limits(price, amount)
 
         if pos and pos.get("side") == "buy":
             # increase existing long without opening a new trade id
@@ -69,6 +70,7 @@ class Wallet(PaperWallet):
             # selling part of a long position
             self.close(symbol, amount, price)
             return
+        self._check_limits(price, amount)
 
         if pos and pos.get("side") == "sell":
             # increase existing short


### PR DESCRIPTION
## Summary
- add dry-run execution settings to config
- enforce stake, price, and notional limits in paper wallet
- wire wallet limits through API, controller, and main

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68a872ea63548330a5e340c656b77c48