### PR TITLE
Tune routing and fusion thresholds

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -12,7 +12,7 @@ trading:
   allowed_quotes: [USD, USDT, USDC, EUR]
   min_ticker_volume: 10000
   timeframes: ["1m","5m","15m","1h"]
-  min_score: 0.20
+  min_score: 0.02
   min_confidence: 0.30
   consensus: weighted
   backfill:
@@ -30,7 +30,7 @@ filters:
 
 # === router ===
 router:
-  min_accept_score: 0.5
+  min_accept_score: 0.02
   prefer_timeframes: ["5m","15m","1m"]
   require_warm: false
   top_k_per_strategy: 3
@@ -40,11 +40,11 @@ router:
 ohlcv:
   storage_path: crypto_bot/data/ohlcv   # directory for persisted OHLCV data
   tail_overlap_bars: 3                  # overlap bars to avoid gaps when appending
-  max_bootstrap_bars: 1000              # limit initial bootstrap to this many bars
+  max_bootstrap_bars: 3000              # limit initial bootstrap to this many bars
   bootstrap_timeframes: ["1m","5m","15m","1h"]
   defer_timeframes: ["4h","1d"]
   warmup_candles:              # override with CT_WARMUP_<TF> env vars
-    "1m": 2000   # CT_WARMUP_1M
+    "1m": 1000   # CT_WARMUP_1M
     "5m": 2000   # CT_WARMUP_5M
     "15m": 2000  # CT_WARMUP_15M
     "1h": 1500   # CT_WARMUP_1H
@@ -341,8 +341,8 @@ loop_interval_seconds: 0.05
 hft_mode: true
 max_age_days: 90
 max_change_pct: 20
-max_concurrent_ohlcv: 50
-http_pool_size: 50
+max_concurrent_ohlcv: 8
+http_pool_size: 25
 max_concurrent_tickers: 20
 max_latency_ms: 500
 max_ohlcv_failures: 2
@@ -508,11 +508,11 @@ risk:
   volume_threshold_ratio: 0.01
   win_rate_threshold: 0.4
   win_rate_boost_factor: 1.5
-  min_score_to_trade: 0.15
+  min_score_to_trade: 0.02
   min_votes: 1
 
 router:
-  min_accept_score: 0.5
+  min_accept_score: 0.02
   prefer_timeframes: ["5m","15m","1m"]
   require_warm: false
   top_k_per_strategy: 3
@@ -557,12 +557,13 @@ sentiment_filter:
 signal_fusion:
   enabled: true
   fusion_method: weight
-  min_confidence: 0.01
+  min_confidence: 0.005
   strategies:
     - [trend_bot, 0.3]
     - [momentum_bot, 0.25]
     - [mean_bot, 0.15]
     - [breakout_bot, 0.1]
+    - [breakout, 0.1]
     - [sniper_bot, 0.1]
     - [grid_bot, 0.05]
     - [micro_scalp_bot, 0.05]
@@ -575,7 +576,6 @@ signal_weight_optimizer:
   enabled: true
   learning_rate: 0.05
   min_weight: 0.01
-skip_symbol_filters: false
 sl_mult: 1.0
 sl_pct: 0.015
 sniper_solana:
@@ -653,7 +653,7 @@ strategy_router:
     adx_threshold: 25
     bbw_pct_max: 5
     vol_z_min: -1.0
-    min_score: 0.05
+    min_score: 0.02
   mean_reverting_timeframe: 1h
   flash_crash_timeframe: 1m
   min_confidence: 0.0005
@@ -830,5 +830,5 @@ onchain_watchers:
   enabled: false   # hard off in CEX mode
 
 strict_cex: true   # only symbols the exchange actually lists
+skip_symbol_filters: false
 denylist_symbols: ['AIBTC/USD','AIBTC:USD','AIBTC/EUR','AIBTC:EUR','BTC/USD.P','ETH/USD.P']
-


### PR DESCRIPTION
## Summary
- Lower router and trading score thresholds to 0.02 and expand OHLCV bootstrap range
- Add breakout strategy to fusion and fast-path maps while relaxing confidence limits
- Reduce Kraken concurrency and expose skip_symbol_filters with strict CEX discovery

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68aa5851a5fc8330b7b60c9f489e056a