### PR TITLE
feat: auto adjust warmup candles

### DIFF
--- a/tests/test_warmup_guard.py
+++ b/tests/test_warmup_guard.py
@@ -21,6 +21,20 @@ def test_auto_raise_warmup(monkeypatch, caplog):
     assert "Auto-raising warmup_candles[1m]" in caplog.text
 
 
+def test_auto_adjust_warmup(monkeypatch, caplog):
+    stub = SimpleNamespace(__name__="stub", required_lookback=lambda: {"1m": 100})
+    monkeypatch.setattr(registry, "load_from_config", lambda cfg: [stub])
+    cfg = {
+        "timeframes": ["1m"],
+        "warmup_candles": {"1m": 200},
+        "data": {"auto_adjust_warmup": True},
+    }
+    caplog.set_level(logging.INFO)
+    market_loader._ensure_strategy_warmup(cfg)
+    assert cfg["warmup_candles"]["1m"] == 100
+    assert "Auto-adjusting warmup_candles[1m]" in caplog.text
+
+
 def test_registry_disables_strategy(caplog):
     stub = SimpleNamespace(__name__="stub", required_lookback=lambda: {"1m": 1440})
     cfg = {"warmup_candles": {"1m": 1000}}


### PR DESCRIPTION
## Summary
- auto-adjust warmup_candles downward to exact strategy lookback requirements
- add test coverage for both raising and lowering warmup

## Testing
- `pytest tests/test_warmup_guard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab1aea82b88330a7a3173f1692d270