### PR TITLE
Add dict-style access to Config dataclass

### DIFF
--- a/crypto_bot/config.py
+++ b/crypto_bot/config.py
@@ -9,7 +9,7 @@ look up limits for any supported timeframe (e.g., ``1m`` or ``5m``).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Any, Dict, List
 
 
 @dataclass
@@ -42,6 +42,15 @@ class Config:
     strict_cex: bool = False
     denylist_symbols: List[str] = field(default_factory=list)
     require_sentiment: bool = True
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return the value of ``key`` or ``default`` if not present."""
+        return getattr(self, key, default)
+
+    def __getitem__(self, key: str) -> Any:
+        if not hasattr(self, key):
+            raise KeyError(key)
+        return getattr(self, key)
 
 
 # Default global configuration used by modules that expect a ``cfg`` object.

--- a/tests/test_required_lookback.py
+++ b/tests/test_required_lookback.py
@@ -78,3 +78,10 @@ def test_compute_required_lookback_aggregate(monkeypatch):
     out = registry.compute_required_lookback_per_tf([breakout_bot, trend_bot, mean_bot])
     assert out == {"1m": 250}
 
+
+def test_breakout_required_lookback_cfg_dataclass(monkeypatch):
+    cfg_obj = config.Config()
+    monkeypatch.setattr(config, "cfg", cfg_obj)
+    out = breakout_bot.required_lookback()
+    assert out == {tf: 200 for tf in cfg_obj.timeframes}
+


### PR DESCRIPTION
## Summary
- allow Config dataclass to be used like a mapping via get() and __getitem__
- ensure breakout_bot.required_lookback handles dataclass config without AttributeError

## Testing
- `pytest tests/test_required_lookback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab1ff9c17c8330990ffe162b2d3c04