### PR TITLE
Warn and abort on empty active universe

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -1495,6 +1495,14 @@ async def fetch_candidates(ctx: BotContext) -> None:
     ctx.active_universe = [s for s, _ in symbols]
     ctx.resolved_mode = resolved_mode
 
+    if not ctx.active_universe:
+        msg = (
+            "Active universe is empty; configure 'symbols' or adjust filters"
+        )
+        logger.warning(msg)
+        if ctx.config.get("abort_on_empty_universe", True):
+            raise RuntimeError(msg)
+
     logger.info(
         "Symbol summary: total=%d selected=%d filtered=%d first=%s",
         total_candidates,

--- a/tests/test_fetch_candidates_empty_universe.py
+++ b/tests/test_fetch_candidates_empty_universe.py
@@ -1,0 +1,71 @@
+import asyncio
+import logging
+import pandas as pd
+import types, sys
+import pytest
+
+from crypto_bot.phase_runner import BotContext
+import crypto_bot.main as main
+
+# Provide dummy modules for optional dependencies
+_dummy = types.ModuleType("dummy")
+for mod in ["telegram", "gspread", "scipy", "scipy.stats", "redis"]:
+    sys.modules.setdefault(mod, _dummy)
+
+
+def _ctx():
+    df = pd.DataFrame({"high": [1, 2], "low": [0, 1], "close": [1, 2]})
+    ctx = BotContext(
+        positions={},
+        df_cache={"1h": {"BTC/USD": df}},
+        regime_cache={},
+        config={
+            "timeframe": "1h",
+            "symbols": ["BTC/USD"],
+            "symbol_batch_size": 1,
+            "benchmark_symbols": [],
+        },
+    )
+    ctx.exchange = object()
+    return ctx
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(main, "symbol_priority_queue", deque())
+    monkeypatch.setattr(main, "calc_atr", lambda df, period=14: pd.Series([0.02]))
+    monkeypatch.setattr(main, "compute_average_atr", lambda *_a, **_k: 0.01)
+    monkeypatch.setattr(main, "get_market_regime", lambda *_a, **_k: "unknown")
+
+from collections import deque
+
+
+def test_fetch_candidates_empty_universe_aborts(monkeypatch, caplog):
+    ctx = _ctx()
+
+    async def fake_get_filtered_symbols(ex, cfg):
+        return [("ETH/USD", 1.0)], []
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(main, "get_filtered_symbols", fake_get_filtered_symbols)
+
+    caplog.set_level(logging.WARNING)
+    with pytest.raises(RuntimeError, match="Active universe is empty"):
+        asyncio.run(main.fetch_candidates(ctx))
+    assert "configure 'symbols' or adjust filters" in caplog.text
+
+
+def test_fetch_candidates_empty_universe_warns(monkeypatch, caplog):
+    ctx = _ctx()
+    ctx.config["abort_on_empty_universe"] = False
+
+    async def fake_get_filtered_symbols(ex, cfg):
+        return [("ETH/USD", 1.0)], []
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(main, "get_filtered_symbols", fake_get_filtered_symbols)
+
+    caplog.set_level(logging.WARNING)
+    asyncio.run(main.fetch_candidates(ctx))
+
+    assert ctx.active_universe == []
+    assert "Active universe is empty" in caplog.text

--- a/tests/test_no_data_symbols.py
+++ b/tests/test_no_data_symbols.py
@@ -22,7 +22,12 @@ def test_symbols_with_no_data_skipped(monkeypatch):
         positions={},
         df_cache={},
         regime_cache={},
-        config={"timeframe": "1h", "symbols": ["FOO/USDC"], "symbol_batch_size": 5},
+        config={
+            "timeframe": "1h",
+            "symbols": ["FOO/USDC"],
+            "symbol_batch_size": 5,
+            "abort_on_empty_universe": False,
+        },
     )
     ctx.exchange = object()
 


### PR DESCRIPTION
## Summary
- warn and optionally abort when no symbols remain in active universe
- add regression tests for empty active universe handling

## Testing
- `pytest tests/test_fetch_candidates_empty_universe.py tests/test_no_data_symbols.py`


------
https://chatgpt.com/codex/tasks/task_e_68a880258934833088591c88acf485c3