### PR TITLE
Include breakout strategy in breakout regime

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -663,6 +663,7 @@ strategy_router:
     - lstm_bot
     breakout:
     - breakout_bot
+    - breakout
     - lstm_bot
     dip_hunter:
     - dip_hunter


### PR DESCRIPTION
## Summary
- Decide breakout_bot as authoritative implementation and include breakout strategy alongside it
- Update `strategy_router.regimes.breakout` to reference both strategies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `pytest tests/test_breakout_bot.py -q` *(fails: assertion mismatches in breakout_bot.generate_signal)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3847f3d883309ec257d191f5ea59