### PR TITLE
Lower trading score thresholds

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -12,7 +12,7 @@ trading:
   allowed_quotes: [USD, USDT, USDC, EUR]
   min_ticker_volume: 10000
   timeframes: ["1m","5m","15m","1h"]
-  min_score: 0.10
+  min_score: 0.05
   min_confidence: 0.05
   consensus: weighted
   backfill:


### PR DESCRIPTION
## Summary
- Reduce trading min_score to 0.05 to permit weaker signals
- Ensure router accepts low-scoring signals with a 0.05 threshold
- Confirm no user_config overrides enforce stricter thresholds

## Testing
- `PYTHONPATH=src pytest -q` *(fails: SyntaxError in tests/test_initial_scan.py; ModuleNotFoundError for crypto_bot.wallet)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4bec96e08330884fbb41cba717bb