### PR TITLE
chore: drop breakout bot from fusion

### DIFF
--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -565,8 +565,7 @@ signal_fusion:
   min_confidence: 0.0
   # weights retained but no longer suppress the max
   strategies:
-    - [breakout_bot, 0.50]
-    - [momentum_bot, 0.25]
+    - [momentum_bot, 0.75]
     - [trend_bot,   0.25]
 signal_threshold: 0.0001
 signal_weight_optimizer:


### PR DESCRIPTION
## Summary
- remove breakout_bot from signal fusion configuration
- rebalance fusion weights so momentum_bot has 0.75 weight and trend_bot 0.25

## Testing
- `python -m crypto_bot.cli --smoke-test`
- `pytest tests/test_config.py::test_load_config_returns_dict tests/test_signal_fusion.py::test_weighted_blending tests/test_momentum_bot.py::test_long_signal_macd -q`
- `python - <<'PY'
import pandas as pd
from crypto_bot.strategy import momentum_bot, trend_bot
from crypto_bot.signals.signal_fusion import SignalFusionEngine

prices = list(range(30))
df = pd.DataFrame({'open': prices,'high': [p+1 for p in prices],'low': [p-1 for p in prices],'close': prices,'volume': [100]*30})
momentum_bot.ta.trend.macd = lambda *args, **kwargs: pd.Series([1]*len(df))
momentum_bot.ta.momentum.rsi = lambda *args, **kwargs: pd.Series([30]*len(df))
score, direction = momentum_bot.generate_signal(df, config={'atr_normalization': False})
engine = SignalFusionEngine([(momentum_bot.generate_signal, 0.75),(trend_bot.generate_signal, 0.25)])
score_fused, direction_fused = engine.fuse(df, config={'momentum_bot': {'atr_normalization': False}})
print('momentum_bot', score, direction)
print('fused', score_fused, direction_fused)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68abc1a0675483308e953150fa3af2c2