### PR TITLE
Handle dict results in scoring loop

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -3810,6 +3810,9 @@ async def _main_impl() -> MainResult:
                             for (sym, tf), val in res.items():
                                 if isinstance(val, tuple):
                                     score, action = val
+                                elif isinstance(val, dict):
+                                    score = val.get("score", 0.0)
+                                    action = val.get("signal", "none")
                                 else:
                                     score, action = val, "none"
                                 logger.info(
@@ -3820,7 +3823,7 @@ async def _main_impl() -> MainResult:
                                     score,
                                     action,
                                 )
-                                scores[f"{strat.name}:{sym}:{tf}"] = score
+                                scores[f"{strat.name}:{sym}:{tf}"] = float(score)
                         except Exception:
                             logger.exception(
                                 "Strategy %s scoring failed", getattr(strat, "name", str(strat))


### PR DESCRIPTION
## Summary
- Support dict outputs from strategies by extracting score and signal
- Ensure strategy score logs and storage use extracted float score

## Testing
- `pytest tests/test_utils_lunarcrush_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8818604f083309dffb2347f1dc94d