### PR TITLE
Enable short selling in trading configuration

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -8,7 +8,7 @@ exchange:
 trading:
   mode: dry_run           # cex | onchain | auto | dry_run
   enable_execution: true          # make sure the trader loop can place paper orders
-  short_selling: false            # unless you really want simulated shorts
+  short_selling: true            # unless you really want simulated shorts
   allowed_quotes: [USD, USDT, USDC, EUR]
   min_ticker_volume: 10000
   timeframes: ["1m","5m","15m","1h"]


### PR DESCRIPTION
## Summary
- enable simulated short trading by setting `trading.short_selling` to true in default config
- note that `PaperWallet` already accepts shorts through its `allow_short` flag

## Testing
- `pytest tests/test_paper_wallet.py::test_short_position_profit -q`
- `pytest tests/test_execute_signals.py::test_execute_signals_respects_short_selling -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4bedd98483308d538467808e6b18