### PR TITLE
Simplify monitor status and console monitor coordination

### DIFF
--- a/crypto_bot/console_monitor.py
+++ b/crypto_bot/console_monitor.py
@@ -11,6 +11,11 @@ import sys
 import csv
 import pandas as pd
 
+# Flag indicating whether ``monitor_loop`` is currently running. The main
+# application checks this to disable its own status output when the console
+# monitor is active.
+MONITOR_ACTIVE = False
+
 TRADE_FILE = LOG_DIR / "trades.csv"
 
 from rich.console import Console
@@ -133,6 +138,8 @@ async def monitor_loop(
     status line when positions exist. Set ``quiet_mode`` to ``True`` to print
     a single update when stdout is not a TTY.
     """
+    global MONITOR_ACTIVE
+    MONITOR_ACTIVE = True
     log_path = Path(log_file)
     last_line = ""
     prev_lines = 0
@@ -152,7 +159,11 @@ async def monitor_loop(
                             bal = await exchange.fetch_balance()
                         else:
                             bal = await asyncio.to_thread(exchange.fetch_balance)
-                        balance = bal.get("USDT", {}).get("free", 0) if isinstance(bal.get("USDT"), dict) else bal.get("USDT", 0)
+                        balance = (
+                            bal.get("USDT", {}).get("free", 0)
+                            if isinstance(bal.get("USDT"), dict)
+                            else bal.get("USDT", 0)
+                        )
                 except Exception:
                     pass
 
@@ -190,6 +201,8 @@ async def monitor_loop(
         # Propagate cancellation after the file handle is closed by the
         # context manager.
         raise
+    finally:
+        MONITOR_ACTIVE = False
 
 
 def display_trades(

--- a/tests/test_monitor_status.py
+++ b/tests/test_monitor_status.py
@@ -1,22 +1,16 @@
-import time
 from types import SimpleNamespace
 
-import pandas as pd
-
 from crypto_bot.main import SessionState, format_monitor_line
-from crypto_bot.utils import market_loader
 
 
-def test_monitor_line_includes_metrics():
+def test_monitor_line_shows_balance_and_log_only():
+    """format_monitor_line should now emit only balance and last log."""
     ctx = SimpleNamespace(active_universe=["BTC/USD", "ETH/USD"], config={"timeframes": ["1h", "4h"]})
     session_state = SessionState()
-    session_state.df_cache["1h"] = {"BTC/USD": pd.DataFrame([1], index=[pd.Timestamp("2024-01-01")])}
     balance = 1000.0
     positions = {}
     last_log = "test"
-    market_loader.IO_TIMESTAMPS.clear()
-    market_loader.record_io()
-    market_loader.record_io()
+
     line = format_monitor_line(ctx, session_state, balance, positions, last_log)
-    assert "OHLCV 1h: 1/2 | 4h: 0/2" in line
-    assert "IOPS" in line and "/s" in line
+
+    assert line == "[Monitor] balance=$1,000.00 last='test'"


### PR DESCRIPTION
## Summary
- Streamline `format_monitor_line` to output only balance and last log entry
- Skip status loop when console monitor is running and delegate PnL display to it
- Update monitor status tests for new minimal output

## Testing
- `pytest tests/test_monitor_status.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis'; No module named 'cointrainer'; SyntaxError in tests/test_initial_scan.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a88bcccd3483308846cbecb19aaa45