### PR TITLE
Update breakout thresholds and intensity levels

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -69,12 +69,14 @@ strategies:
     tf: "5m"
     donchian_len: 40
     keltner_len: 20
-    bbw_pct_max: 15               # BB width in bottom 15th percentile
-    volume_z_min: 1.0
+    bbw_pct_max: 20               # BB width in bottom 15th percentile
+    volume_z_min: 0.0
     atr_mult_stop: 1.2
     atr_mult_tp: 1.2
     max_spread_bp: 10
     time_exit_bars: 12
+    min_intensity:
+      "1h": 0.01
 
   mean_bot:
     enabled: true
@@ -249,7 +251,7 @@ breakout:
   vol_multiplier: 0.5
   volume_window: 15
   min_intensity:
-    "1h": 0.015
+    "1h": 0.01
 cycle_bias:
   enabled: false
   mvrv_url: https://api.example.com/mvrv


### PR DESCRIPTION
## Summary
- tune breakout strategy to widen BB width threshold, allow zero volume z-score, and enforce hourly intensity floor
- lower global breakout intensity requirement

## Testing
- `pytest` *(fails: ImportError cannot import name 'wallet_manager' from 'crypto_bot')*
- `python -m crypto_bot.main` *(failed: prompt requested exchange selection)*

------
https://chatgpt.com/codex/tasks/task_e_68abc19adb448330a790d5a65027e4dd