### PR TITLE
Separate console monitor output lines

### DIFF
--- a/crypto_bot/console_monitor.py
+++ b/crypto_bot/console_monitor.py
@@ -124,14 +124,14 @@ async def monitor_loop(
     *,
     quiet_mode: bool = False,
 ) -> None:
-    """Periodically output balance, last log line and open trade stats.
+    """Periodically print the latest log line, balance and open trade stats.
 
     This coroutine runs until cancelled and is intentionally lightweight so
     tests can easily patch it. The monitor fetches the current balance from
-    ``exchange`` or ``paper_wallet`` and prints the last line of ``log_file``.
-    Open trade PnL lines are generated from ``trade_file`` and printed below the
-    status line when positions exist. Set ``quiet_mode`` to ``True`` to print
-    a single update when stdout is not a TTY.
+    ``exchange`` or ``paper_wallet`` and prints the most recent line of
+    ``log_file``. A separate balance line and one line per open trade PnL are
+    rendered below. Set ``quiet_mode`` to ``True`` to print a single update when
+    stdout is not a TTY.
     """
     log_path = Path(log_file)
     last_line = ""
@@ -162,12 +162,11 @@ async def monitor_loop(
                         last_line = line.rstrip("\n")
                 offset = fh.tell()
 
-                message = f"[Monitor] balance={balance} log='{last_line}'"
-                lines = await trade_stats_lines(exchange, Path(trade_file))
+                log_line = last_line
+                balance_line = f"Balance: {balance}"
+                trade_lines = await trade_stats_lines(exchange, Path(trade_file))
 
-                output = message
-                if lines:
-                    output += "\n" + "\n".join(lines)
+                output = "\n".join([log_line, balance_line, *trade_lines])
 
                 if sys.stdout.isatty():
                     # Clear previously printed lines

--- a/tests/test_monitor_pnl_refresh.py
+++ b/tests/test_monitor_pnl_refresh.py
@@ -13,10 +13,12 @@ def test_monitor_pnl_refresh(monkeypatch, tmp_path):
     log_file.write_text("start\n")
 
     outputs = []
+
     def fake_print(*args, **kwargs):
         text = " ".join(str(a) for a in args)
-        if "[Monitor]" in text:
-            outputs.append(text)
+        if text.startswith("\033"):
+            return
+        outputs.append(text)
 
     call_counts = {"sleep": 0, "stats": 0}
 
@@ -43,6 +45,10 @@ def test_monitor_pnl_refresh(monkeypatch, tmp_path):
     first_lines = outputs[0].splitlines()
     second_lines = outputs[1].splitlines()
 
-    assert first_lines[1:] == ["XBT/USDT -- 100.00 -- +0.00"]
-    assert second_lines[1:] == ["XBT/USDT -- 100.00 -- +10.00"]
+    assert first_lines[0] == "start"
+    assert first_lines[1] == "Balance: 0"
+    assert first_lines[2:] == ["XBT/USDT -- 100.00 -- +0.00"]
+    assert second_lines[0] == "start"
+    assert second_lines[1] == "Balance: 0"
+    assert second_lines[2:] == ["XBT/USDT -- 100.00 -- +10.00"]
     assert first_lines != second_lines

--- a/tests/test_monitor_trade_file.py
+++ b/tests/test_monitor_trade_file.py
@@ -19,8 +19,9 @@ def test_monitor_loop_custom_trade_file(monkeypatch, tmp_path):
 
     def fake_print(*args, **kwargs):
         text = " ".join(str(a) for a in args)
-        if "[Monitor]" in text:
-            outputs.append(text)
+        if text.startswith("\033"):
+            return
+        outputs.append(text)
 
     call_count = 0
 
@@ -51,6 +52,10 @@ def test_monitor_loop_custom_trade_file(monkeypatch, tmp_path):
     first_lines = outputs[0].splitlines()
     second_lines = outputs[1].splitlines()
 
-    assert first_lines[1:] == ["XBT/USDT -- 100.00 -- +10.00"]
-    assert second_lines[1:] == []
+    assert first_lines[0] == "start"
+    assert first_lines[1] == "Balance: 0"
+    assert first_lines[2:] == ["XBT/USDT -- 100.00 -- +10.00"]
+    assert second_lines[0] == "start"
+    assert second_lines[1] == "Balance: 0"
+    assert second_lines[2:] == []
     assert first_lines != second_lines


### PR DESCRIPTION
## Summary
- Show latest log entry, balance, and open trade PnL each on their own line in console monitor
- Adjust monitor console tests for the multi-line format

## Testing
- `pytest tests/test_main_console.py tests/test_monitor_trade_file.py tests/test_monitor_pnl_refresh.py`


------
https://chatgpt.com/codex/tasks/task_e_68a88bcb3f7c8330ace1674cbeb1d039