### PR TITLE
Refactor ML availability warning and strategy initialization

### DIFF
--- a/crypto_bot/strategy/bounce_scalper.py
+++ b/crypto_bot/strategy/bounce_scalper.py
@@ -29,19 +29,14 @@ from crypto_bot.utils import stats
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.cooldown_manager import in_cooldown, mark_cooldown
 from crypto_bot.utils.regime_pnl_tracker import get_recent_win_rate
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 
 NAME = "bounce_scalper"
 logger = logging.getLogger(__name__)
 
-try:  # pragma: no cover - optional dependency
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
-    warn_ml_unavailable_once()
-
+ML_AVAILABLE = init_ml_or_warn()
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("bounce_scalper")
 else:  # pragma: no cover - fallback
     MODEL = None

--- a/crypto_bot/strategy/breakout_bot.py
+++ b/crypto_bot/strategy/breakout_bot.py
@@ -41,19 +41,15 @@ except Exception:  # pragma: no cover - fallback
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils import stats
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 
 NAME = "breakout_bot"
 logger = logging.getLogger(__name__)
 
-try:  # pragma: no cover - optional dependency
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
-    warn_ml_unavailable_once()
+ML_AVAILABLE = init_ml_or_warn()
 
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("breakout_bot")
 else:  # pragma: no cover - fallback
     MODEL = None

--- a/crypto_bot/strategy/dip_hunter.py
+++ b/crypto_bot/strategy/dip_hunter.py
@@ -9,7 +9,7 @@ from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils import stats
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
 from crypto_bot.cooldown_manager import cooldown, in_cooldown
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 
 NAME = "dip_hunter"
 logger = setup_logger(__name__, LOG_DIR / "bot.log")
@@ -18,14 +18,9 @@ score_logger = setup_logger(
     "symbol_filter", LOG_DIR / "symbol_filter.log", to_console=False
 )
 
-try:  # Optional LightGBM integration
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
-    warn_ml_unavailable_once()
-
+ML_AVAILABLE = init_ml_or_warn()
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("dip_hunter")
 else:  # pragma: no cover - fallback
     MODEL = None

--- a/crypto_bot/strategy/grid_bot.py
+++ b/crypto_bot/strategy/grid_bot.py
@@ -17,7 +17,7 @@ from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.volatility import atr_percent
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
 from crypto_bot.volatility_filter import calc_atr
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 
 DYNAMIC_THRESHOLD = 1.5
 logger = setup_logger(__name__, LOG_DIR / "bot.log")
@@ -26,11 +26,7 @@ score_logger = setup_logger(
     "symbol_filter", LOG_DIR / "symbol_filter.log", to_console=False
 )
 
-try:  # pragma: no cover - optional dependency
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
+ML_AVAILABLE = init_ml_or_warn()
 
 # ``micro_scalp_bot`` is imported lazily inside ``generate_signal`` to avoid
 # issues if the module has optional dependencies or is otherwise unavailable
@@ -40,10 +36,10 @@ from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
 from crypto_bot.utils.regime_pnl_tracker import get_recent_win_rate
 
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("grid_bot")
 else:  # pragma: no cover - fallback
     MODEL = None
-    warn_ml_unavailable_once()
 
 
 @dataclass

--- a/crypto_bot/strategy/lstm_bot.py
+++ b/crypto_bot/strategy/lstm_bot.py
@@ -4,17 +4,12 @@ import logging
 import pandas as pd
 
 logger = logging.getLogger(__name__)
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 NAME = "lstm_bot"
 
-try:  # pragma: no cover - optional trainer
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer unavailable
-    ML_AVAILABLE = False
-    warn_ml_unavailable_once()
-
+ML_AVAILABLE = init_ml_or_warn()
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("lstm_bot")
 else:  # pragma: no cover - fallback
     MODEL = None

--- a/crypto_bot/strategy/mean_bot.py
+++ b/crypto_bot/strategy/mean_bot.py
@@ -23,7 +23,7 @@ except Exception:  # pragma: no cover - fallback
 from ta.trend import ADXIndicator
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils import stats
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
@@ -35,17 +35,12 @@ score_logger = setup_logger(
     "symbol_filter", LOG_DIR / "symbol_filter.log", to_console=False
 )
 
