### PR TITLE
Default win rate is 0.6 when no trade history

### DIFF
--- a/crypto_bot/log_reader.py
+++ b/crypto_bot/log_reader.py
@@ -76,7 +76,10 @@ def trade_summary(path: Path | str) -> Dict[str, float]:
             # Excess sell amount opens short position
             if amount > 0:
                 open_shorts.append((price, amount))
-    win_rate = wins / closed if closed else 0.0
+    # When no round-trip trades have been closed, assume a neutral bootstrap
+    # win rate of ``0.6`` so downstream components are not overly penalised by
+    # lack of history.
+    win_rate = wins / closed if closed else 0.6
     active = sum(qty for _, qty in open_longs) + sum(qty for _, qty in open_shorts)
     return {
         "num_trades": num_trades,

--- a/crypto_bot/utils/regime_pnl_tracker.py
+++ b/crypto_bot/utils/regime_pnl_tracker.py
@@ -159,8 +159,11 @@ def get_recent_win_rate(
 
     outcomes = (recent["pnl"] > 0).astype(float)
     total = len(outcomes)
+    # If there are no trades in the requested window (or for the filtered
+    # strategy), fall back to the bootstrap win rate of ``0.6`` to avoid
+    # overly pessimistic defaults.
     if not total:
-        return 0.0
+        return 0.6
 
     if half_life and half_life > 0:
         ages = np.arange(total - 1, -1, -1)

--- a/tests/test_log_reader.py
+++ b/tests/test_log_reader.py
@@ -31,6 +31,16 @@ def test_trade_summary_handles_bad_rows(tmp_path):
     assert stats["total_pnl"] == 0
 
 
+def test_trade_summary_no_history_defaults_win_rate(tmp_path):
+    """When no trades are present the win rate should fall back to 0.6."""
+    path = tmp_path / "trades.csv"
+
+    stats = log_reader.trade_summary(path)
+    assert stats["num_trades"] == 0
+    assert stats["total_pnl"] == 0
+    assert stats["win_rate"] == 0.6
+
+
 def test_trade_summary_short_positions(tmp_path):
     path = tmp_path / "trades.csv"
     data = [

--- a/tests/test_regime_pnl_tracker.py
+++ b/tests/test_regime_pnl_tracker.py
@@ -89,6 +89,23 @@ def test_win_rate_default(tmp_path, monkeypatch):
     assert rpt.get_recent_win_rate(5, log) == 0.6
 
 
+def test_win_rate_no_history_for_strategy(tmp_path, monkeypatch):
+    """If other strategies have history but the requested one does not, the
+    bootstrap win rate of 0.6 should be returned."""
+    log = tmp_path / "pnl.csv"
+    perf = tmp_path / "perf.json"
+    monkeypatch.setattr(rpt, "LOG_FILE", log)
+    monkeypatch.setattr(rpt, "PERF_FILE", perf)
+
+    # Log trades for a different strategy
+    rpt.log_trade("trending", "grid_bot", 1.0)
+    rpt.log_trade("trending", "grid_bot", -0.5)
+
+    # Request win rate for strategy with no trades
+    rate = rpt.get_recent_win_rate(5, log, strategy="trend_bot")
+    assert rate == 0.6
+
+
 def test_recent_win_rate_decay_weights_newer_trades(tmp_path, monkeypatch):
     log = tmp_path / "pnl.csv"
     perf = tmp_path / "perf.json"


### PR DESCRIPTION
## Summary
- Return a bootstrap win rate of 0.6 when no trades are found in `get_recent_win_rate`
- Default `trade_summary` win rate to 0.6 when no closed trades exist
- Add regression tests for both behaviours

## Testing
- `pytest tests/test_regime_pnl_tracker.py::test_win_rate_no_history_for_strategy tests/test_log_reader.py::test_trade_summary_no_history_defaults_win_rate -q`


------
https://chatgpt.com/codex/tasks/task_e_68a88e0b972c83309aab960ce0af286e