### PR TITLE
Raise router min accept score to 0.12

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -30,7 +30,7 @@ filters:
 
 # === router ===
 router:
-  min_accept_score: 0.02
+  min_accept_score: 0.12
   prefer_timeframes: ["5m","15m","1m"]
   require_warm: false
   top_k_per_strategy: 3
@@ -512,7 +512,7 @@ risk:
   min_votes: 1
 
 router:
-  min_accept_score: 0.02
+  min_accept_score: 0.12
   prefer_timeframes: ["5m","15m","1m"]
   require_warm: false
   top_k_per_strategy: 3


### PR DESCRIPTION
## Summary
- Increase `router.min_accept_score` from 0.02 to 0.12 in crypto bot configuration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68aa74ed476c83308d0780ba2de20591