### PR TITLE
Handle configurable quote currency when fetching balance

### DIFF
--- a/crypto_bot/main.py
+++ b/crypto_bot/main.py
@@ -683,7 +683,11 @@ async def fetch_balance(exchange, wallet, config):
             bal = await exchange.fetch_balance()
         else:
             bal = await asyncio.to_thread(exchange.fetch_balance)
-        return bal["USDT"]["free"] if isinstance(bal["USDT"], dict) else bal["USDT"]
+        quote = config.get("quote") or config.get("allowed_quotes", ["USDT"])[0]
+        balance_entry = bal.get(quote)
+        if isinstance(balance_entry, dict):
+            return balance_entry.get("free", 0.0)
+        return balance_entry if isinstance(balance_entry, (int, float)) else 0.0
     if wallet:
         return getattr(wallet, "total_balance", getattr(wallet, "balance", 0.0))
     return 0.0

--- a/tests/test_fetch_balance_missing_quote.py
+++ b/tests/test_fetch_balance_missing_quote.py
@@ -1,0 +1,13 @@
+import asyncio
+import crypto_bot.main as main
+
+
+class DummyExchange:
+    async def fetch_balance(self):
+        return {"BTC": {"free": 1}}
+
+
+def test_fetch_balance_missing_quote_returns_zero():
+    cfg = {"execution_mode": "live", "quote": "USDT"}
+    balance = asyncio.run(main.fetch_balance(DummyExchange(), None, cfg))
+    assert balance == 0.0


### PR DESCRIPTION
## Summary
- Determine quote currency from config instead of hard-coding USDT
- Safely read balances and default to zero when quote currency missing
- Add regression test for missing quote balance

## Testing
- `pytest tests/test_fetch_balance_missing_quote.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cointrainer'; and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ac84bc310083309bf99193c6a9bfc3