### PR TITLE
Scale min_accept_score for fusion setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,9 @@ regime_overrides:
   parallel evaluation cycle.
 * **ensemble_min_conf** – minimum score required for a strategy to be
   ranked in ensemble mode.
+* **router.min_accept_score** – minimum score a strategy must achieve to be
+  kept after ranking. Defaults to `0.1` and when `signal_fusion.enabled` is
+  true the threshold is scaled by the highest fusion strategy weight.
 
 To enable the Thompson sampling router add the following to `crypto_bot/config.yaml`:
 

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -30,7 +30,9 @@ filters:
 
 # === router ===
 router:
-  min_accept_score: 0.12        # was 0.5
+  # When signal fusion heavily weights strategies, lower this threshold so
+  # scaled scores are not rejected. Defaults to 0.1 when omitted.
+  min_accept_score: 0.05        # example value for fusion-heavy setups
   prefer_timeframes: ["5m","15m","1m"]
   require_warm: true
   top_k_per_strategy: 5
@@ -512,7 +514,9 @@ risk:
   min_votes: 1                  # was 2
 
 router:
-  min_accept_score: 0.12        # was 0.5
+  # Example threshold for setups using heavy signal fusion. Default is 0.1 and
+  # is scaled by the largest strategy weight when fusion is enabled.
+  min_accept_score: 0.05
   prefer_timeframes: ["5m","15m","1m"]
   require_warm: true
   top_k_per_strategy: 5

--- a/crypto_bot/utils/market_analyzer.py
+++ b/crypto_bot/utils/market_analyzer.py
@@ -163,7 +163,21 @@ async def run_candidates(
 
     router_cfg = (cfg or {}).get("router", {}) if isinstance(cfg, dict) else {}
     fast_track = float(router_cfg.get("fast_track_score", 0.95))
-    min_accept = float(router_cfg.get("min_accept_score", 0.0))
+
+    fusion_active = False
+    if isinstance(cfg, dict):
+        fusion_active = bool(cfg.get("signal_fusion", {}).get("enabled")) or bool(
+            router_cfg.get("fusion_enabled")
+        )
+
+    min_accept = router_cfg.get("min_accept_score")
+    if min_accept is None:
+        min_accept = 0.1
+    min_accept = float(min_accept)
+    if fusion_active:
+        max_weight = max(weights.values(), default=1.0)
+        min_accept *= max_weight
+
     top_k = int(router_cfg.get("top_k_per_strategy", 0))
 
     for fn, sc, d in ranked:


### PR DESCRIPTION
## Summary
- scale router `min_accept_score` by highest strategy weight when signal fusion is enabled
- document new `min_accept_score` behavior
- show example `router.min_accept_score` suitable for fusion-heavy configurations

## Testing
- `python3 -m pytest tests/test_run_candidates.py -q` *(fails: No module named 'solana')*

------
https://chatgpt.com/codex/tasks/task_e_68ab186f6b78833095bc9e555d46c5a0