### PR TITLE
feat(config): unify short selling flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ The `crypto_bot/config.yaml` file holds the runtime settings for the bot. Below 
   `onchain_symbols`. Defaults to `USDC`.
 * **benchmark_symbols** – list of markets always added for performance comparison.
   Defaults to `[symbol, "SOL/USDC"]`. Set to `[]` to disable benchmarks.
-* **allow_short** – enable short selling. Set to `true` only when your exchange account supports short selling.
+* **trading.short_selling** – enable short selling. Set to `true` only when your exchange account supports short selling.
 * Trades and swaps automatically retry transient errors up to three times.
 
 ### Market Scanning

--- a/crypto_bot/bot_controller.py
+++ b/crypto_bot/bot_controller.py
@@ -17,6 +17,7 @@ from crypto_bot import main
 
 import yaml
 from crypto_bot.utils.symbol_utils import fix_symbol
+from .config import short_selling_enabled
 
 from .portfolio_rotator import PortfolioRotator
 from .console_monitor import get_open_trades
@@ -45,7 +46,7 @@ class TradingBotController:
             self.wallet = Wallet(
                 self.config.get("start_balance", 1000.0),
                 exec_cfg.get("max_positions", self.config.get("max_open_trades", 1)),
-                self.config.get("allow_short", False),
+                short_selling_enabled(self.config),
                 stake_usd=exec_cfg.get("stake_usd"),
                 min_price=exec_cfg.get("min_price", 0.0),
                 min_notional=exec_cfg.get("min_notional", 0.0),

--- a/crypto_bot/config.py
+++ b/crypto_bot/config.py
@@ -53,3 +53,37 @@ class Config:
 cfg = Config()
 
 
+def short_selling_enabled(cfg_dict: dict, default: bool = False) -> bool:
+    """Return True if short selling is enabled in the configuration.
+
+    This centralises backward-compatibility handling for legacy keys. New
+    configurations should define ``trading.short_selling``. Older configs may
+    use ``allow_short`` or ``allow_shorting`` either at the top level or within
+    ``trading``. This helper resolves the setting with the following
+    precedence:
+
+    1. ``trading.short_selling``
+    2. ``trading.allow_shorting``
+    3. ``allow_short`` (top level)
+    4. ``allow_shorting`` (top level)
+
+    Parameters
+    ----------
+    cfg_dict:
+        Configuration dictionary to inspect.
+    default:
+        Value to return if none of the known keys are present.
+    """
+
+    trading = cfg_dict.get("trading", {}) or {}
+    if "short_selling" in trading:
+        return bool(trading["short_selling"])
+    if "allow_shorting" in trading:
+        return bool(trading["allow_shorting"])
+    if "allow_short" in cfg_dict:
+        return bool(cfg_dict["allow_short"])
+    if "allow_shorting" in cfg_dict:
+        return bool(cfg_dict["allow_shorting"])
+    return bool(default)
+
+

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -8,7 +8,7 @@ exchange:
 trading:
   mode: dry_run           # cex | onchain | auto | dry_run
   enable_execution: true          # make sure the trader loop can place paper orders
-  allow_shorting: false           # unless you really want simulated shorts
+  short_selling: false            # unless you really want simulated shorts
   allowed_quotes: [USD, USDT, USDC, EUR]
   min_ticker_volume: 10000
   timeframes: ["1m","5m","15m","1h"]
@@ -188,7 +188,6 @@ adaptive_scan:
   enabled: true
   max_factor: 10.0
 adx_threshold: 15
-allow_short: false
 arbitrage_enabled: true
 arbitrage_threshold: 0.005
 atr_normalization: true

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -45,6 +45,7 @@ from crypto_bot.utils import ml_utils
 # Expose ML availability flag for tests and external modules
 ML_AVAILABLE = ml_utils.ML_AVAILABLE
 from crypto_bot.ml.model_loader import load_regime_model, _norm_symbol
+from .config import short_selling_enabled
 
 # Internal project modules are imported lazily in `_import_internal_modules()`
 
@@ -2307,7 +2308,7 @@ async def execute_signals(
             reasons.append("no direction")
         if res.get("too_flat", False):
             reasons.append("atr too flat")
-        if side == "sell" and not ctx.config.get("allow_short", True):
+        if side == "sell" and not short_selling_enabled(ctx.config, default=True):
             reasons.append("short selling disabled")
         if reasons:
             logger.warning("Skipping %s: %s", sym, ", ".join(reasons))
@@ -2498,7 +2499,7 @@ async def execute_signals(
                 "skip_trade reason flags | symbol=%s side=%s short_selling=%s sentiment_enabled=%s sentiment_ok=%s ml_enabled=%s ml_ok=%s model_found=%s pred=%s thr=%s venue_ok=%s cooldown=%s sizing_ok=%s budget_ok=%s",
                 sym,
                 side,
-                bool(ctx.config.get("allow_short", False)),
+                short_selling_enabled(ctx.config),
                 ctx.config.get("trading", {}).get("require_sentiment", True),
                 sentiment_ok,
                 ctx.config.get("ml_enabled", True),
@@ -2621,7 +2622,7 @@ async def execute_signals(
             _log_rejection(sym, score, direction, min_req, outcome_reason, "SCORING")
             reject_counts["no_actionable_side"] += 1
             continue
-        allow_short = bool(ctx.config.get("allow_short", False))
+        allow_short = short_selling_enabled(ctx.config)
         if side == "sell" and not allow_short:
             logger.info("Skip: short selling disabled; %s", candidate)
             outcome_reason = "short selling disabled"
@@ -3680,7 +3681,7 @@ async def _main_impl() -> MainResult:
         wallet = Wallet(
             start_bal,
             exec_cfg.get("max_positions", config.get("max_open_trades", 1)),
-            config.get("allow_short", False),
+            short_selling_enabled(config),
             stake_usd=exec_cfg.get("stake_usd"),
             min_price=exec_cfg.get("min_price", 0.0),
             min_notional=exec_cfg.get("min_notional", 0.0),

--- a/crypto_bot/strategy/breakout.py
+++ b/crypto_bot/strategy/breakout.py
@@ -9,6 +9,7 @@ import ta
 from crypto_bot.utils import stats
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils.market_loader import get_progress_eta
+from crypto_bot.config import short_selling_enabled
 
 NAME = "breakout"
 logger = logging.getLogger(__name__)
@@ -59,7 +60,7 @@ def generate_signal(
     volume_z_min = float(cfg.get("volume_z_min", 1.0))
     atr_len = int(cfg.get("atr_len", keltner_len))
     max_spread_bp = float(cfg.get("max_spread_bp", 5.0))
-    allow_short = bool(cfg.get("allow_short", False))
+    allow_short = short_selling_enabled(cfg_all)
     score_threshold = float(cfg.get("score_threshold", 0.0))
     lookback = max(donchian_len, keltner_len, bbw_lookback, vol_window, atr_len)
     progress_logging = bool(cfg_all.get("ohlcv", {}).get("progress_logging", False))

--- a/frontend/api.py
+++ b/frontend/api.py
@@ -9,6 +9,7 @@ from crypto_bot.utils.logger import LOG_DIR
 import yaml
 from pathlib import Path
 from wallet import Wallet
+from crypto_bot.config import short_selling_enabled
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from crypto_bot.bot_controller import TradingBotController
@@ -32,7 +33,7 @@ def get_controller() -> "TradingBotController":
             wallet = Wallet(
                 cfg.get("start_balance", 1000.0),
                 exec_cfg.get("max_positions", cfg.get("max_open_trades", 1)),
-                cfg.get("allow_short", False),
+                short_selling_enabled(cfg),
                 stake_usd=exec_cfg.get("stake_usd"),
                 min_price=exec_cfg.get("min_price", 0.0),
                 min_notional=exec_cfg.get("min_notional", 0.0),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,7 +98,7 @@ def test_load_config_returns_dict():
     assert "arbitrage_threshold" in config
     assert "sl_mult" in config
     assert "tp_mult" in config
-    assert "allow_short" in config
+    assert "short_selling" in config.get("trading", {})
     assert "ml_enabled" in config
     assert "scan_lookback_limit" in config
     assert "cycle_lookback_limit" in config

--- a/tests/test_execute_signals.py
+++ b/tests/test_execute_signals.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from crypto_bot.phase_runner import BotContext
 from crypto_bot.paper_wallet import PaperWallet
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
+from crypto_bot.config import short_selling_enabled
 
 
 class DummyRM:
@@ -68,6 +69,7 @@ def load_execute_signals():
         "_monitor_micro_scalp_exit": lambda *a, **k: None,
         "BotContext": BotContext,
         "refresh_balance": lambda ctx: asyncio.sleep(0),
+        "short_selling_enabled": short_selling_enabled,
     }
     ns["score_logger"].setLevel(logging.DEBUG)
     exec(funcs["direction_to_side"], ns)
@@ -76,7 +78,7 @@ def load_execute_signals():
 
 
 @pytest.mark.asyncio
-async def test_execute_signals_respects_allow_short(monkeypatch, caplog):
+async def test_execute_signals_respects_short_selling(monkeypatch, caplog):
     df = pd.DataFrame({"close": [100.0]})
     candidate = {
         "symbol": "XBT/USDT",
@@ -94,7 +96,7 @@ async def test_execute_signals_respects_allow_short(monkeypatch, caplog):
         positions={},
         df_cache={"1h": {"XBT/USDT": df}},
         regime_cache={},
-        config={"execution_mode": "dry_run", "allow_short": False, "top_n_symbols": 1},
+        config={"execution_mode": "dry_run", "trading": {"short_selling": False}, "top_n_symbols": 1},
         exchange=object(),
         ws_client=None,
         risk_manager=DummyRM(),


### PR DESCRIPTION
## Summary
- add `short_selling_enabled` helper with legacy key fallback
- switch config to `trading.short_selling` and update bot paths
- adjust tests for new config key

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `pytest tests/test_execute_signals.py::test_execute_signals_respects_short_selling -q`
- `pytest tests/test_config.py::test_load_config_returns_dict -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8980cd680833085dc8d2e8f5f6d13