### PR TITLE
Document default win rate fallback

### DIFF
--- a/crypto_bot/utils/regime_pnl_tracker.py
+++ b/crypto_bot/utils/regime_pnl_tracker.py
@@ -140,7 +140,9 @@ def get_recent_win_rate(
     -------
     float
         Win rate over the evaluated trades. Newer trades count more when
-        ``half_life`` is provided.
+        ``half_life`` is provided. If the log file is missing or contains no
+        trades, a default win rate of ``0.6`` is returned as a conservative
+        fallback.
     """
     file = Path(path)
     if not file.exists():


### PR DESCRIPTION
## Summary
- Document that `get_recent_win_rate` returns a default win rate of 0.6 when log data is missing or empty

## Testing
- `pytest` *(fails: ModuleNotFoundError for cointrainer, crypto_bot.wallet)*

------
https://chatgpt.com/codex/tasks/task_e_68a88bc3b8308330a34e4abdf862a46d