### PR TITLE
Guard coroutine signals in strategy loop

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -4087,6 +4087,8 @@ async def _main_impl() -> MainResult:
                     signals = await strategy_manager.evaluate_all(
                         selected_symbols, config.get("timeframes", [])
                     )
+                    if asyncio.iscoroutine(signals):
+                        signals = await signals
                     logger.info(
                         "Strategy manager produced %d signals", len(signals)
                     )


### PR DESCRIPTION
## Summary
- Await strategy_manager.evaluate_all and guard against coroutine results

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68ac65ab9a6883308bd5184b50340244