### PR TITLE
Add strategy manager and trade router modules

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -96,6 +96,15 @@ score_logger = setup_logger(
     "symbol_filter", LOG_DIR / "symbol_filter.log", to_console=False
 )
 
+# Core orchestration modules used by the CLI.  Fail fast if they cannot be
+# imported so errors surface during startup instead of manifesting as subtle
+# runtime issues later on.
+try:
+    from crypto_bot import strategy_manager, trade_router
+except Exception as exc:  # pragma: no cover - import is critical
+    logger.error("Failed to import strategy manager or trade router: %s", exc)
+    raise
+
 # Module-level placeholders populated once internal modules are loaded in ``main``
 
 

--- a/crypto_bot/strategy_manager.py
+++ b/crypto_bot/strategy_manager.py
@@ -1,0 +1,60 @@
+import asyncio
+import logging
+from typing import Iterable, List, Dict, Any
+
+from .strategies.loader import load_strategies
+from .strategies import score as _score
+
+logger = logging.getLogger(__name__)
+
+
+async def evaluate_all(
+    symbols: Iterable[str],
+    timeframes: Iterable[str],
+    mode: str = "cex",
+) -> List[Dict[str, Any]]:
+    """Evaluate enabled strategies across ``symbols`` and ``timeframes``.
+
+    Strategies are loaded via :func:`load_strategies` and each is scored using
+    :func:`crypto_bot.strategies.score`.  Any strategy errors are logged and the
+    strategy is skipped.  The returned list contains one entry per
+    ``symbol/timeframe`` combination with ``score`` and ``direction`` fields.
+    """
+
+    strategies = load_strategies(mode)
+    signals: List[Dict[str, Any]] = []
+
+    for strat in strategies:
+        name = getattr(strat, "__name__", str(strat))
+        try:
+            results = await _score(strat, symbols=symbols, timeframes=timeframes)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Strategy %s evaluation failed: %s", name, exc)
+            continue
+
+        for (symbol, timeframe), data in results.items():
+            score_val = 0.0
+            direction = "none"
+            extra: Dict[str, Any] = {}
+            if isinstance(data, dict):
+                score_val = float(data.get("score", 0.0))
+                direction = str(data.get("signal") or data.get("direction") or "none")
+                extra = data.get("meta") or data.get("extra") or {}
+            elif isinstance(data, tuple):
+                if len(data) > 0:
+                    score_val = float(data[0])
+                if len(data) > 1:
+                    direction = str(data[1])
+                if len(data) > 2 and isinstance(data[2], dict):
+                    extra = data[2]
+            signals.append(
+                {
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "score": score_val,
+                    "direction": direction,
+                    "extra": extra,
+                }
+            )
+
+    return signals

--- a/crypto_bot/trade_router.py
+++ b/crypto_bot/trade_router.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Iterable, List, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+
+def select(
+    signals: Iterable[Dict[str, Any]],
+    *,
+    min_score: float = 0.0,
+    limit: int | None = None,
+) -> List[Dict[str, Any]]:
+    """Filter and rank strategy ``signals`` into trade candidates.
+
+    Parameters
+    ----------
+    signals:
+        Iterable of signal dictionaries produced by :mod:`strategy_manager`.
+    min_score:
+        Minimum score a signal must have to be considered.
+    limit:
+        Optional maximum number of candidates to return.
+    """
+
+    if not signals:
+        return []
+
+    candidates: List[Dict[str, Any]] = []
+    for sig in signals:
+        try:
+            score = float(sig.get("score", 0.0))
+            direction = sig.get("direction") or sig.get("signal")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Skipping malformed signal %s: %s", sig, exc)
+            continue
+        if direction in {"long", "short"} and score >= min_score:
+            candidates.append(sig)
+
+    candidates.sort(key=lambda s: s.get("score", 0.0), reverse=True)
+    if limit is not None:
+        candidates = candidates[:limit]
+    return candidates


### PR DESCRIPTION
## Summary
- add `strategy_manager.evaluate_all` to score enabled strategies across symbols/timeframes
- add `trade_router.select` to rank and filter trade signals
- integrate new modules into `main.py` with explicit error logging on import failure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'crypto_bot.wallet')*


------
https://chatgpt.com/codex/tasks/task_e_68abcb3d51f883308a260812a56fcb5c