### PR TITLE
Reduce warmup defaults and document overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,16 @@ option has been removed.
 ### Warm-up candles
 
 The `warmup_candles` mapping controls how many bars are preloaded for each
-timeframe. Ensure the count for a given timeframe exceeds the longest
-indicator lookback used by your strategies plus a safety margin so indicators
-have enough history to stabilize.
+timeframe. Default values roughly match the largest indicator lookback used by
+the built-in strategies (about **100–300** bars on intraday frames).  At
+startup a *warmup guard* inspects enabled strategies and automatically raises
+any entries that are too low, so keeping these numbers small speeds up
+bootstrap while still ensuring sufficient history.
+
+To override a timeframe explicitly, edit the `warmup_candles` mapping in your
+configuration or set an environment variable such as `CT_WARMUP_1M=500`. When
+choosing manual values, use at least the longest indicator lookback plus a
+safety margin so indicators have time to stabilise.
 
 ### Optional ML Fallback
 

--- a/config.example.testing.yaml
+++ b/config.example.testing.yaml
@@ -23,11 +23,11 @@ ohlcv:
   bootstrap_timeframes: ["1m", "5m", "15m", "1h"]
   defer_timeframes: ["4h", "1d"]
   warmup_candles:
-    "1m": 2000
-    "5m": 2000
-    "15m": 2000
-    "1h": 1500
-    "1d": 120
+    "1m": 300
+    "5m": 300
+    "15m": 300
+    "1h": 200
+    "1d": 100
   initial_history_candles: 600
   scan_lookback_limit: 1200
 filters:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,12 +33,12 @@ ohlcv:
   progress_logging: false               # include percent/ETA when data is missing
   bootstrap_timeframes: ["1m", "5m", "15m", "1h"]
   defer_timeframes: ["4h", "1d"]
-  warmup_candles:            # override with CT_WARMUP_<TF> env vars
-    "1m": 2000   # CT_WARMUP_1M
-    "5m": 2000   # CT_WARMUP_5M
-    "15m": 2000  # CT_WARMUP_15M
-    "1h": 1500   # CT_WARMUP_1H
-    "1d": 120    # CT_WARMUP_1D
+  warmup_candles:            # auto-adjusts; override with CT_WARMUP_<TF> env vars
+    "1m": 300    # CT_WARMUP_1M
+    "5m": 300    # CT_WARMUP_5M
+    "15m": 300   # CT_WARMUP_15M
+    "1h": 200    # CT_WARMUP_1H
+    "1d": 100    # CT_WARMUP_1D
   initial_history_candles: 600
   scan_lookback_limit: 1200
 

--- a/crypto_bot/config.py
+++ b/crypto_bot/config.py
@@ -27,7 +27,7 @@ class Config:
 
     timeframes: List[str] = field(default_factory=lambda: ["1m", "5m"])
     warmup_candles: Dict[str, int] = field(
-        default_factory=lambda: {"1m": 2000, "5m": 2000, "15m": 2000, "1h": 1500}
+        default_factory=lambda: {"1m": 300, "5m": 300, "15m": 300, "1h": 200}
     )
     deep_backfill_days: Dict[str, int] = field(default_factory=dict)
     backfill_days: Dict[str, int] = field(

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -43,12 +43,12 @@ ohlcv:
   max_bootstrap_bars: 3000              # limit initial bootstrap to this many bars
   bootstrap_timeframes: ["1m","5m","15m","1h"]
   defer_timeframes: ["4h","1d"]
-  warmup_candles:              # override with CT_WARMUP_<TF> env vars
-    "1m": 1000   # CT_WARMUP_1M
-    "5m": 2000   # CT_WARMUP_5M
-    "15m": 2000  # CT_WARMUP_15M
-    "1h": 1500   # CT_WARMUP_1H
-    "1d": 120    # CT_WARMUP_1D
+  warmup_candles:              # auto-adjusts; override with CT_WARMUP_<TF> env vars
+    "1m": 300    # CT_WARMUP_1M
+    "5m": 300    # CT_WARMUP_5M
+    "15m": 300   # CT_WARMUP_15M
+    "1h": 200    # CT_WARMUP_1H
+    "1d": 100    # CT_WARMUP_1D
   initial_history_candles: 600
   scan_lookback_limit: 1200
 
@@ -761,12 +761,12 @@ deep_backfill_days:
   '5m': 14
   '15m': 60
   '1h': 180
-warmup_candles:       # override with CT_WARMUP_<TF> env vars
-  '1m': 2000   # CT_WARMUP_1M
-  '5m': 2000   # CT_WARMUP_5M
-  '15m': 2000  # CT_WARMUP_15M
-  '1h': 1500   # CT_WARMUP_1H
-  '1d': 120    # CT_WARMUP_1D
+warmup_candles:       # auto-adjusts; override with CT_WARMUP_<TF> env vars
+  '1m': 300    # CT_WARMUP_1M
+  '5m': 300    # CT_WARMUP_5M
+  '15m': 300   # CT_WARMUP_15M
+  '1h': 200    # CT_WARMUP_1H
+  '1d': 100    # CT_WARMUP_1D
 allowed_quotes: ['USD','USDT','USDC','EUR']
 hft: true
 token_registry:


### PR DESCRIPTION
## Summary
- Lower warmup_candles defaults across config files to 100–300 bars and rely on auto-adjust logic
- Document how warmup values are derived and how to override them
- Sync example configs with updated warmup defaults

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68ab1aebfd048330b18439d79daaf376