### PR TITLE
Await scoring results and handle coroutine signals

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -4084,8 +4084,11 @@ async def _main_impl() -> MainResult:
                         len(selected_symbols),
                         len(config.get("timeframes", [])),
                     )
-                    signals = await strategy_manager.evaluate_all(
+                    raw_signals = await strategy_manager.evaluate_all(
                         selected_symbols, config.get("timeframes", [])
+                    )
+                    signals = (
+                        await raw_signals if inspect.isawaitable(raw_signals) else raw_signals
                     )
                     logger.info(
                         "Strategy manager produced %d signals", len(signals)

--- a/crypto_bot/strategy_manager.py
+++ b/crypto_bot/strategy_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import logging
 from typing import Iterable, List, Dict, Any
 
@@ -27,7 +28,8 @@ async def evaluate_all(
     for strat in strategies:
         name = getattr(strat, "__name__", str(strat))
         try:
-            results = await _score(strat, symbols=symbols, timeframes=timeframes)
+            pending = _score(strat, symbols=symbols, timeframes=timeframes)
+            results = await pending if inspect.isawaitable(pending) else pending
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Strategy %s evaluation failed: %s", name, exc)
             continue

--- a/tests/test_strategy_loop_coroutine.py
+++ b/tests/test_strategy_loop_coroutine.py
@@ -1,0 +1,165 @@
+import asyncio
+import types
+import pytest
+
+from crypto_bot import main
+import crypto_bot.strategy_manager as strategy_manager
+import crypto_bot.trade_router as trade_router_module
+import crypto_bot.risk.risk_manager as risk_module
+
+
+class DummyExchange:
+    options = {}
+
+    async def fetch_balance(self):
+        return {"USDT": {"free": 0}}
+
+    def fetch_ohlcv(self, *args, **kwargs):
+        return []
+
+    def load_markets(self):
+        return {}
+
+
+class DummyWallet:
+    def __init__(self, balance, max_trades, allow_short):
+        self.total_balance = balance
+        self.positions = {}
+
+
+class DummyNotifier:
+    enabled = False
+    token = None
+    chat_id = None
+
+    def notify(self, msg):
+        pass
+
+
+class DummyRiskManager:
+    def __init__(self, cfg):
+        pass
+
+    def plan_orders(self, candidates):
+        return [], []
+
+
+class DummyConsole:
+    async def control_loop(self, state, ctx, session_state):
+        return
+
+
+class DummyBotContext:
+    def __init__(self, *args, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class DummyStrategy:
+    name = "dummy"
+
+
+@pytest.mark.asyncio
+async def test_strategy_loop_handles_coroutine(monkeypatch):
+    cfg = {
+        "hft": True,
+        "telegram": {},
+        "mempool_monitor": {},
+        "scan_markets": False,
+        "execution_mode": "dry_run",
+        "mode": "cex",
+        "scan_in_background": False,
+        "symbols": ["BTC/USDT"],
+        "timeframes": ["1m"],
+        "scan_interval_seconds": 0,
+    }
+
+    async def fake_load_config_async():
+        return cfg, False
+
+    async def fake_load_mints():
+        return {}
+
+    async def fake_initial_scan(*args, **kwargs):
+        return None
+
+    async def fake_fetch_and_log_balance(exchange, wallet, config):
+        return 0.0
+
+    async def async_fake_score(*args, **kwargs):
+        return {}
+
+    async def fake_eval(symbols, timeframes, mode="cex"):
+        async def inner():
+            main.shutdown_event.set()
+            return [
+                {
+                    "symbol": "BTC/USDT",
+                    "timeframe": "1m",
+                    "score": 0.0,
+                    "direction": "none",
+                    "extra": {},
+                }
+            ]
+        return inner()
+
+    monkeypatch.setattr(main, "load_config_async", fake_load_config_async)
+    monkeypatch.setattr(main, "load_token_mints", fake_load_mints)
+    monkeypatch.setattr(main, "set_token_mints", lambda *_a, **_k: None)
+    monkeypatch.setattr(main, "load_or_create", lambda **_k: {})
+    monkeypatch.setattr(
+        main,
+        "TelegramNotifier",
+        types.SimpleNamespace(from_config=lambda cfg: DummyNotifier()),
+        raising=False,
+    )
+    monkeypatch.setattr(main, "send_test_message", lambda *a, **k: None)
+    monkeypatch.setattr(main, "get_exchange", lambda cfg: (DummyExchange(), None))
+    monkeypatch.setattr(main, "fetch_balance", lambda *a, **k: 0.0)
+    monkeypatch.setattr(main, "initial_scan", fake_initial_scan)
+    monkeypatch.setattr(main, "build_risk_config", lambda c, v: {})
+    monkeypatch.setattr(risk_module, "RiskManager", DummyRiskManager, raising=False)
+    monkeypatch.setattr(main, "RiskManager", DummyRiskManager, raising=False)
+    monkeypatch.setattr(main, "Wallet", DummyWallet, raising=False)
+    monkeypatch.setattr(main, "notify_balance_change", lambda *a: 0.0, raising=False)
+    monkeypatch.setattr(main, "fetch_and_log_balance", fake_fetch_and_log_balance, raising=False)
+    monkeypatch.setattr(main, "console_control", DummyConsole(), raising=False)
+    async def fake_rotation_loop(*a, **k):
+        return None
+
+    monkeypatch.setattr(main, "_rotation_loop", fake_rotation_loop)
+    monkeypatch.setattr(main, "log_balance", lambda *a, **k: None)
+    monkeypatch.setattr(main, "format_monitor_line", lambda *a, **k: "")
+    monkeypatch.setattr(
+        main,
+        "PortfolioRotator",
+        lambda: types.SimpleNamespace(config={}),
+        raising=False,
+    )
+    monkeypatch.setattr(main, "log_ml_status_once", lambda: None, raising=False)
+    monkeypatch.setattr(main, "BotContext", DummyBotContext, raising=False)
+    monkeypatch.setattr(main, "load_strategies", lambda *a, **k: [DummyStrategy()])
+    monkeypatch.setattr(main.strategies, "score", async_fake_score)
+    monkeypatch.setattr(strategy_manager, "evaluate_all", fake_eval)
+
+    record = {}
+
+    def fake_select(signals):
+        record["type"] = type(signals)
+        return []
+
+    monkeypatch.setattr(trade_router_module, "select", fake_select, raising=False)
+
+    import sys
+
+    fake_executor = types.SimpleNamespace(execute_trade_async=lambda **order: {})
+    monkeypatch.setitem(sys.modules, "crypto_bot.execution.order_executor", fake_executor)
+    monkeypatch.setattr(main, "_verify_hft_modules", lambda *a, **k: None)
+
+    result = await main._main_impl()
+    tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    for t in tasks:
+        t.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+    assert isinstance(result, main.MainResult)
+    assert record["type"] is list


### PR DESCRIPTION
## Summary
- ensure strategy scoring results are awaited in `strategy_manager.evaluate_all`
- safeguard `strategy_loop` against coroutine signals before routing
- add regression test verifying coroutine signals are safely handled

## Testing
- `pytest tests/test_strategy_loop_coroutine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac65b6fe748330b88eac65399cf3b6