### PR TITLE
Await strategy evaluation before routing signals

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -4084,7 +4084,7 @@ async def _main_impl() -> MainResult:
                         len(selected_symbols),
                         len(config.get("timeframes", [])),
                     )
-                    signals = strategy_manager.evaluate_all(
+                    signals = await strategy_manager.evaluate_all(
                         selected_symbols, config.get("timeframes", [])
                     )
                     logger.info(


### PR DESCRIPTION
## Summary
- Await strategy manager evaluation to handle asynchronous signal generation in `strategy_loop`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cointrainer', SyntaxError in tests/test_initial_scan.py)*
- `printf '\n' | timeout 20s python -m crypto_bot --paper` *(fails: Interactive setup required; run wallet_manager to create credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68ac59d09240833086c26f5b4bed03ce