### PR TITLE
Lower breakout min intensity for 1h timeframe

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -247,7 +247,7 @@ breakout:
   vol_multiplier: 0.5
   volume_window: 15
   min_intensity:
-    "1h": 0.03
+    "1h": 0.015
 cycle_bias:
   enabled: false
   mvrv_url: https://api.example.com/mvrv

--- a/crypto_bot/strategies/breakout_bot.py
+++ b/crypto_bot/strategies/breakout_bot.py
@@ -32,7 +32,7 @@ def generate_signal(
                     "kc_mult": float,
                     "volume_window": int,
                     "vol_multiplier": float,
-                    "min_intensity": {"1h": 0.03, ...}
+                    "min_intensity": {"1h": 0.015, ...}
                 }
             }
 


### PR DESCRIPTION
## Summary
- lower `breakout` strategy's 1h min intensity threshold to 0.015
- align breakout bot docstring example with new min intensity value

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis'; ModuleNotFoundError: No module named 'cointrainer'; SyntaxError in tests/test_initial_scan.py)*

------
https://chatgpt.com/codex/tasks/task_e_68aa74f5a11c8330b091306fe0a53ad1