### PR TITLE
Tune fast-path scoring threshold

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -653,7 +653,7 @@ strategy_router:
     adx_threshold: 25
     bbw_pct_max: 5
     vol_z_min: -1.0
-    min_score: 10
+    min_score: 0.05
   mean_reverting_timeframe: 1h
   flash_crash_timeframe: 1m
   min_confidence: 0.0005


### PR DESCRIPTION
## Summary
- align `fast_path.min_score` with other router thresholds so early scans trigger realistically
- keep existing ADX/BBW filters intact for meaningful fast-path gating

## Testing
- `pytest tests/test_strategy_router.py::test_route_skips_adx_fast_path_for_small_df tests/test_strategy_router.py::test_fastpath_breakout tests/test_strategy_router.py::test_fastpath_trend -q`
- `pytest tests/test_config_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa38449678833094c78a50f23beeda