### PR TITLE
Reuse shared HTTP session across data loaders

### DIFF
--- a/crypto_bot/lunarcrush_client.py
+++ b/crypto_bot/lunarcrush_client.py
@@ -8,6 +8,7 @@ import asyncio
 import aiohttp
 
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
+from crypto_bot.utils.http_client import get_session
 
 
 logger = setup_logger(__name__, LOG_DIR / "lunarcrush.log")
@@ -32,10 +33,8 @@ class LunarCrushClient:
         if self.api_key:
             params["key"] = self.api_key
 
-        if self.session is None:
-            async with aiohttp.ClientSession() as session:
-                return await self._fetch(session, params)
-        return await self._fetch(self.session, params)
+        session = self.session or get_session()
+        return await self._fetch(session, params)
 
     def get_sentiment_sync(self, symbol: str) -> float:
         """Return sentiment score for ``symbol`` using ``asyncio.run``.

--- a/crypto_bot/utils/lunarcrush_client.py
+++ b/crypto_bot/utils/lunarcrush_client.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping
 import aiohttp
 
 from .logger import LOG_DIR, setup_logger
+from .http_client import get_session, close_session
 
 logger = setup_logger(__name__, LOG_DIR / "lunarcrush_client.log")
 
@@ -19,16 +20,14 @@ class LunarCrushClient:
     def __init__(self, api_key: str | None = None) -> None:
         """Create client using ``api_key`` or ``LUNARCRUSH_API_KEY`` env var."""
         self.api_key = api_key or os.getenv("LUNARCRUSH_API_KEY")
-        self._session: aiohttp.ClientSession | None = None
 
     async def _get_session(self) -> aiohttp.ClientSession:
-        if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession()
-        return self._session
+        """Return the shared HTTP session."""
+        return get_session()
 
     async def close(self) -> None:
-        if self._session and not self._session.closed:
-            await self._session.close()
+        """Close the shared session if open."""
+        await close_session()
 
     async def request(
         self, endpoint: str, params: Mapping[str, Any] | None = None

--- a/tasks/refresh_pairs.py
+++ b/tasks/refresh_pairs.py
@@ -10,6 +10,7 @@ import logging
 import ccxt.async_support as ccxt
 import aiohttp
 from crypto_bot.utils.market_loader import timeframe_seconds
+from crypto_bot.utils.http_client import get_session
 from configy import load_config
 
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "crypto_bot" / "config.yaml"
@@ -91,11 +92,11 @@ async def _close_exchange(exchange: ccxt.Exchange) -> None:
 async def get_solana_liquid_pairs(min_volume: float, quote: str = "USDC") -> list[str]:
     """Return Raydium symbols with liquidity above ``min_volume`` using ``quote`` as quote currency."""
     url = "https://api.raydium.io/v2/main/pairs"
+    session = get_session()
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, timeout=10) as resp:
-                resp.raise_for_status()
-                data = await resp.json()
+        async with session.get(url, timeout=10) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
     except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
         logger.error("Failed to fetch Solana pairs: %s", exc)
         return []

--- a/tests/test_gecko.py
+++ b/tests/test_gecko.py
@@ -49,7 +49,7 @@ def test_gecko_request_retry_backoff(monkeypatch):
         DummyResponse(429),
         DummyResponse(200, {"ok": True}),
     ]
-    monkeypatch.setattr(gecko.aiohttp, "ClientSession", lambda: DummySession(responses))
+    monkeypatch.setattr(gecko, "get_session", lambda: DummySession(responses))
 
     sleeps: list[float] = []
 

--- a/tests/test_lunarcrush_client.py
+++ b/tests/test_lunarcrush_client.py
@@ -1,6 +1,7 @@
 import aiohttp
 import pytest
 
+import crypto_bot.lunarcrush_client as lc
 from crypto_bot.lunarcrush_client import LunarCrushClient
 
 
@@ -40,7 +41,7 @@ class DummySession:
 @pytest.mark.asyncio
 async def test_get_sentiment(monkeypatch):
     session = DummySession({"data": [{"sentiment": 4}]})
-    monkeypatch.setattr(aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setattr(lc, "get_session", lambda: session)
     client = LunarCrushClient()
     score = await client.get_sentiment("BTC")
     assert session.last_params["symbol"] == "BTC"

--- a/tests/test_refresh_pairs.py
+++ b/tests/test_refresh_pairs.py
@@ -6,6 +6,8 @@ import pytest
 import os
 import time
 
+import crypto_bot.utils.http_client  # ensure module present
+
 yaml_mod = types.ModuleType("yaml")
 yaml_mod.safe_load = lambda *_a, **_k: {}
 sys.modules.setdefault("yaml", yaml_mod)
@@ -233,8 +235,7 @@ def test_get_solana_liquid_pairs(monkeypatch):
         {"base": {"symbol": "C"}, "quote": {"symbol": "OTHER"}, "liquidity": 5_000_000},
     ]
     session = DummySession(data)
-    aiohttp_mod = type("M", (), {"ClientSession": lambda: session, "ClientError": Exception})
-    monkeypatch.setattr(rp, "aiohttp", aiohttp_mod)
+    monkeypatch.setattr(rp, "get_session", lambda: session)
     res = asyncio.run(rp.get_solana_liquid_pairs(1_000_000))
     assert res == ["A/USDC"]
     assert session.url == "https://api.raydium.io/v2/main/pairs"

--- a/tests/test_symbol_pre_filter.py
+++ b/tests/test_symbol_pre_filter.py
@@ -1212,6 +1212,12 @@ def test_fetch_ticker_async_timeout(monkeypatch):
     calls: list[int | None] = []
 
     class FakeResp:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            pass
+
         def raise_for_status(self):
             pass
 
@@ -1219,17 +1225,11 @@ def test_fetch_ticker_async_timeout(monkeypatch):
             return {}
 
     class FakeSession:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *exc):
-            pass
-
         async def get(self, url, timeout=None):
             calls.append(timeout)
             return FakeResp()
 
-    monkeypatch.setattr(sp.aiohttp, "ClientSession", lambda: FakeSession())
+    monkeypatch.setattr(sp, "get_session", lambda: FakeSession())
 
     asyncio.run(sp._fetch_ticker_async(["XBTUSD"], timeout=5))
 


### PR DESCRIPTION
## Summary
- Share the global aiohttp session across LunarCrush clients and Gecko requests
- Use shared session for Solana pair refresh and symbol pre-filter ticker fetches
- Adjust unit tests to patch shared session entry points

## Testing
- `pytest tests/test_gecko.py tests/test_lunarcrush_client.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68aa384e26148330b8e4e4423281f0e6