### PR TITLE
feat: guard against missing OHLCV data

### DIFF
--- a/crypto_bot/strategies/breakout_bot.py
+++ b/crypto_bot/strategies/breakout_bot.py
@@ -2,7 +2,7 @@ import pandas as pd
 import ta
 from typing import Any, Dict
 
-
+from crypto_bot.utils.ohlcv_check import ensure_ohlcv
 def generate_signal(
     df: pd.DataFrame,
     symbol: str | None = None,
@@ -42,6 +42,8 @@ def generate_signal(
         ``(metric, signal, meta)`` where ``metric`` is the breakout intensity
         and ``signal`` is ``"long"`` or ``"none"``.
     """
+    if not ensure_ohlcv(symbol or "", df):
+        return 0.0, "none", {"reason": "missing_ohlcv"}
 
     cfg = config or {}
     brk = cfg.get("breakout", {})

--- a/crypto_bot/strategy/breakout_bot.py
+++ b/crypto_bot/strategy/breakout_bot.py
@@ -42,6 +42,7 @@ from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.indicator_cache import cache_series
 from crypto_bot.utils import stats
 from crypto_bot.utils.ml_utils import init_ml_or_warn
+from crypto_bot.utils.ohlcv_check import ensure_ohlcv
 
 NAME = "breakout_bot"
 logger = logging.getLogger(__name__)
@@ -128,8 +129,7 @@ def generate_signal(
         timeframe = None
     config = kwargs.get("config")
     higher_df: Optional[pd.DataFrame] = kwargs.get("higher_df")
-
-    if df is None or df.empty:
+    if not ensure_ohlcv(symbol or "", df):
         return (0.0, "none") if higher_df is not None else (0.0, "none", 0.0)
 
     cfg_all = config or {}

--- a/crypto_bot/utils/market_analyzer.py
+++ b/crypto_bot/utils/market_analyzer.py
@@ -36,6 +36,7 @@ from ta.trend import ADXIndicator
 from crypto_bot.utils.stats import zscore
 from crypto_bot.utils.telemetry import telemetry
 from .ml_utils import ML_AVAILABLE
+from crypto_bot.utils.ohlcv_check import ensure_ohlcv
 
 
 def _fn_name(fn: Callable) -> str:
@@ -226,13 +227,7 @@ async def analyze_symbol(
     base_tf = router_cfg.timeframe
     higher_tf = config.get("higher_timeframe", "1d")
     df = df_map.get(base_tf)
-    if df is None:
-        telemetry.inc("analysis.skipped_no_df")
-        return {"symbol": symbol, "skip": "no_ohlcv"}
-
-    if df.empty:
-        telemetry.inc("analysis.skipped_no_df")
-        analysis_logger.info("Skipping %s: no data for %s", symbol, base_tf)
+    if not ensure_ohlcv(symbol, df, metric="analysis.skipped_no_df"):
         return {
             "symbol": symbol,
             "df": df,

--- a/crypto_bot/utils/ohlcv_check.py
+++ b/crypto_bot/utils/ohlcv_check.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pandas as pd
+
+from .telemetry import telemetry
+
+logger = logging.getLogger(__name__)
+
+# Track symbols already logged for missing OHLCV to avoid spamming
+_LOGGED: set[str] = set()
+
+
+def ensure_ohlcv(symbol: str, df: Optional[pd.DataFrame], metric: str = "signals.missing_ohlcv") -> bool:
+    """Return ``True`` if ``df`` contains OHLCV data.
+
+    Parameters
+    ----------
+    symbol:
+        Trading pair identifier used for logging.
+    df:
+        OHLCV data frame which may be ``None`` or empty.
+    metric:
+        Telemetry counter name incremented when data is missing.
+
+    The function logs a warning only once per ``symbol`` to prevent log spam
+    and increments the provided telemetry ``metric`` each time it is invoked
+    with missing data.
+    """
+    if df is None or df.empty:
+        telemetry.inc(metric)
+        sym = symbol or "unknown"
+        if sym not in _LOGGED:
+            logger.warning("No OHLCV data for %s; skipping", sym)
+            _LOGGED.add(sym)
+        return False
+    return True

--- a/crypto_bot/utils/telemetry.py
+++ b/crypto_bot/utils/telemetry.py
@@ -39,6 +39,10 @@ PROM_COUNTERS: Dict[str, Counter] = {
         "analysis_regime_unknown_alerts",
         "Number of alerts triggered for sustained unknown regime classifications",
     ),
+    "signals.missing_ohlcv": Counter(
+        "signals_missing_ohlcv",
+        "Number of symbols skipped due to missing OHLCV data during signal generation",
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- add `ensure_ohlcv` helper that logs once and bumps telemetry when OHLCV data is missing
- wire pre-check into market analyzer and breakout strategies
- expose `signals.missing_ohlcv` counter for telemetry

## Testing
- `pytest tests/test_breakout_bot.py tests/test_market_analyzer_fallback.py tests/test_market_analyzer_unknown_regime.py tests/test_single_strong_signal_override.py tests/test_strategy_regime_strength.py -q` *(fails: breakout bot signal tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1863e81c833088e0c1464278117f