### PR TITLE
Add voting toggle for strategy voting

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,18 @@ symbol_score_weights:
 * **voting_strategies** – strategies used for the voting router. Supports
   optional `weights`, `min_agree_fraction`, `quorum`, and
   `min_agreeing_votes` settings.
+* **voting_enabled** – when `true`, uses the voting strategies above to
+  override the base strategy. Defaults to `false`, so each strategy runs
+  independently unless enabled.
+
+Example:
+
+```yaml
+voting_enabled: true
+voting_strategies:
+  strategies: ["trend_bot", "momentum_bot"]
+  min_agreeing_votes: 2
+```
 * **micro_scalp_bot** – EMA settings plus volume z-score and ATR filters for the scalp bot.
   Supports tick-level aggregation, optional mempool fee checks and order-book
   imbalance filtering with an optional penalty. Set `trend_filter` or

--- a/config.example.testing.yaml
+++ b/config.example.testing.yaml
@@ -5,6 +5,11 @@ trading:
   min_confidence: 0.30
   consensus: weighted
   require_sentiment: false   # CT_REQUIRE_SENTIMENT=false also disables checks
+voting_enabled: false  # set true to enable strategy voting
+# Example voting configuration
+voting_strategies:
+  strategies: []
+  min_agreeing_votes: 1
 exchange:
   name: kraken
   max_concurrency: 3

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,11 @@ trading:
   exclude_symbols: ["AIBTC/USD"]   # remove noisy/synthetic pairs
 <<<<<< codex/add-ct_require_sentiment-section-in-readme
   require_sentiment: false          # override with CT_REQUIRE_SENTIMENT=false to bypass
+voting_enabled: false  # set true to enable strategy voting
+# Example voting configuration
+voting_strategies:
+  strategies: []
+  min_agreeing_votes: 1
 
 
 # === ohlcv cache ===

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -793,6 +793,7 @@ use_websocket: true
 volatility_filter:
   max_funding_rate: 0.2  # Allow hotter funding
   min_atr_pct: 0.00005  # Include flatter markets
+voting_enabled: false  # Run each strategy independently unless enabled
 voting_strategies:
   strategies:
     - trend_bot

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,6 +105,7 @@ def test_load_config_returns_dict():
     assert "top_n_symbols" in config
     assert "min_confidence_score" in config
     assert "signal_fusion" in config
+    assert "voting_enabled" in config
     assert "voting_strategies" in config
     voting = config["voting_strategies"]
     assert isinstance(voting, dict)

--- a/tests/test_single_strong_signal_override.py
+++ b/tests/test_single_strong_signal_override.py
@@ -39,6 +39,7 @@ async def test_single_strong_signal_override_dry_run(monkeypatch):
     cfg = {
         "timeframe": "1h",
         "regime_timeframes": ["1h"],
+        "voting_enabled": True,
         "voting_strategies": {"strategies": ["s"], "min_agreeing_votes": 2},
     }
     res = await ma.analyze_symbol("AAA", {"1h": df}, "dry_run", cfg, None)
@@ -63,6 +64,7 @@ async def test_single_strong_signal_live_respects_quorum(monkeypatch):
     cfg = {
         "timeframe": "1h",
         "regime_timeframes": ["1h"],
+        "voting_enabled": True,
         "voting_strategies": {"strategies": ["s"], "min_agreeing_votes": 2},
     }
     res = await ma.analyze_symbol("AAA", {"1h": df}, "cex", cfg, None)


### PR DESCRIPTION
## Summary
- allow strategy voting to be toggled via new `voting_enabled` flag
- skip voting logic in market analyzer when disabled
- document voting flag and update configs and tests

## Testing
- `pytest tests/test_regime_classifier.py::test_voting_direction_override tests/test_regime_classifier.py::test_voting_no_consensus tests/test_regime_classifier.py::test_voting_single_vote tests/test_regime_classifier.py::test_voting_disabled_runs_base tests/test_single_strong_signal_override.py tests/test_config.py::test_load_config_returns_dict -q`


------
https://chatgpt.com/codex/tasks/task_e_68a88bac20708330a7829d4c0f044b96