### PR TITLE
Handle dict values in format_top sorting

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -71,8 +71,15 @@ shutdown_event = asyncio.Event()
 def format_top(scores, n: int = 25) -> str:
     """Return formatted top-N entries from a score mapping."""
     try:
-        items = sorted(scores.items(), key=lambda x: x[1], reverse=True)[:n]
-        return "\n".join(f"{sym}: {val}" for sym, val in items)
+        items = sorted(
+            scores.items(),
+            key=lambda x: x[1].get("score", 0.0) if isinstance(x[1], dict) else x[1],
+            reverse=True,
+        )[:n]
+        return "\n".join(
+            f"{sym}: {val.get('score', 0.0) if isinstance(val, dict) else val}"
+            for sym, val in items
+        )
     except Exception:
         return str(scores)
 


### PR DESCRIPTION
## Summary
- Sort score entries by `score` field when values are dictionaries
- Display symbol and extracted score for top-N entries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_68a88187688083308201270ba11b7701