-try:  # pragma: no cover - optional dependency
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
-
+ML_AVAILABLE = init_ml_or_warn()
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("mean_bot")
 else:  # pragma: no cover - fallback
     MODEL = None
-    warn_ml_unavailable_once()
 
 
 def generate_signal(

--- a/crypto_bot/strategy/micro_scalp_bot.py
+++ b/crypto_bot/strategy/micro_scalp_bot.py
@@ -7,18 +7,13 @@ import ta
 from crypto_bot.execution.solana_mempool import SolanaMempoolMonitor
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.volatility import normalize_score_by_volatility
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 
 logger = logging.getLogger(__name__)
 
-try:  # pragma: no cover - optional dependency
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
-    warn_ml_unavailable_once()
-
+ML_AVAILABLE = init_ml_or_warn()
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("micro_scalp_bot")
 else:  # pragma: no cover - fallback
     MODEL = None

--- a/crypto_bot/strategy/momentum_bot.py
+++ b/crypto_bot/strategy/momentum_bot.py
@@ -5,24 +5,19 @@ import pandas as pd
 import ta
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.volatility import normalize_score_by_volatility
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 
 logger = logging.getLogger(__name__)
 
 NAME = "momentum_bot"
 
-try:  # pragma: no cover - optional dependency
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
-
+ML_AVAILABLE = init_ml_or_warn()
 MODEL: Optional[object]
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("momentum_bot")
 else:  # pragma: no cover - fallback
     MODEL = None
-    warn_ml_unavailable_once()
 
 
 def generate_signal(

--- a/crypto_bot/strategy/range_arb_bot.py
+++ b/crypto_bot/strategy/range_arb_bot.py
@@ -16,19 +16,14 @@ from scipy.optimize import fmin_l_bfgs_b
 from crypto_bot.utils.stats import last_window_zscore
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.volatility import normalize_score_by_volatility
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 
 logger = logging.getLogger(__name__)
 
-try:  # pragma: no cover - optional dependency
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
-    warn_ml_unavailable_once()
-
+ML_AVAILABLE = init_ml_or_warn()
 NAME = "range_arb_bot"
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("range_arb_bot")
 else:  # pragma: no cover - fallback
     MODEL = None

--- a/crypto_bot/strategy/sniper_bot.py
+++ b/crypto_bot/strategy/sniper_bot.py
@@ -6,7 +6,7 @@ import pandas as pd
 from crypto_bot.utils import volatility
 from crypto_bot.utils.pair_cache import load_liquid_pairs
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 NAME = "sniper_bot"
 DEFAULT_PAIRS = ["BTC/USD", "ETH/USD"]
 ALLOWED_PAIRS = load_liquid_pairs() or DEFAULT_PAIRS
@@ -17,14 +17,9 @@ score_logger = setup_logger(
     "symbol_filter", LOG_DIR / "symbol_filter.log", to_console=False
 )
 
-try:  # pragma: no cover - optional dependency
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
-    warn_ml_unavailable_once()
-
+ML_AVAILABLE = init_ml_or_warn()
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("sniper_bot")
 else:  # pragma: no cover - fallback
     MODEL = None

--- a/crypto_bot/strategy/stat_arb_bot.py
+++ b/crypto_bot/strategy/stat_arb_bot.py
@@ -8,19 +8,15 @@ import pandas as pd
 from crypto_bot.utils import stats
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.volatility import normalize_score_by_volatility
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 
 logger = logging.getLogger(__name__)
 
-try:  # pragma: no cover - optional dependency
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
-    warn_ml_unavailable_once()
+ML_AVAILABLE = init_ml_or_warn()
 
 NAME = "stat_arb_bot"
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("stat_arb_bot")
 else:  # pragma: no cover - fallback
     MODEL = None

--- a/crypto_bot/strategy/trend_bot.py
+++ b/crypto_bot/strategy/trend_bot.py
@@ -28,7 +28,7 @@ from crypto_bot.utils import stats
 
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
-from crypto_bot.utils.ml_utils import warn_ml_unavailable_once
+from crypto_bot.utils.ml_utils import init_ml_or_warn
 
 logger = setup_logger(__name__, LOG_DIR / "bot.log")
 # Shared logger for symbol scoring
@@ -36,14 +36,9 @@ score_logger = setup_logger(
     "symbol_filter", LOG_DIR / "symbol_filter.log", to_console=False
 )
 
-try:  # pragma: no cover - optional dependency
-    from coinTrader_Trainer.ml_trainer import load_model
-    ML_AVAILABLE = True
-except Exception:  # pragma: no cover - trainer missing
-    ML_AVAILABLE = False
-    warn_ml_unavailable_once()
-
+ML_AVAILABLE = init_ml_or_warn()
 if ML_AVAILABLE:
+    from coinTrader_Trainer.ml_trainer import load_model
     MODEL = load_model("trend_bot")
 else:  # pragma: no cover - fallback
     MODEL = None

--- a/crypto_bot/utils/ml_utils.py
+++ b/crypto_bot/utils/ml_utils.py
@@ -24,12 +24,14 @@ _LOGGER_ONCE = {
 
 def warn_ml_unavailable_once() -> None:
     """Log a one-time notice when ML components are missing."""
-    if not _LOGGER_ONCE["ml_unavailable"]:
+    if _LOGGER_ONCE["ml_unavailable"]:
+        return
+    available, _ = init_ml_components()
+    if not available:
         logger.info(
-            "Machine learning model not found; running without ML features."
+            "Machine learning model not found; running without ML features.",
         )
         _LOGGER_ONCE["ml_unavailable"] = True
-
 
 def _check_packages(pkgs: Iterable[str]) -> list[str]:
     """Return a list of packages from ``pkgs`` that cannot be imported."""
@@ -159,10 +161,26 @@ def init_ml_components() -> tuple[bool, str]:
     return ML_AVAILABLE, ML_UNAVAILABLE_REASON
 
 
+def init_ml_or_warn() -> bool:
+    """Attempt to initialize ML components; warn once if unavailable."""
+    available, _ = init_ml_components()
+    if not available:
+        warn_ml_unavailable_once()
+        return False
+    try:
+        import coinTrader_Trainer.ml_trainer  # type: ignore  # noqa: F401
+    except Exception:
+        warn_ml_unavailable_once()
+        return False
+    return True
+
+
 __all__ = [
     "is_ml_available",
     "ML_AVAILABLE",
     "ML_UNAVAILABLE_REASON",
     "warn_ml_unavailable_once",
     "init_ml_components",
+    "init_ml_or_warn",
 ]
+

--- a/tests/test_ml_utils.py
+++ b/tests/test_ml_utils.py
@@ -1,5 +1,36 @@
+import logging
+import sys
+import types
+
+import crypto_bot.utils.ml_utils as ml_utils
 from crypto_bot.utils.ml_utils import ML_AVAILABLE
 
 
 def test_ml_available_is_bool():
     assert isinstance(ML_AVAILABLE, bool)
+
+
+def test_no_warning_when_models_available(monkeypatch, caplog):
+    def fake_init():
+        ml_utils.ML_AVAILABLE = True
+        return True, ""
+
+    monkeypatch.setattr(ml_utils, "init_ml_components", fake_init)
+    monkeypatch.setattr(ml_utils, "_ml_checked", False)
+    monkeypatch.setattr(
+        ml_utils, "_LOGGER_ONCE", {k: False for k in ml_utils._LOGGER_ONCE}
+    )
+
+    monkeypatch.setitem(sys.modules, "coinTrader_Trainer", types.ModuleType("coinTrader_Trainer"))
+    monkeypatch.setitem(
+        sys.modules,
+        "coinTrader_Trainer.ml_trainer",
+        types.ModuleType("coinTrader_Trainer.ml_trainer"),
+    )
+
+    caplog.set_level(logging.INFO)
+    assert ml_utils.init_ml_or_warn() is True
+    assert "Machine learning model not found" not in caplog.text
+    caplog.clear()
+    ml_utils.warn_ml_unavailable_once()
+    assert "Machine learning model not found" not in caplog.text


### PR DESCRIPTION
## Summary
- Ensure ML availability checks run before warning by refactoring `warn_ml_unavailable_once`
- Add `init_ml_or_warn` helper and update strategies to initialize models before logging
- Add test verifying no warning is logged when models and packages exist

## Testing
- `pytest tests/test_ml_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a879d23db48330b3aa0fc8509b1013