### PR TITLE
Bypass bearish sentiment check in risk manager

### DIFF
--- a/crypto_bot/risk/risk_manager.py
+++ b/crypto_bot/risk/risk_manager.py
@@ -15,7 +15,7 @@ from crypto_bot.volatility_filter import too_flat, calc_atr
 
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
 from crypto_bot.utils.regime_pnl_tracker import get_recent_win_rate
-from crypto_bot.sentiment_filter import too_bearish, boost_factor
+from crypto_bot.sentiment_filter import boost_factor
 from crypto_bot.risk.sentiment_gate import sentiment_factor_or_default
 
 
@@ -331,19 +331,8 @@ class RiskManager:
             return False, reason
 
         if require_sentiment and sentiment_score != 1.0:
-            try:
-                if asyncio.run(
-                    too_bearish(
-                        self.config.min_fng,
-                        self.config.min_sentiment,
-                        symbol=symbol,
-                    )
-                ):
-                    reason = "Bearish sentiment"
-                    logger.info("[EVAL] %s", reason)
-                    return False, reason
-            except Exception as exc:  # pragma: no cover - sentiment failure
-                logger.error("Sentiment check failed: %s", exc)
+            # Temporary bypass of sentiment check for testing
+            pass  # was: asyncio.run(too_bearish(...))
 
         self.boost = 1.0
         if sentiment_score != 1.0 and (


### PR DESCRIPTION
## Summary
- Temporarily disable sentiment gating in risk manager by bypassing `too_bearish` check
- Remove unused `too_bearish` import

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*


------
https://chatgpt.com/codex/tasks/task_e_68a88da2da1c83309b6e7a4b5eedd6ce