### PR TITLE
Disable signal fusion by default

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -556,7 +556,7 @@ sentiment_filter:
   min_fng: 20  # Lower if current FNG is blocking
   min_sentiment: 40
 signal_fusion:
-  enabled: true
+  enabled: false
   fusion_method: max            # was weight
   min_confidence: 0.0
   # weights retained but no longer suppress the max


### PR DESCRIPTION
## Summary
- disable the signal fusion feature in the default configuration by setting `signal_fusion.enabled` to false

## Testing
- `pytest tests/test_config.py tests/test_signal_fusion.py` *(fails: test_config has 2 failing assertions)*
- `pytest tests/test_signal_fusion.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab170c3698833098a7a65d210cd54d