### PR TITLE
Expose strict CEX config

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -50,6 +50,7 @@ from crypto_bot.utils import ml_utils
 ML_AVAILABLE = ml_utils.ML_AVAILABLE
 from crypto_bot.ml.model_loader import load_regime_model, _norm_symbol
 from .config import short_selling_enabled
+from crypto_bot.config import cfg
 
 # Internal project modules are imported lazily in `_import_internal_modules()`
 
@@ -1079,6 +1080,15 @@ def _flatten_config(data: dict, parent: str = "") -> dict:
     return flat
 
 
+def _apply_runtime_cfg(config: dict) -> None:
+    """Populate global ``cfg`` with fields needed by symbol services."""
+    strict = config.get("strict_cex")
+    if strict is None and config.get("mode") == "cex":
+        strict = True
+    cfg.strict_cex = bool(strict)
+    cfg.denylist_symbols = list(config.get("denylist_symbols", []))
+
+
 async def reload_config(
     config: dict,
     ctx: BotContext,
@@ -1094,6 +1104,7 @@ async def reload_config(
         return
 
     _merge_dict(config, new_config)
+    _apply_runtime_cfg(config)
     if (
         not config.get("symbols")
         and not config.get("onchain_symbols")
@@ -3418,6 +3429,7 @@ async def _main_impl() -> MainResult:
     logger.info("Starting bot")
     global UNKNOWN_COUNT, TOTAL_ANALYSES
     config, _ = await load_config_async()
+    _apply_runtime_cfg(config)
     config["timeframes"] = collect_timeframes(config)
     if (
         not config.get("symbols")

--- a/tests/test_runtime_cfg.py
+++ b/tests/test_runtime_cfg.py
@@ -1,0 +1,34 @@
+from crypto_bot.config import cfg
+from crypto_bot import main
+
+
+def test_apply_runtime_cfg_assigns_values():
+    orig_strict = cfg.strict_cex
+    orig_deny = list(cfg.denylist_symbols)
+    try:
+        config = {
+            "mode": "cex",
+            "strict_cex": False,
+            "denylist_symbols": ["BAD/USDT"],
+        }
+        main._apply_runtime_cfg(config)
+        assert cfg.strict_cex is False
+        assert cfg.denylist_symbols == ["BAD/USDT"]
+    finally:
+        cfg.strict_cex = orig_strict
+        cfg.denylist_symbols = orig_deny
+
+
+def test_apply_runtime_cfg_defaults_to_cex():
+    orig_strict = cfg.strict_cex
+    orig_deny = list(cfg.denylist_symbols)
+    try:
+        cfg.strict_cex = False
+        cfg.denylist_symbols = []
+        main._apply_runtime_cfg({"mode": "cex"})
+        assert cfg.strict_cex is True
+        main._apply_runtime_cfg({"mode": "onchain"})
+        assert cfg.strict_cex is False
+    finally:
+        cfg.strict_cex = orig_strict
+        cfg.denylist_symbols = orig_deny


### PR DESCRIPTION
## Summary
- update global runtime config with strict CEX and denylist fields
- default strict CEX mode when trading in cex mode
- test runtime config propagation to global cfg

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis', cointrainer; SyntaxError in tests)*
- `PYTHONPATH=$PWD:$PWD/src pytest tests/test_runtime_cfg.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac65c2d08083308bed9a85d6ea7a9e