### PR TITLE
Introduce centralized trade queue

### DIFF
--- a/crypto_bot/core/__init__.py
+++ b/crypto_bot/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core utilities and shared state for crypto_bot."""
+
+from .queues import TradeCandidate, trade_queue
+
+__all__ = ["TradeCandidate", "trade_queue"]

--- a/crypto_bot/core/queues.py
+++ b/crypto_bot/core/queues.py
@@ -1,0 +1,21 @@
+"""Centralized asyncio queues used across the trading bot."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, TypedDict
+
+
+class TradeCandidate(TypedDict):
+    """Represents a potential trade awaiting execution."""
+
+    symbol: str
+    side: str
+    score: float
+    strategy: str
+    timeframe: str
+    meta: dict[str, Any]
+
+
+# Global queue of trade candidates awaiting execution
+trade_queue: asyncio.Queue[TradeCandidate] = asyncio.Queue(maxsize=1000)

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -36,6 +36,7 @@ from crypto_bot.utils.logging_config import setup_logging
 
 lastlog = setup_logging(LOG_DIR / "bot.log")
 
+from crypto_bot.core.queues import trade_queue
 from crypto_bot.universe import build_tradable_set
 from crypto_bot.strategy.evaluator import StreamEvaluator, set_stream_evaluator
 from crypto_bot.risk.risk_manager import RiskManager, RiskConfig


### PR DESCRIPTION
## Summary
- Add core queues module with `TradeCandidate` TypedDict and shared `trade_queue`
- Re-export queue in `crypto_bot.core` package and integrate into `main` imports

## Testing
- `PYTHONPATH=.:src python -m pytest -q` *(fails: SyntaxError in tests/test_initial_scan.py and import errors for wallet modules)*
- `PYTHONPATH=/workspace/coinTrader2.0:/workspace/coinTrader2.0/src python -m pytest tests/test_wallet.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8a69024e083308c963ee938a7b08b