### PR TITLE
Expand Kraken HTTP session pool

### DIFF
--- a/crypto_bot/execution/cex_executor.py
+++ b/crypto_bot/execution/cex_executor.py
@@ -69,6 +69,8 @@ def get_exchange(config) -> Tuple[ccxt.Exchange, Optional[KrakenWSClient]]:
         params["password"] = os.getenv("API_PASSPHRASE")
         exchange = ccxt.coinbase(params)
     elif exchange_name == "kraken":
+        pool_size = int(config.get("http_pool_size", 50))
+        params["session"] = kraken._build_session(pool_maxsize=pool_size)
         exchange = KrakenClient(ccxt.kraken(params))
 
         if use_ws:


### PR DESCRIPTION
## Summary
- widen HTTP adapter pool for Kraken requests session to reduce connection pool saturation
- allow pool size from config when building Kraken exchange

## Testing
- `pytest` *(fails: ImportError in test_wallet_manager; KeyError in cex_executor tests)*

------
https://chatgpt.com/codex/tasks/task_e_68abbf5ab994833097df8546b5e82a28