### PR TITLE
feat: track bootstrap progress

### DIFF
--- a/crypto_bot/utils/bootstrap_progress.py
+++ b/crypto_bot/utils/bootstrap_progress.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import json
+from typing import Dict
 
 CACHE_DIR = Path(__file__).resolve().parents[2] / "cache"
 PROGRESS_FILE = CACHE_DIR / "bootstrap_progress.json"
@@ -10,3 +12,23 @@ def reset_bootstrap_progress() -> None:
         PROGRESS_FILE.unlink()
     except FileNotFoundError:
         pass
+
+
+def update_bootstrap_progress(stats: Dict[str, Dict[str, int]]) -> None:
+    """Merge *stats* into the cached bootstrap progress file.
+
+    Parameters
+    ----------
+    stats : Dict[str, Dict[str, int]]
+        Mapping of timeframe -> {"fetched": int, "required": int}
+    """
+
+    PROGRESS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with PROGRESS_FILE.open() as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        data = {}
+    data.update(stats)
+    with PROGRESS_FILE.open("w") as f:
+        json.dump(data, f)

--- a/tests/test_market_loader.py
+++ b/tests/test_market_loader.py
@@ -1168,7 +1168,10 @@ def test_update_multi_tf_ohlcv_cache_resume(tmp_path, monkeypatch):
         )
     )
     data = json.loads(state_file.read_text())
-    assert set(data.get("1h", [])) == {"BTC/USD", "ETH/USD"}
+    assert set(data.get("1h", {}).keys()) == {"BTC/USD", "ETH/USD"}
+    for sym in ("BTC/USD", "ETH/USD"):
+        assert data["1h"][sym]["fetched"] == 1
+        assert data["1h"][sym]["required"] == 1
     assert set(calls) == {"BTC/USD", "ETH/USD"}
 
     calls.clear()


### PR DESCRIPTION
## Summary
- track required vs fetched candles per symbol/timeframe and log percentage progress
- persist bootstrap progress to resume accurately and export stats for UI
- adjust tests for new bootstrap progress structure

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis'; ModuleNotFoundError: No module named 'cointrainer'; SyntaxError in tests/test_initial_scan.py; ModuleNotFoundError: No module named 'crypto_bot.wallet')*


------
https://chatgpt.com/codex/tasks/task_e_68a88d7641a883308ca00efae79d54c0