### PR TITLE
Add asynchronous meme wave runner

### DIFF
--- a/crypto_bot/runners/__init__.py
+++ b/crypto_bot/runners/__init__.py
@@ -1,0 +1,3 @@
+"""Runner utilities for coordinating bot pipelines."""
+
+__all__ = []

--- a/crypto_bot/runners/meme_wave_runner.py
+++ b/crypto_bot/runners/meme_wave_runner.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Mapping
+
+from crypto_bot.core.pipeline import (
+    scoring_loop,
+    execution_loop,
+    heartbeat_loop,
+)
+from crypto_bot.strategy import load_strategies
+
+
+async def run(config: Mapping[str, object]) -> None:
+    """Run the meme-wave trading pipeline."""
+    # Load strategies or perform other warm-up tasks before starting loops
+    load_strategies(config.get("mode", "cex"))
+
+    score_task = asyncio.create_task(scoring_loop(config))
+    exec_task = asyncio.create_task(execution_loop(config))
+    heartbeat_task = asyncio.create_task(heartbeat_loop(config))
+
+    await asyncio.gather(score_task, exec_task, heartbeat_task)
+
+
+__all__ = ["run"]


### PR DESCRIPTION
## Summary
- Add runners package with meme wave runner
- Run scoring, execution, and heartbeat loops concurrently
- Load strategies before starting pipeline loops

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*


------
https://chatgpt.com/codex/tasks/task_e_68a8a68f31548330b07cf37bea4e5371