### PR TITLE
Log queue operations in evaluation engine

### DIFF
--- a/crypto_bot/engine/evaluation_engine.py
+++ b/crypto_bot/engine/evaluation_engine.py
@@ -158,6 +158,7 @@ class StreamEvaluationEngine:
         while not self._stop.is_set():
             try:
                 symbol, ctx = await self.queue.get()
+                logger.info("DEQUEUED %s", symbol)
                 try:
                     needs_5m = self._symbol_requires_5m(ctx)
                     if not self.data.ready(symbol, "1m"):
@@ -182,6 +183,7 @@ class StreamEvaluationEngine:
         await asyncio.sleep(0)
 
     async def enqueue(self, symbol: str, ctx: dict) -> None:
+        logger.info("ENQUEUED %s", symbol)
         await self.queue.put((symbol, ctx))
 
     async def drain(self) -> None:


### PR DESCRIPTION
## Summary
- log when symbols are enqueued and dequeued in evaluation engine workers

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68a8a6dbe3948330a4a645d83c048f99