### PR TITLE
Add progress ETA helper and logging toggle

### DIFF
--- a/config.example.testing.yaml
+++ b/config.example.testing.yaml
@@ -19,6 +19,7 @@ ohlcv:
   storage_path: crypto_bot/data/ohlcv   # directory for persisted OHLCV data
   tail_overlap_bars: 3                  # overlap bars to avoid gaps when appending
   max_bootstrap_bars: 1000              # limit initial bootstrap to this many bars
+  progress_logging: false               # include percent/ETA when data is missing
   bootstrap_timeframes: ["1m", "5m", "15m", "1h"]
   defer_timeframes: ["4h", "1d"]
   warmup_candles:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,6 +30,7 @@ ohlcv:
   storage_path: crypto_bot/data/ohlcv   # directory for persisted OHLCV data
   tail_overlap_bars: 3                  # overlap bars to avoid gaps when appending
   max_bootstrap_bars: 1000              # limit initial bootstrap to this many bars
+  progress_logging: false               # include percent/ETA when data is missing
   bootstrap_timeframes: ["1m", "5m", "15m", "1h"]
   defer_timeframes: ["4h", "1d"]
   warmup_candles:


### PR DESCRIPTION
## Summary
- add `get_progress_eta` helper to report bootstrap percentage and ETA
- log OHLCV progress in breakout strategy when enabled via config
- add `progress_logging` option to example configs

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager')*


------
https://chatgpt.com/codex/tasks/task_e_68a88d73d3408330ab128c90a781500a