### PR TITLE
Respect strict CEX candidate filtering

### DIFF
--- a/crypto_bot/utils/symbol_utils.py
+++ b/crypto_bot/utils/symbol_utils.py
@@ -291,10 +291,16 @@ async def get_filtered_symbols(
             prev_strict = getattr(cfg, "strict_cex", False)
             prev_quotes = list(getattr(cfg, "allowed_quotes", []) or [])
             prev_vol = float(getattr(cfg, "min_volume", 0.0) or 0.0)
+            strict = bool(config.get("strict_cex", prev_strict))
             try:
-                cfg.strict_cex = True
+                cfg.strict_cex = strict
                 cfg.allowed_quotes = list(allowed_quotes)
                 cfg.min_volume = float(sf.get("min_volume_usd", 0) or 0)
+                if not strict:
+                    try:
+                        exchange.markets = markets
+                    except Exception:
+                        pass
                 symbols = service.get_candidates()
             finally:
                 cfg.strict_cex = prev_strict

--- a/tests/test_strict_cex_candidates.py
+++ b/tests/test_strict_cex_candidates.py
@@ -1,0 +1,48 @@
+import asyncio
+from types import SimpleNamespace
+
+from crypto_bot.utils import symbol_utils as su
+from crypto_bot.markets import symbol_service as ss
+
+
+class DummyExchange:
+    id = "dummy"
+
+    def __init__(self):
+        self._markets = {"AAA/USDT": {}, "BBB/USDT": {}}
+
+    def list_markets(self, timeout=None):
+        return list(self._markets.keys())
+
+    @property
+    def markets(self):
+        return self._markets
+
+    @markets.setter
+    def markets(self, value):
+        self._markets = value
+
+
+async def _fake_filter_symbols(exchange, symbols, config):
+    return [(s, 0.0) for s in symbols], []
+
+
+def test_strict_cex_returns_only_listed(monkeypatch):
+    cfg = SimpleNamespace(strict_cex=False, allowed_quotes=[], min_volume=0.0, denylist_symbols=[])
+    monkeypatch.setattr(su, "cfg", cfg, raising=False)
+    monkeypatch.setattr(ss, "cfg", cfg, raising=False)
+    monkeypatch.setattr(su, "filter_symbols", _fake_filter_symbols)
+    monkeypatch.setattr(ss.SymbolService, "_kraken_symbols", staticmethod(lambda: set()))
+    su.invalidate_symbol_cache()
+
+    config = {
+        "mode": "cex",
+        "strict_cex": True,
+        "symbol_filter": {},
+        "symbol_refresh_minutes": 0,
+        "symbols": ["AAA/USDT", "CCC/USDT"],
+    }
+    exchange = DummyExchange()
+    scored, onchain = asyncio.run(su.get_filtered_symbols(exchange, config))
+    assert [s for s, _ in scored] == ["AAA/USDT"]
+    assert onchain == []


### PR DESCRIPTION
## Summary
- honor `strict_cex` flag when pulling candidate markets so only exchange-listed pairs are considered
- add regression test ensuring strict CEX mode filters out non-listed symbols

## Testing
- `pytest tests/test_strict_cex_candidates.py::test_strict_cex_returns_only_listed -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab4bf0780483309bfb08f834e9ca92