### PR TITLE
Increase Kraken HTTP connection pool

### DIFF
--- a/config.example.testing.yaml
+++ b/config.example.testing.yaml
@@ -14,6 +14,9 @@ exchange:
   name: kraken
   max_concurrency: 3
   request_timeout_ms: 10000
+
+kraken:
+  http_pool_size: 50
 timeframes: ["1h", "4h", "1d"]
 ohlcv:
   storage_path: crypto_bot/data/ohlcv   # directory for persisted OHLCV data

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,6 +4,9 @@ exchange:
   max_concurrency: 3
   request_timeout_ms: 10000
 
+kraken:
+  http_pool_size: 50
+
 # === trading/base ===
 trading:
   mode: dry_run           # cex | onchain | auto | dry_run


### PR DESCRIPTION
## Summary
- add configurable HTTP session builder for Kraken
- use larger request pool in exchange setup and provide better rejection reasons
- document new `kraken.http_pool_size` option in example configs

## Testing
- `pytest tests/test_kraken_list_markets.py -q`
- `pytest tests/test_cex_executor.py::test_get_exchange_websocket -q`
- `pytest tests/test_cex_executor.py::test_get_exchange_websocket_missing_creds -q`
- `pytest tests/test_cex_executor.py::test_get_exchange_ws_token_failure_fallback -q`
- `pytest tests/test_cex_executor.py::test_execute_trade_skips_on_slippage -q`
- `pytest tests/test_cex_executor.py::test_execute_trade_skips_on_liquidity_usage -q`


------
https://chatgpt.com/codex/tasks/task_e_68abbf50a8f08330a9f95c04eac2de09