### PR TITLE
Unify trading mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,8 +422,7 @@ Edit `crypto_bot/config.yaml` to adjust trading behaviour. Key settings include:
 primary_exchange: coinbase  # coinbase or kraken
 secondary_exchange: kraken
 solana_rpc: https://api.mainnet-beta.solana.com
-execution_mode: dry_run  # or live
-mode: auto               # router chooses CEX or on-chain based on token mints
+execution_mode: dry_run  # cex | onchain | auto | dry_run
 use_websocket: true
 kraken:
   use_private_ws: false  # set true only if private WS feeds are required
@@ -455,8 +454,8 @@ The `crypto_bot/config.yaml` file holds the runtime settings for the bot. Below 
 
 ### Exchange and Execution
 * **exchange** – target CEX (`coinbase` or `kraken`).
-* **execution_mode** – choose `dry_run` for simulation or `live` for real orders.
-  Paper trading defaults to long-only on spot exchanges.
+* **execution_mode** – choose `dry_run` for simulation or `cex`, `onchain`, or
+  `auto` for real orders. Paper trading defaults to long-only on spot exchanges.
 * **use_websocket** – enable WebSocket data via `KrakenWSClient`.
 * **force_websocket_history** – disable REST fallbacks when streaming (default: true).
 * **kraken.use_private_ws** – enable private WebSocket feeds for trading; REST-only trading continues when `false`.
@@ -679,7 +678,6 @@ regime_overrides:
 * **scoring_weights** - weighting factors for regime confidence, symbol score and volume metrics.
 * **signal_fusion** – enable to combine scores from multiple strategies via a `fusion_method` for improved selection.
 * **strategy_router** - maps market regimes to lists of strategy names. Each regime also accepts a `<regime>_timeframe` key (e.g. `trending_timeframe: 1h`, `volatile_timeframe: 1m`). The `range_arb_bot` strategy is always active and does not need to be listed in any regime.
-* **mode_threshold**/**mode_degrade_window** - degrade to manual mode when auto selection underperforms.
 * **meta_selector**/**rl_selector** – experimental strategy routers. Enable these along with `signal_fusion` for improved strategy selection.
   Train the meta selector on your historical trade results with:
 
@@ -1056,7 +1054,7 @@ environment so the bot can retrieve social metrics. The free tier allows about
    exchanges: [coinbase, kraken]
    primary_exchange: coinbase
    secondary_exchange: kraken
-   execution_mode: dry_run  # or live
+   execution_mode: dry_run  # cex | onchain | auto | dry_run
    use_websocket: true      # enable when trading on Kraken via WebSocket
    ```
 
@@ -1072,7 +1070,7 @@ For Kraken, a WebSocket token is requested automatically using your API key and 
     exchanges: [coinbase, kraken]
     primary_exchange: coinbase
     secondary_exchange: kraken
-    execution_mode: dry_run  # or live
+    execution_mode: dry_run  # cex | onchain | auto | dry_run
     use_websocket: true      # enable when trading on Kraken via WebSocket
     ```
 

--- a/crypto_bot/config.yaml
+++ b/crypto_bot/config.yaml
@@ -6,7 +6,6 @@ exchange:
 
 # === trading/base ===
 trading:
-  mode: dry_run           # cex | onchain | auto | dry_run
   enable_execution: true          # make sure the trader loop can place paper orders
   short_selling: true            # unless you really want simulated shorts
   allowed_quotes: [USD, USDT, USDC, EUR]
@@ -292,7 +291,7 @@ excluded_symbols:
 exec:
   allow_market_orders: true
   order_retry_interval: 3
-execution_mode: dry_run
+execution_mode: dry_run  # cex | onchain | auto | dry_run
 exit_strategy:
   default_sl_pct: 0.015
   default_tp_pct: 0.07
@@ -425,8 +424,6 @@ ml_enabled: true
 ml_signal_model:
   enabled: true
   weight: 0.9
-mode: auto
-mode_degrade_window: 15
 ohlcv_batch_size: 10
 ohlcv_snapshot_frequency_minutes: 720
 ohlcv_snapshot_limit: 500

--- a/crypto_bot/exchange/__init__.py
+++ b/crypto_bot/exchange/__init__.py
@@ -34,10 +34,10 @@ async def place_order(candidate: TradeCandidate, config: Dict[str, Any]) -> Dict
     candidate:
         Description of the trade to execute.
     config:
-        Runtime configuration. The function honours ``execution_mode`` or
-        ``trading.mode`` set to ``"dry_run"`` by returning a mock order object.
-        When live trading, an exchange client is resolved from ``config`` and
-        used to submit the order via ``create_order``.
+        Runtime configuration. The function honours ``execution_mode`` set to
+        ``"dry_run"`` by returning a mock order object. When live trading, an
+        exchange client is resolved from ``config`` and used to submit the
+        order via ``create_order``.
 
     Returns
     -------
@@ -46,10 +46,7 @@ async def place_order(candidate: TradeCandidate, config: Dict[str, Any]) -> Dict
         guaranteed to contain an ``id`` key for logging.
     """
 
-    mode = str(
-        config.get("execution_mode")
-        or config.get("trading", {}).get("mode", "")
-    ).lower()
+    mode = str(config.get("execution_mode", "")).lower()
     if mode in {"dry_run", "paper", "paper_trading"} or config.get("paper_trading"):
         # Paper trading – fabricate a lightweight order object
         return {

--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -838,6 +838,7 @@ def _load_config_file() -> dict:
         or trading_cfg.get("mode")
         or "dry_run"
     )
+    trading_cfg["mode"] = trading_mode
     allowed_quotes = trading_cfg.get("allowed_quotes", [])
     require_env = os.getenv("CT_REQUIRE_SENTIMENT")
     if require_env is not None:
@@ -3511,6 +3512,10 @@ async def _main_impl() -> MainResult:
         logger.warning("SUPABASE_URL missing; disabling ML features")
 
     user = load_or_create(interactive=False)
+    wallet_mode = user.get("mode")
+    if wallet_mode:
+        config["execution_mode"] = wallet_mode
+        config.setdefault("trading", {})["mode"] = wallet_mode
 
     status_updates = config.get("telegram", {}).get("status_updates", True)
     balance_updates = config.get("telegram", {}).get("balance_updates", False)


### PR DESCRIPTION
## Summary
- Respect wallet manager's cex/onchain choice by setting both `execution_mode` and `trading.mode`
- Remove duplicate mode fields and document `execution_mode` as the single canonical config key
- Simplify `exchange.place_order` to rely on unified execution mode

## Testing
- `pytest` *(fails: ImportError: cannot import name 'wallet_manager' from 'crypto_bot')*


------
https://chatgpt.com/codex/tasks/task_e_68ac65c04a3c8330888f40a2a6d42e2c