### PR TITLE
feat: use max fusion method

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -556,21 +556,22 @@ sentiment_filter:
   min_sentiment: 40
 signal_fusion:
   enabled: true
-  fusion_method: weight
+  fusion_method: max
   min_confidence: 0.005
-  strategies:
-    - [trend_bot, 0.3]
-    - [momentum_bot, 0.25]
-    - [mean_bot, 0.15]
-    - [breakout_bot, 0.1]
-    - [breakout, 0.1]
-    - [sniper_bot, 0.1]
-    - [grid_bot, 0.05]
-    - [micro_scalp_bot, 0.05]
-    - [lstm_bot, 0.1]
-    - [bounce_scalper, 0.1]
-    - [flash_crash_bot, 0.05]
-    - [meme_wave_bot, 0.05]
+  # Strategies are retained for documentation purposes only.
+  # strategies:
+  #   - [trend_bot, 0.3]
+  #   - [momentum_bot, 0.25]
+  #   - [mean_bot, 0.15]
+  #   - [breakout_bot, 0.1]
+  #   - [breakout, 0.1]
+  #   - [sniper_bot, 0.1]
+  #   - [grid_bot, 0.05]
+  #   - [micro_scalp_bot, 0.05]
+  #   - [lstm_bot, 0.1]
+  #   - [bounce_scalper, 0.1]
+  #   - [flash_crash_bot, 0.05]
+  #   - [meme_wave_bot, 0.05]
 signal_threshold: 0.0001
 signal_weight_optimizer:
   enabled: true


### PR DESCRIPTION
## Summary
- use `max` fusion method for signal fusion
- keep weighted strategies list commented for documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_68aa74f2e42c8330966858b925f06437