### PR TITLE
Reduce minimum strategy votes to one

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -509,7 +509,7 @@ risk:
   win_rate_threshold: 0.4
   win_rate_boost_factor: 1.5
   min_score_to_trade: 0.15
-  min_votes: 2
+  min_votes: 1
 
 router:
   min_accept_score: 0.5


### PR DESCRIPTION
## Summary
- allow single-strategy execution by setting risk.min_votes to 1

## Testing
- `pytest` *(fails: No module named 'fakeredis', No module named 'cointrainer', No module named 'crypto_bot.wallet')*

------
https://chatgpt.com/codex/tasks/task_e_68aa3854bfe48330a02a8fdafda3dbd9