### PR TITLE
Expand router timeframe preferences to include hourly data

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -33,7 +33,7 @@ router:
   # When signal fusion heavily weights strategies, lower this threshold so
   # scaled scores are not rejected. Defaults to 0.1 when omitted.
   min_accept_score: 0.05        # example value for fusion-heavy setups
-  prefer_timeframes: ["5m","15m","1m"]
+  prefer_timeframes: ["5m","15m","1m","1h"]
   require_warm: true
   top_k_per_strategy: 5
   fast_track_score: 0.85        # keep fast-path possible
@@ -517,7 +517,7 @@ router:
   # Example threshold for setups using heavy signal fusion. Default is 0.1 and
   # is scaled by the largest strategy weight when fusion is enabled.
   min_accept_score: 0.05
-  prefer_timeframes: ["5m","15m","1m"]
+  prefer_timeframes: ["5m","15m","1m","1h"]
   require_warm: true
   top_k_per_strategy: 5
   fast_track_score: 0.85        # keep fast-path possible


### PR DESCRIPTION
## Summary
- include `1h` in `router.prefer_timeframes` so routing considers hourly signals

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis'; ModuleNotFoundError: No module named 'cointrainer'; SyntaxError in tests/test_initial_scan.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4bece3948330908c058fa1253fba